### PR TITLE
Implement geofence-based presence

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -54,8 +54,9 @@ dependencies {
     compile "com.android.support:design:25.3.1"
     compile 'com.android.support:multidex:1.0.1'
     compile 'com.google.code.gson:gson:2.7'
-    compile 'com.google.android.gms:play-services-analytics:10.2.1'
-    compile 'com.google.android.gms:play-services-gcm:10.2.1'
+    compile 'com.google.android.gms:play-services-analytics:10.2.4'
+    compile 'com.google.android.gms:play-services-gcm:10.2.4'
+    compile 'com.google.android.gms:play-services-location:10.2.4'
     compile 'com.crittercism:crittercism-android-agent:5.8.1-rc-1'
     compile 'org.jmdns:jmdns:3.5.1'
     compile 'com.squareup.okhttp3:okhttp:3.6.0'

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -75,6 +75,11 @@
             android:label="@string/title_activity_openhabwritetag" />
         <activity android:name="de.duenndns.ssl.MemorizingActivity" />
 
+        <service android:name=".core.GeofenceIntentService"/>
+        <receiver android:name=".core.GeofenceBroadcastReceiver"
+            android:exported="false">
+        </receiver>
+
         <service
             android:name=".core.OpenHABVoiceService"
             android:exported="false" />

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
 
     <uses-permission android:name="org.openhab.habdroid.gcm.permission.C2D_MESSAGE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <uses-feature
         android:name="android.hardware.location.gps"
@@ -75,9 +76,13 @@
             android:label="@string/title_activity_openhabwritetag" />
         <activity android:name="de.duenndns.ssl.MemorizingActivity" />
 
+        <service android:name=".core.GeofenceRegistrationService"/>
         <service android:name=".core.GeofenceIntentService"/>
         <receiver android:name=".core.GeofenceBroadcastReceiver"
             android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+            </intent-filter>
         </receiver>
 
         <service

--- a/mobile/src/main/java/org/openhab/habdroid/core/GeofenceBroadcastReceiver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/GeofenceBroadcastReceiver.java
@@ -16,10 +16,16 @@ public class GeofenceBroadcastReceiver extends WakefulBroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        Log.i(TAG, "onReceive");
-        ComponentName comp = new ComponentName(context.getPackageName(),
-                GeofenceIntentService.class.getName());
-        startWakefulService(context, (intent.setComponent(comp)));
+        Log.d(TAG, "onReceive");
+        if(intent.getAction()!= null && intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED)){
+            // Did we just boot? Go register.
+            Intent serviceIntent = new Intent(context , GeofenceRegistrationService.class);
+            startWakefulService(context, serviceIntent);
+        } else {
+            ComponentName comp = new ComponentName(context.getPackageName(),
+                    GeofenceIntentService.class.getName());
+            startWakefulService(context, (intent.setComponent(comp)));
+        }
         setResultCode(Activity.RESULT_OK);
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/core/GeofenceBroadcastReceiver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/GeofenceBroadcastReceiver.java
@@ -1,0 +1,25 @@
+package org.openhab.habdroid.core;
+
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.content.WakefulBroadcastReceiver;
+import android.util.Log;
+
+/**
+ * Created by jjhuff on 8/18/17.
+ */
+
+public class GeofenceBroadcastReceiver extends WakefulBroadcastReceiver {
+    private static final String TAG = GeofenceBroadcastReceiver.class.getSimpleName();
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Log.i(TAG, "onReceive");
+        ComponentName comp = new ComponentName(context.getPackageName(),
+                GeofenceIntentService.class.getName());
+        startWakefulService(context, (intent.setComponent(comp)));
+        setResultCode(Activity.RESULT_OK);
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/core/GeofenceIntentService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/GeofenceIntentService.java
@@ -1,16 +1,11 @@
 package org.openhab.habdroid.core;
 
-import android.app.IntentService;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
-import android.os.Handler;
-import android.os.Looper;
-import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.TaskStackBuilder;
 import android.text.TextUtils;
@@ -22,14 +17,9 @@ import com.google.android.gms.location.GeofencingEvent;
 import org.openhab.habdroid.ui.OpenHABMainActivity;
 import org.openhab.habdroid.R;
 import org.openhab.habdroid.util.Constants;
-import org.openhab.habdroid.util.MyAsyncHttpClient;
-import org.openhab.habdroid.util.MyHttpClient;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import okhttp3.Call;
-import okhttp3.Headers;
 
 /**
  * Created by jjhuff on 8/17/17.
@@ -42,7 +32,6 @@ public class GeofenceIntentService extends OpenHABIntentService {
         super(TAG);
     }
 
-
     /**
      * Handles incoming intents.
      * @param intent sent by Location Services. This Intent is provided to Location
@@ -50,11 +39,9 @@ public class GeofenceIntentService extends OpenHABIntentService {
      */
     @Override
     protected void processIntent(Intent intent) {
-        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(this);
-
         GeofencingEvent geofencingEvent = GeofencingEvent.fromIntent(intent);
         if (geofencingEvent.hasError()) {
-            Log.e(TAG, "Error:"+geofencingEvent.getErrorCode());
+            Log.e(TAG, "Error:" + geofencingEvent.getErrorCode());
             return;
         }
 
@@ -69,16 +56,16 @@ public class GeofenceIntentService extends OpenHABIntentService {
                 triggeringGeofences);
 
         // Log the transition details.
-        Log.i(TAG, geofenceTransitionDetails);
+        Log.d(TAG, geofenceTransitionDetails);
 
         // Send the notification if enabled
-        boolean notificationsEnabled = settings.getBoolean(Constants.PREFERENCE_PRESENCE_DEBUG, false);
+        boolean notificationsEnabled = mSettings.getBoolean(Constants.PREFERENCE_PRESENCE_DEBUG, false);
         if (notificationsEnabled) {
             sendNotification(geofenceTransitionDetails);
         }
 
         // Send command to presence item
-        String item = settings.getString(Constants.PREFERENCE_PRESENCE_ITEM, null);
+        String item = mSettings.getString(Constants.PREFERENCE_PRESENCE_ITEM, null);
         if (!item.isEmpty()) {
             String command;
             if (geofenceTransition == Geofence.GEOFENCE_TRANSITION_ENTER ||

--- a/mobile/src/main/java/org/openhab/habdroid/core/GeofenceIntentService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/GeofenceIntentService.java
@@ -50,6 +50,8 @@ public class GeofenceIntentService extends OpenHABIntentService {
      */
     @Override
     protected void processIntent(Intent intent) {
+        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(this);
+
         GeofencingEvent geofencingEvent = GeofencingEvent.fromIntent(intent);
         if (geofencingEvent.hasError()) {
             Log.e(TAG, "Error:"+geofencingEvent.getErrorCode());
@@ -66,12 +68,16 @@ public class GeofenceIntentService extends OpenHABIntentService {
         String geofenceTransitionDetails = getGeofenceTransitionDetails(geofenceTransition,
                 triggeringGeofences);
 
-        // Send notification and log the transition details.
-        sendNotification(geofenceTransitionDetails);
+        // Log the transition details.
         Log.i(TAG, geofenceTransitionDetails);
 
+        // Send the notification if enabled
+        boolean notificationsEnabled = settings.getBoolean(Constants.PREFERENCE_PRESENCE_DEBUG, false);
+        if (notificationsEnabled) {
+            sendNotification(geofenceTransitionDetails);
+        }
+
         // Send command to presence item
-        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(this);
         String item = settings.getString(Constants.PREFERENCE_PRESENCE_ITEM, null);
         if (!item.isEmpty()) {
             String command;

--- a/mobile/src/main/java/org/openhab/habdroid/core/GeofenceIntentService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/GeofenceIntentService.java
@@ -1,0 +1,162 @@
+package org.openhab.habdroid.core;
+
+import android.app.IntentService;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.BitmapFactory;
+import android.graphics.Color;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.TaskStackBuilder;
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.google.android.gms.location.Geofence;
+import com.google.android.gms.location.GeofencingEvent;
+
+import org.openhab.habdroid.ui.OpenHABMainActivity;
+import org.openhab.habdroid.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by jjhuff on 8/17/17.
+ */
+
+public class GeofenceIntentService extends IntentService {
+    private static final String TAG = GeofenceIntentService.class.getSimpleName();
+
+    /**
+     * This constructor is required, and calls the super IntentService(String)
+     * constructor with the name for a worker thread.
+     */
+    public GeofenceIntentService() {
+        // Use the TAG to name the worker thread.
+        super(TAG);
+    }
+
+    /**
+     * Handles incoming intents.
+     * @param intent sent by Location Services. This Intent is provided to Location
+     *               Services (inside a PendingIntent) when addGeofences() is called.
+     */
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        GeofencingEvent geofencingEvent = GeofencingEvent.fromIntent(intent);
+        if (geofencingEvent.hasError()) {
+            Log.e(TAG, "Error:"+geofencingEvent.getErrorCode());
+            return;
+        }
+
+        // Get the transition type.
+        int geofenceTransition = geofencingEvent.getGeofenceTransition();
+
+        // Test that the reported transition was of interest.
+        if (geofenceTransition == Geofence.GEOFENCE_TRANSITION_ENTER ||
+                geofenceTransition == Geofence.GEOFENCE_TRANSITION_EXIT) {
+
+            // Get the geofences that were triggered. A single event can trigger multiple geofences.
+            List<Geofence> triggeringGeofences = geofencingEvent.getTriggeringGeofences();
+
+            // Get the transition details as a String.
+            String geofenceTransitionDetails = getGeofenceTransitionDetails(geofenceTransition,
+                    triggeringGeofences);
+
+            // Send notification and log the transition details.
+            sendNotification(geofenceTransitionDetails);
+
+            Log.i(TAG, geofenceTransitionDetails);
+        } else {
+            // Log the error.
+            Log.e(TAG, "Invalid transition type:"+geofenceTransition);
+        }
+    }
+
+    /**
+     * Gets transition details and returns them as a formatted string.
+     *
+     * @param geofenceTransition    The ID of the geofence transition.
+     * @param triggeringGeofences   The geofence(s) triggered.
+     * @return                      The transition details formatted as String.
+     */
+    private String getGeofenceTransitionDetails(
+            int geofenceTransition,
+            List<Geofence> triggeringGeofences) {
+
+        String geofenceTransitionString = getTransitionString(geofenceTransition);
+
+        // Get the Ids of each geofence that was triggered.
+        ArrayList<String> triggeringGeofencesIdsList = new ArrayList<>();
+        for (Geofence geofence : triggeringGeofences) {
+            triggeringGeofencesIdsList.add(geofence.getRequestId());
+        }
+        String triggeringGeofencesIdsString = TextUtils.join(", ",  triggeringGeofencesIdsList);
+
+        return geofenceTransitionString + ": " + triggeringGeofencesIdsString;
+    }
+
+    /**
+     * Posts a notification in the notification bar when a transition is detected.
+     * If the user clicks the notification, control goes to the MainActivity.
+     */
+    private void sendNotification(String notificationDetails) {
+        // Create an explicit content Intent that starts the main Activity.
+        Intent notificationIntent = new Intent(getApplicationContext(), OpenHABMainActivity.class);
+
+        // Construct a task stack.
+        TaskStackBuilder stackBuilder = TaskStackBuilder.create(this);
+
+        // Add the main Activity to the task stack as the parent.
+        stackBuilder.addParentStack(OpenHABMainActivity.class);
+
+        // Push the content Intent onto the stack.
+        stackBuilder.addNextIntent(notificationIntent);
+
+        // Get a PendingIntent containing the entire back stack.
+        PendingIntent notificationPendingIntent =
+                stackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
+
+        // Get a notification builder that's compatible with platform versions >= 4
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this);
+
+        // Define the notification settings.
+        builder.setSmallIcon(R.drawable.ic_launcher)
+                // In a real app, you may want to use a library like Volley
+                // to decode the Bitmap.
+                .setLargeIcon(BitmapFactory.decodeResource(getResources(),
+                        R.drawable.ic_launcher))
+                .setColor(Color.RED)
+                .setContentTitle(notificationDetails)
+                .setContentText("Geofence transition")
+                .setContentIntent(notificationPendingIntent);
+
+        // Dismiss notification once the user touches it.
+        builder.setAutoCancel(true);
+
+        // Get an instance of the Notification manager
+        NotificationManager mNotificationManager =
+                (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+
+        // Issue the notification
+        mNotificationManager.notify(0, builder.build());
+    }
+
+    /**
+     * Maps geofence transition types to their human-readable equivalents.
+     *
+     * @param transitionType    A transition type constant defined in Geofence
+     * @return                  A String indicating the type of transition
+     */
+    private String getTransitionString(int transitionType) {
+        switch (transitionType) {
+            case Geofence.GEOFENCE_TRANSITION_ENTER:
+                return "GEOFENCE_TRANSITION_ENTER";
+            case Geofence.GEOFENCE_TRANSITION_EXIT:
+                return "GEOFENCE_TRANSITION_EXIT";
+            default:
+                return "Unknown type"+transitionType;
+        }
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/core/GeofenceIntentService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/GeofenceIntentService.java
@@ -126,14 +126,9 @@ public class GeofenceIntentService extends OpenHABIntentService {
         NotificationCompat.Builder builder = new NotificationCompat.Builder(this);
 
         // Define the notification settings.
-        builder.setSmallIcon(R.drawable.ic_launcher)
-                // In a real app, you may want to use a library like Volley
-                // to decode the Bitmap.
-                .setLargeIcon(BitmapFactory.decodeResource(getResources(),
-                        R.drawable.ic_launcher))
-                .setColor(Color.RED)
+        builder.setSmallIcon(R.drawable.ic_stat_openhab_bw)
                 .setContentTitle(notificationDetails)
-                .setContentText("Geofence transition")
+                .setContentText(getString(R.string.geofence_debug_notification))
                 .setContentIntent(notificationPendingIntent);
 
         // Dismiss notification once the user touches it.
@@ -162,7 +157,7 @@ public class GeofenceIntentService extends OpenHABIntentService {
             case Geofence.GEOFENCE_TRANSITION_DWELL:
                 return "GEOFENCE_TRANSITION_DWELL";
             default:
-                return "Unknown type"+transitionType;
+                return getString(R.string.geofence_debug_unknown, transitionType);
         }
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/core/GeofenceRegistrationService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/GeofenceRegistrationService.java
@@ -14,6 +14,7 @@ import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingRequest;
 import com.google.android.gms.location.LocationServices;
 
+import org.openhab.habdroid.R;
 import org.openhab.habdroid.util.Constants;
 
 /**
@@ -65,7 +66,8 @@ public class GeofenceRegistrationService extends OpenHABIntentService implements
             lat = Float.parseFloat(mSettings.getString(Constants.PREFERENCE_PRESENCE_LAT, "0"));
             lng = Float.parseFloat(mSettings.getString(Constants.PREFERENCE_PRESENCE_LNG, "0"));
         } catch(NumberFormatException e) {
-            Log.i(TAG, "Invalid lat/lng");
+            Log.e(TAG, "Invalid lat/lng");
+            showToast(getString(R.string.presence_invalid_latlng));
             return;
         }
 

--- a/mobile/src/main/java/org/openhab/habdroid/core/GeofenceRegistrationService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/GeofenceRegistrationService.java
@@ -58,8 +58,19 @@ public class GeofenceRegistrationService extends OpenHABIntentService implements
     @SuppressWarnings("MissingPermission")
     public void onConnected(Bundle connectionHint) {
         Log.d(TAG, "onConnected");
+
+        float lat;
+        float lng;
+        try {
+            lat = Float.parseFloat(mSettings.getString(Constants.PREFERENCE_PRESENCE_LAT, "0"));
+            lng = Float.parseFloat(mSettings.getString(Constants.PREFERENCE_PRESENCE_LNG, "0"));
+        } catch(NumberFormatException e) {
+            Log.i(TAG, "Invalid lat/lng");
+            return;
+        }
+
         LocationServices.GeofencingApi.addGeofences(mApiClient,
-                getGeofencingRequest(), getGeofencePendingIntent()).setResultCallback(new ResultCallback<Status>() {
+                getGeofencingRequest(lat, lng), getGeofencePendingIntent()).setResultCallback(new ResultCallback<Status>() {
             @Override
             public void onResult(@NonNull Status status) {
                 if(status.isSuccess()){
@@ -77,23 +88,12 @@ public class GeofenceRegistrationService extends OpenHABIntentService implements
     }
 
 
-    /**
-     * Handles incoming intents.
-     * @param intent sent by Location Services. This Intent is provided to Location
-     *               Services (inside a PendingIntent) when addGeofences() is called.
-     */
-    @Override
-    protected void processIntent(Intent intent) {
-    }
 
     /**
      * Return the geofence request
      * @return
      */
-    private GeofencingRequest getGeofencingRequest() {
-        float lat = Float.parseFloat(mSettings.getString(Constants.PREFERENCE_PRESENCE_LAT, "0"));
-        float lng = Float.parseFloat(mSettings.getString(Constants.PREFERENCE_PRESENCE_LNG, "0"));
-
+    private GeofencingRequest getGeofencingRequest(float lat, float lng) {
         Geofence geofence;
         geofence = new Geofence.Builder()
                 .setRequestId("home")

--- a/mobile/src/main/java/org/openhab/habdroid/core/GeofenceRegistrationService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/GeofenceRegistrationService.java
@@ -1,0 +1,118 @@
+package org.openhab.habdroid.core;
+
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.common.api.ResultCallback;
+import com.google.android.gms.common.api.Status;
+import com.google.android.gms.location.Geofence;
+import com.google.android.gms.location.GeofencingRequest;
+import com.google.android.gms.location.LocationServices;
+
+import org.openhab.habdroid.util.Constants;
+
+/**
+ * Created by jjhuff on 8/29/17.
+ */
+
+public class GeofenceRegistrationService extends OpenHABIntentService implements
+        GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener  {
+    private static final String TAG = GeofenceRegistrationService.class.getSimpleName();
+    private GoogleApiClient mApiClient;
+
+    public GeofenceRegistrationService() {
+        super(TAG);
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        // Setup API client for LocationServices
+        mApiClient = new GoogleApiClient.Builder(this)
+                .addApi(LocationServices.API)
+                .addConnectionCallbacks(this)
+                .addOnConnectionFailedListener(this)
+                .build();
+        mApiClient.connect();
+    }
+
+    /**
+     * Google API service connection failed in a non-recoverable way.
+     * @param connectionResult
+     */
+    @Override
+    public void onConnectionFailed(ConnectionResult connectionResult) {
+        Log.e(TAG, "Connection to Google Play services failed with error: " + connectionResult.getErrorMessage());
+    }
+
+    /**
+     * Once the Google API service connection is available, send a request to add the Geofences.
+     */
+    @Override
+    @SuppressWarnings("MissingPermission")
+    public void onConnected(Bundle connectionHint) {
+        Log.d(TAG, "onConnected");
+        LocationServices.GeofencingApi.addGeofences(mApiClient,
+                getGeofencingRequest(), getGeofencePendingIntent()).setResultCallback(new ResultCallback<Status>() {
+            @Override
+            public void onResult(@NonNull Status status) {
+                if(status.isSuccess()){
+                    Log.d(TAG, "Registration success");
+                }else{
+                    Log.e(TAG, "Registration failure");
+                }
+            }
+        });
+    }
+
+    @Override
+    public void onConnectionSuspended (int cause) {
+        Log.d(TAG, "onConnectionSuspended");
+    }
+
+
+    /**
+     * Handles incoming intents.
+     * @param intent sent by Location Services. This Intent is provided to Location
+     *               Services (inside a PendingIntent) when addGeofences() is called.
+     */
+    @Override
+    protected void processIntent(Intent intent) {
+    }
+
+    /**
+     * Return the geofence request
+     * @return
+     */
+    private GeofencingRequest getGeofencingRequest() {
+        float lat = Float.parseFloat(mSettings.getString(Constants.PREFERENCE_PRESENCE_LAT, "0"));
+        float lng = Float.parseFloat(mSettings.getString(Constants.PREFERENCE_PRESENCE_LNG, "0"));
+
+        Geofence geofence;
+        geofence = new Geofence.Builder()
+                .setRequestId("home")
+                .setCircularRegion(lat, lng, 100)
+                .setNotificationResponsiveness(30 * 1000 ) // 30 sec
+                .setExpirationDuration(Geofence.NEVER_EXPIRE)
+                .setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER |
+                        Geofence.GEOFENCE_TRANSITION_EXIT)
+                .build();
+
+        GeofencingRequest.Builder builder = new GeofencingRequest.Builder();
+        builder.setInitialTrigger(GeofencingRequest.INITIAL_TRIGGER_ENTER | GeofencingRequest.INITIAL_TRIGGER_EXIT);
+        builder.addGeofence(geofence);
+        return builder.build();
+    }
+
+    private PendingIntent getGeofencePendingIntent() {
+        Intent intent = new Intent(this, GeofenceBroadcastReceiver.class);
+        return PendingIntent.getBroadcast(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    }
+
+}

--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHABIntentService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHABIntentService.java
@@ -155,6 +155,11 @@ public class OpenHABIntentService extends ContinuingIntentService implements Ope
 
                             @Override
                             public void onFailure(Call call, int statusCode, Headers headers, byte[] responseBody, Throwable error) {
+                                if (statusCode == 404) {
+                                    showToast("Item " + itemName + " doesn't exist");
+                                } else {
+                                    showToast("Error " + statusCode + " while sending " + command + " to " + itemName);
+                                }
                                 Log.e(TAG, "Got command error " + statusCode, error);
                             }
                         });

--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHABIntentService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHABIntentService.java
@@ -123,7 +123,7 @@ public class OpenHABIntentService extends ContinuingIntentService implements Ope
         Log.d(TAG, "processIntent()");
         if (mOpenHABBaseUrl == null) {
             Log.w(TAG, "Couldn't determine OpenHAB URL");
-            showToast("Couldn't determine OpenHAB URL");
+            showToast(getString(R.string.error_find_url));
         }
     }
 
@@ -158,9 +158,9 @@ public class OpenHABIntentService extends ContinuingIntentService implements Ope
                             @Override
                             public void onFailure(Call call, int statusCode, Headers headers, byte[] responseBody, Throwable error) {
                                 if (statusCode == 404) {
-                                    showToast("Item " + itemName + " doesn't exist");
+                                    showToast(getString(R.string.error_item_missing, itemName));
                                 } else {
-                                    showToast("Error " + statusCode + " while sending " + command + " to " + itemName);
+                                    showToast(getString(R.string.error_item_command, statusCode, command, itemName));
                                 }
                                 Log.e(TAG, "Got command error " + statusCode, error);
                             }

--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHABIntentService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHABIntentService.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.openhab.habdroid.core;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Handler;
+import android.os.Looper;
+import android.preference.PreferenceManager;
+import android.speech.RecognizerIntent;
+import android.util.Log;
+import android.widget.Toast;
+
+import org.openhab.habdroid.R;
+import org.openhab.habdroid.util.Constants;
+import org.openhab.habdroid.util.ContinuingIntentService;
+import org.openhab.habdroid.util.MyAsyncHttpClient;
+import org.openhab.habdroid.util.MyHttpClient;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+import okhttp3.Call;
+import okhttp3.Headers;
+
+/**
+ * This service handles voice commands and sends them to OpenHAB.
+ * It will use the openHAB base URL if passed in the intent's extra,
+ * or else use the {@link OpenHABTracker} to discover openHAB itself.
+ */
+public class OpenHABIntentService extends ContinuingIntentService implements OpenHABTrackerReceiver {
+
+    private static final String TAG = OpenHABIntentService.class.getSimpleName();
+    public static final String OPENHAB_BASE_URL_EXTRA = "openHABBaseUrl";
+
+    private String mOpenHABBaseUrl;
+    private MyAsyncHttpClient mAsyncHttpClient;
+
+    private OpenHABTracker mOpenHABTracker;
+    private Queue<Intent> mBufferedIntents;
+
+    public OpenHABIntentService(String name) {
+        super(name);
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        Log.d(TAG, "onCreate()");
+
+        mBufferedIntents = new LinkedList<Intent>();
+        initHttpClient();
+    }
+
+    private void initHttpClient() {
+        SharedPreferences mSettings = PreferenceManager.getDefaultSharedPreferences(this);
+        String username = mSettings.getString(Constants.PREFERENCE_USERNAME, null);
+        String password = mSettings.getString(Constants.PREFERENCE_PASSWORD, null);
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        mAsyncHttpClient = new MyAsyncHttpClient(this, prefs.getBoolean(Constants.PREFERENCE_SSLHOST,
+                false), prefs.getBoolean(Constants.PREFERENCE_SSLCERT, false));
+        mAsyncHttpClient.setBasicAuth(username, password);
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        Log.d(TAG, "onHandleIntent()");
+        bufferIntent(intent);
+        if (intent.hasExtra(OPENHAB_BASE_URL_EXTRA)) {
+            Log.d(TAG, "openHABBaseUrl passed as Intent");
+            onOpenHABTracked(intent.getStringExtra(OPENHAB_BASE_URL_EXTRA), null);
+        } else if (mOpenHABTracker == null) {
+            Log.d(TAG, "No openHABBaseUrl passed, starting OpenHABTracker");
+            mOpenHABTracker = new OpenHABTracker(this, getString(R.string.openhab_service_type), false);
+            mOpenHABTracker.start();
+        }
+    }
+
+    /**
+     * Buffers the {@link Intent} to be processed later when openHABBaseUrl has been determined by {@link OpenHABTracker}.
+     *
+     * Usually, the discovery of the openHABBaseUrl is fast enough, so there will be only one intent in the buffer
+     * when the buffer is processed and this service is stopped.
+     * However, it is not guaranteed that this service is only called once before openHABBaseUrl can be discovered.
+     * Therefore all intents are buffered and later this buffer will be processed.
+     *
+     * @param intent The {@link Intent} to be buffered.
+     */
+    private void bufferIntent(Intent intent) {
+        mBufferedIntents.add(intent);
+    }
+
+    @Override
+    public void onOpenHABTracked(String baseUrl, String message) {
+        Log.d(TAG, "onOpenHABTracked(): " + baseUrl);
+        mOpenHABBaseUrl = baseUrl;
+        while (!mBufferedIntents.isEmpty()) {
+            processIntent(mBufferedIntents.poll());
+        }
+        Log.d(TAG, "Stopping service for start ID " + getLastStartId());
+        stopSelf(getLastStartId());
+    }
+
+    @Override
+    public void onError(String error) {
+        showToast(error);
+        Log.d(TAG, "onError(): " + error);
+        stopSelf();
+    }
+
+
+    protected void processIntent(Intent data) {
+        Log.d(TAG, "processIntent()");
+        if (mOpenHABBaseUrl == null) {
+            Log.w(TAG, "Couldn't determine OpenHAB URL");
+            showToast("Couldn't determine OpenHAB URL");
+        }
+    }
+
+
+    protected void sendItemCommand(final String itemName, final String command) {
+        Log.d(TAG, "sendItemCommand(): itemName=" + itemName + ", command=" + command);
+        try {
+            performHttpPost(itemName, command);
+        } catch (RuntimeException e) {
+            Log.e(TAG, "Unable to encode command " + command, e);
+        }
+    }
+
+    protected void performHttpPost(final String itemName, final String command) {
+        /* Call MyAsyncHttpClient on the main UI thread in order to retrieve the callbacks correctly.
+         * If calling MyAsyncHttpClient directly, the following would happen:
+         * (1) MyAsyncHttpClient performs the HTTP post asynchronously
+         * (2) OpenHABVoiceService stops because all intents have been handled
+         * (3) MyAsyncHttpClient tries to call onSuccess() or onFailure(), which is not possible
+         *     anymore because OpenHABVoiceService is already stopped/destroyed.
+         */
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                mAsyncHttpClient.post(mOpenHABBaseUrl + "rest/items/" + itemName,
+                        command, "text/plain;charset=UTF-8", new MyHttpClient.ResponseHandler() {
+                            @Override
+                            public void onSuccess(Call call, int statusCode, Headers headers, byte[] responseBody) {
+                                Log.d(TAG, "Command was sent successfully");
+                            }
+
+                            @Override
+                            public void onFailure(Call call, int statusCode, Headers headers, byte[] responseBody, Throwable error) {
+                                Log.e(TAG, "Got command error " + statusCode, error);
+                            }
+                        });
+            }
+        });
+    }
+
+
+    @Override
+    public void onDestroy() {
+        Log.d(TAG, "onDestroy()");
+        if (mOpenHABTracker != null) {
+            mOpenHABTracker.stop();
+        }
+        super.onDestroy();
+    }
+
+    /**
+     * Displays the given message as a toast
+     *
+     * @param message The message to be displayed.
+     */
+    protected void showToast(final String message) {
+        // Display toast on main looper because OpenHABVoiceService might be destroyed
+        // before to toast has finished displaying
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG).show();
+            }
+        });
+    }
+
+    @Override
+    public void onBonjourDiscoveryStarted() {
+        Log.d(TAG, "onBonjourDiscoveryStarted()");
+    }
+
+    @Override
+    public void onBonjourDiscoveryFinished() {
+        Log.d(TAG, "onBonjourDiscoveryFinished()");
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHABIntentService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHABIntentService.java
@@ -47,6 +47,8 @@ public class OpenHABIntentService extends ContinuingIntentService implements Ope
     private OpenHABTracker mOpenHABTracker;
     private Queue<Intent> mBufferedIntents;
 
+    protected SharedPreferences mSettings;
+
     public OpenHABIntentService(String name) {
         super(name);
     }
@@ -57,11 +59,11 @@ public class OpenHABIntentService extends ContinuingIntentService implements Ope
         Log.d(TAG, "onCreate()");
 
         mBufferedIntents = new LinkedList<Intent>();
+        mSettings = PreferenceManager.getDefaultSharedPreferences(this);
         initHttpClient();
     }
 
     private void initHttpClient() {
-        SharedPreferences mSettings = PreferenceManager.getDefaultSharedPreferences(this);
         String username = mSettings.getString(Constants.PREFERENCE_USERNAME, null);
         String password = mSettings.getString(Constants.PREFERENCE_PASSWORD, null);
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
@@ -71,6 +71,10 @@ public class OpenHABPreferencesActivity extends PreferenceActivity {
         Preference versionPreference = getPreferenceScreen().findPreference(Constants.PREFERENCE_APPVERSION);
         final Preference sslClientCert = getPreferenceScreen().findPreference(Constants.PREFERENCE_SSLCLIENTCERT);
         final Preference sslClientCertHowTo = getPreferenceScreen().findPreference(Constants.PREFERENCE_SSLCLIENTCERT_HOWTO);
+        final Preference itemPreference = getPreferenceScreen().findPreference(Constants.PREFERENCE_PRESENCE_ITEM);
+        final Preference latPreference = getPreferenceScreen().findPreference(Constants.PREFERENCE_PRESENCE_LAT);
+        final Preference lngPreference = getPreferenceScreen().findPreference(Constants.PREFERENCE_PRESENCE_LNG);
+
         urlPreference.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
@@ -118,6 +122,30 @@ public class OpenHABPreferencesActivity extends PreferenceActivity {
         versionPreference.setSummary(versionPreference.getSummary() + " - " +
                 DateFormat.getDateTimeInstance().format(BuildConfig.buildTime));
 
+        itemPreference.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                updateTextPreferenceSummary(preference, (String) newValue);
+                return true;
+            }
+        });
+        updateTextPreferenceSummary(itemPreference, null);
+        latPreference.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                updateTextPreferenceSummary(preference, (String) newValue);
+                return true;
+            }
+        });
+        updateTextPreferenceSummary(latPreference, null);
+        lngPreference.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                updateTextPreferenceSummary(preference, (String) newValue);
+                return true;
+            }
+        });
+        updateTextPreferenceSummary(lngPreference, null);
 
         updateSslCleintCertSumary(sslClientCert);
 

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
@@ -26,5 +26,9 @@ public class Constants {
     public static final String PREFERENCE_TONE              = "default_openhab_alertringtone";
     public static final String PREFERENCE_SSLCLIENTCERT     = "default_openhab_sslclientcert";
     public static final String PREFERENCE_SSLCLIENTCERT_HOWTO = "default_openhab_sslclientcert_howto";
+    public static final String PREFERENCE_PRESENCE_ENABLE   = "default_openhab_presence_enable";
+    public static final String PREFERENCE_PRESENCE_ITEM     = "default_openhab_presence_item";
+    public static final String PREFERENCE_PRESENCE_LAT      = "default_openhab_presence_lat";
+    public static final String PREFERENCE_PRESENCE_LNG      = "default_openhab_presence_lng";
     public static final String DEFAULT_GCM_SENDER_ID        = "737820980945";
 }

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
@@ -30,5 +30,6 @@ public class Constants {
     public static final String PREFERENCE_PRESENCE_ITEM     = "default_openhab_presence_item";
     public static final String PREFERENCE_PRESENCE_LAT      = "default_openhab_presence_lat";
     public static final String PREFERENCE_PRESENCE_LNG      = "default_openhab_presence_lng";
+    public static final String PREFERENCE_PRESENCE_DEBUG     = "default_openhab_presence_debug";
     public static final String DEFAULT_GCM_SENDER_ID        = "737820980945";
 }

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="error_find_url">Couldn\'t determine OpenHAB URL</string>
     <string name="error_item_missing">Item %s doesn\'t exist.</string>
     <string name="error_item_command">Error %1$d while sending %2$s to %3$s</string>
+    <string name="presence_pref_title">Presence</string>
     <string name="presence_pref_enable_title">Enable</string>
     <string name="presence_pref_enable_summary">Enable location-based presence reporting</string>
     <string name="presence_pref_item_title">Presence Item</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="erorr_invalid_url">Please enter a valid URL in a \'protocol://host:port/\' form</string>
     <string name="erorr_no_wifi_mcast_permission">CHANGE_WIFI_MULTICAST_STATE permission is not granted, openHAB discovery will be disabled!</string>
     <string name="erorr_no_wifi_state_permission">ACCESS_WIFI_STATE permission is not granted, openHAB discovery will be disabled!</string>
+    <string name="erorr_no_location_permission">ACCESS_FINE_LOCATION permission is not granted, openHAB presence reporting will be disabled!</string>
     <string name="error_connection_failed">Connection to host failed</string>
     <string name="error_connection_sslhandshake_failed">SSL Handshake failed - maybe you need a valid client certificate</string>
     <string name="title_activity_openhabwritetag">Write NFC tag</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -112,4 +112,19 @@
     <!-- drawer -->
     <string name="drawer_open">Sitemap drawer opened</string>
     <string name="drawer_close">Sitemap drawer closed</string>
+
+    <!-- Presence/Geofence -->
+    <string name="geofence_debug_notification">Geofence transition</string>
+    <string name="geofence_debug_unknown">Unknown transition type: %d</string>
+    <string name="presence_invalid_latlng">Invalid presence Lat/Lng</string>
+    <string name="error_find_url">Couldn\'t determine OpenHAB URL</string>
+    <string name="error_item_missing">Item %s doesn\'t exist.</string>
+    <string name="error_item_command">Error %1$d while sending %2$s to %3$s</string>
+    <string name="presence_pref_enable_title">Enable</string>
+    <string name="presence_pref_enable_summary">Enable location-based presence reporting</string>
+    <string name="presence_pref_item_title">Presence Item</string>
+    <string name="presence_pref_lat_title">Latitude</string>
+    <string name="presence_pref_lng_title">Longitude</string>
+    <string name="presence_pref_debug_title">Debugging</string>
+    <string name="presence_pref_debug_summary">Enable debug notifications</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -123,7 +123,7 @@
     <string name="presence_pref_title">Presence</string>
     <string name="presence_pref_enable_title">Enable</string>
     <string name="presence_pref_enable_summary">Enable location-based presence reporting</string>
-    <string name="presence_pref_item_title">Presence Item</string>
+    <string name="presence_pref_item_title">Item</string>
     <string name="presence_pref_lat_title">Latitude</string>
     <string name="presence_pref_lng_title">Longitude</string>
     <string name="presence_pref_debug_title">Debugging</string>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -58,7 +58,7 @@
             android:summary="@string/settings_openhab_sslhost_summary"
             android:title="@string/settings_openhab_sslhost" />
     </PreferenceCategory>
-    <PreferenceCategory android:title="Presence">
+    <PreferenceCategory android:title="@string/presence_pref_title">
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="default_openhab_presence_enable"

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -60,7 +60,7 @@
     </PreferenceCategory>
     <PreferenceCategory android:title="Presence">
         <CheckBoxPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="default_openhab_presence_enable"
             android:summary="Enable location-based presence reporting"
             android:title="Enable" />

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -72,21 +72,22 @@
             android:summary=""
             android:title="Presence Item" />
         <EditTextPreference
-            android:defaultValue="47.6"
+            android:defaultValue=""
             android:dependency="default_openhab_presence_enable"
             android:inputType="numberDecimal"
             android:key="default_openhab_presence_lat"
             android:summary=""
             android:title="Latitude" />
         <EditTextPreference
-            android:defaultValue="-122.3"
+            android:defaultValue=""
             android:dependency="default_openhab_presence_enable"
             android:inputType="numberDecimal"
             android:key="default_openhab_presence_lng"
             android:summary=""
             android:title="Longitude" />
         <CheckBoxPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
+            android:dependency="default_openhab_presence_enable"
             android:key="default_openhab_presence_debug"
             android:summary="Enable debug notifications"
             android:title="Debugging" />

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -58,6 +58,34 @@
             android:summary="@string/settings_openhab_sslhost_summary"
             android:title="@string/settings_openhab_sslhost" />
     </PreferenceCategory>
+    <PreferenceCategory android:title="Presence">
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="default_openhab_presence_enable"
+            android:summary="Enable location-based presence reporting"
+            android:title="Enable" />
+        <EditTextPreference
+            android:defaultValue="isPresent"
+            android:dependency="default_openhab_presence_enable"
+            android:inputType="textNoSuggestions"
+            android:key="default_openhab_presence_item"
+            android:summary=""
+            android:title="Presence Item" />
+        <EditTextPreference
+            android:defaultValue="47.606383"
+            android:dependency="default_openhab_presence_enable"
+            android:inputType="numberDecimal"
+            android:key="default_openhab_presence_lat"
+            android:summary=""
+            android:title="Home Latitude" />
+        <EditTextPreference
+            android:defaultValue="-122.304941"
+            android:dependency="default_openhab_presence_enable"
+            android:inputType="numberDecimal"
+            android:key="default_openhab_presence_lng"
+            android:summary=""
+            android:title="Home Longitude" />
+    </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_display_title">
         <ListPreference
             android:key="default_openhab_theme"

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -72,19 +72,24 @@
             android:summary=""
             android:title="Presence Item" />
         <EditTextPreference
-            android:defaultValue="47.606383"
+            android:defaultValue="47.6"
             android:dependency="default_openhab_presence_enable"
             android:inputType="numberDecimal"
             android:key="default_openhab_presence_lat"
             android:summary=""
-            android:title="Home Latitude" />
+            android:title="Latitude" />
         <EditTextPreference
-            android:defaultValue="-122.304941"
+            android:defaultValue="-122.3"
             android:dependency="default_openhab_presence_enable"
             android:inputType="numberDecimal"
             android:key="default_openhab_presence_lng"
             android:summary=""
-            android:title="Home Longitude" />
+            android:title="Longitude" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="default_openhab_presence_debug"
+            android:summary="Enable debug notifications"
+            android:title="Debugging" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_display_title">
         <ListPreference

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -62,35 +62,33 @@
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="default_openhab_presence_enable"
-            android:summary="Enable location-based presence reporting"
-            android:title="Enable" />
+            android:summary="@string/presence_pref_enable_summary"
+            android:title="@string/presence_pref_enable_title" />
         <EditTextPreference
             android:defaultValue="isPresent"
             android:dependency="default_openhab_presence_enable"
             android:inputType="textNoSuggestions"
             android:key="default_openhab_presence_item"
             android:summary=""
-            android:title="Presence Item" />
+            android:title="@string/presence_pref_item_title" />
         <EditTextPreference
-            android:defaultValue=""
             android:dependency="default_openhab_presence_enable"
             android:inputType="numberDecimal"
             android:key="default_openhab_presence_lat"
             android:summary=""
-            android:title="Latitude" />
+            android:title="@string/presence_pref_lat_title" />
         <EditTextPreference
-            android:defaultValue=""
             android:dependency="default_openhab_presence_enable"
             android:inputType="numberDecimal"
             android:key="default_openhab_presence_lng"
             android:summary=""
-            android:title="Longitude" />
+            android:title="@string/presence_pref_lng_title" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:dependency="default_openhab_presence_enable"
             android:key="default_openhab_presence_debug"
-            android:summary="Enable debug notifications"
-            android:title="Debugging" />
+            android:summary="@string/presence_pref_debug_summary"
+            android:title="@string/presence_pref_debug_title" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_display_title">
         <ListPreference


### PR DESCRIPTION
This implements #343 

* Added prefs.
* If Lat/Lng aren't set, it fetches `/services/org.eclipse.smarthome.core.i18nprovider/config` to get `location`. I'd be totally in favor of fetching that another way if there is one. Maybe a new core service to expose for location?
* Request permissions dynamically if they weren't already granted
* Setup geofences (on boot too!)
* Update item state on enter/exit

I don't do tons of Java or Android, so please tell me what can be improved!