### PR TITLE
Dim display when inactive

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.READ_LOGS" />
     <uses-permission android:name="android.permission.GET_TASKS" />
     <uses-permission android:name="android.permission.NFC" />
+    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <!-- Keeps the processor from sleeping when a message is received. -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -28,6 +28,7 @@ import android.nfc.NfcAdapter;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.speech.RecognizerIntent;
@@ -195,6 +196,10 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
     private ProgressBar mProgressBar;
     private Boolean mIsMyOpenHAB = false;
     private NotificationSettings mNotifySettings = null;
+    // Dim display after inactivity
+    private boolean dimDisplayEnabled;
+    private int screenBrightness;
+    private long dimDisplayTime;
 
     public static String GCM_SENDER_ID;
 
@@ -386,6 +391,22 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         }
 
         checkFullscreen();
+
+        dimDisplayEnabled = mSettings.getBoolean(Constants.PREFERENCE_SCREEN_DIM, false);
+        if(dimDisplayEnabled) {
+            Log.d(TAG, "Set up dimmer");
+            // We get minutes, but need milliseconds
+            try {
+                dimDisplayTime = Integer.valueOf(mSettings.getString(Constants.PREFERENCE_SCREEN_DIM_TIME, "")) * 60 * 1000;
+            } catch (Exception e) {
+                e.printStackTrace();
+                dimDisplayTime = 5 * 60 * 1000;
+            }
+            resetDimDisplayTimer();
+        } else {
+            // stop running timer
+            stopDimDisplayTimer();
+        }
     }
 
     /**
@@ -427,6 +448,20 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         }
         if (mOpenHABTracker != null) {
             mOpenHABTracker.stop();
+        }
+
+        stopDimDisplayTimer();
+        if(dimDisplayEnabled) {
+            restoreDisplayBrightness();
+        }
+    }
+
+    @Override
+    public void onUserInteraction(){
+        Log.d(TAG, "onUserInteraction()");
+        if(dimDisplayEnabled) {
+            resetDimDisplayTimer();
+            restoreDisplayBrightness();
         }
     }
 
@@ -1285,6 +1320,68 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         return supportsKitKat && fullScreen;
     }
 
+    /**
+     * Save initial brightness and set it to 0
+     *
+     * @author mueller-ma
+     */
+    private void reduceDisplayBrightness() {
+        Log.d(TAG, "dim");
+        // Save brightness
+        try {
+            screenBrightness = Settings.System.getInt(getContentResolver(), Settings.System.SCREEN_BRIGHTNESS);
+        } catch (Exception e) {
+            e.printStackTrace();
+            // if it fails, assume maximum brightness
+            screenBrightness = 255;
+        }
+        // Set brightness to 0
+        android.provider.Settings.System.putInt(getContentResolver(),
+                android.provider.Settings.System.SCREEN_BRIGHTNESS, 0);
+    }
+
+    /**
+     * Restore screen brightness
+     *
+     * @author mueller-ma
+     */
+    private void restoreDisplayBrightness() {
+        try {
+            // In case the brightness was changed, while openhab dimmed the display, save the new value
+            int currentScreenBrightness = Settings.System.getInt(getContentResolver(), Settings.System.SCREEN_BRIGHTNESS);
+            if(currentScreenBrightness != 0) {
+                screenBrightness = currentScreenBrightness;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        android.provider.Settings.System.putInt(getContentResolver(),
+                android.provider.Settings.System.SCREEN_BRIGHTNESS, screenBrightness);
+    }
+
+    private Handler dimDisplayHandler = new Handler(){};
+
+    private Runnable dimDisplayCallback = new Runnable() {
+        @Override
+        public void run() {
+            reduceDisplayBrightness();
+        }
+    };
+
+    /**
+     * Resets the timer. When no timer is running, start it.
+     */
+    public void resetDimDisplayTimer(){
+        dimDisplayHandler.removeCallbacks(dimDisplayCallback);
+        dimDisplayHandler.postDelayed(dimDisplayCallback, dimDisplayTime);
+    }
+
+    /**
+     * Stops the timer
+     */
+    public void stopDimDisplayTimer(){
+        dimDisplayHandler.removeCallbacks(dimDisplayCallback);
+    }
 
     private void loadDrawerItems() {
         mDrawerItemList.clear();

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
@@ -12,6 +12,8 @@ package org.openhab.habdroid.util;
 public class Constants {
     public static final String PREFERENCE_APPVERSION        = "default_openhab_appversion";
     public static final String PREFERENCE_SCREENTIMEROFF    = "default_openhab_screentimeroff";
+    public static final String PREFERENCE_SCREEN_DIM        = "default_openhab_screen_dim";
+    public static final String PREFERENCE_SCREEN_DIM_TIME   = "default_openhab_screen_dim_time";
     public static final String PREFERENCE_USERNAME          = "default_openhab_username";
     public static final String PREFERENCE_PASSWORD          = "default_openhab_password";
     public static final String PREFERENCE_SITEMAP           = "default_openhab_sitemap";

--- a/mobile/src/main/res/values/arrays.xml
+++ b/mobile/src/main/res/values/arrays.xml
@@ -27,4 +27,16 @@
         <item>@string/settings_openhab_icon_format_png</item>
         <item>@string/settings_openhab_icon_format_svg</item>
     </string-array>
+
+    <string-array name="screen_dim_time_values">
+        <item>1</item>
+        <item>5</item>
+        <item>10</item>
+    </string-array>
+
+    <string-array name="screen_dim_time">
+        <item>@string/settings_openhab_screen_dim_time_one_minute</item>
+        <item>@string/settings_openhab_screen_dim_time_five_minutes</item>
+        <item>@string/settings_openhab_screen_dim_time_ten_minutes</item>
+    </string-array>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -129,4 +129,10 @@
     <string name="about_links">Links</string>
     <string name="about_links_list"><![CDATA[\u00B7 <a href="https://github.com/openhab/openhab.android">openHAB App source code</a><br><br> \u00B7 <a href="https://github.com/openhab/openhab.android/issues">Report a problem</a><br><br> \u00B7 <a href="http://docs.openhab.org/">openHAB Documentation</a><br><br> \u00B7 <a href="https://community.openhab.org/">Community Forum</a>]]></string>
     <string name="about_copyright" translatable="false">© 2012 - %s openHAB Foundation</string>
+    <string name="settings_display_hardware">Hardware display</string>
+    <string name="settings_openhab_screen_dim_time_five_minutes">5 minutes</string>
+    <string name="settings_openhab_screen_dim_time_ten_minutes">10 minutes</string>
+    <string name="settings_openhab_screen_dim_time_one_minute">1 minute</string>
+    <string name="settings_openhab_screen_dim_title">Dim display when inactive</string>
+    <string name="settings_openhab_screen_dim_time_title">Time</string>
 </resources>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -59,22 +59,36 @@
             android:title="@string/settings_openhab_sslhost" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_display_title">
+        <PreferenceScreen android:title="@string/settings_display_hardware">
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="default_openhab_fullscreen"
+                android:summary="@string/settings_openhab_fullscreen_summary"
+                android:title="@string/settings_openhab_fullscreen" />
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="default_openhab_screentimeroff"
+                android:summary="@string/settings_openhab_screentimeroff_summary"
+                android:title="@string/settings_openhab_screentimeroff" />
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="default_openhab_screen_dim"
+                android:title="@string/settings_openhab_screen_dim_title" />
+            <ListPreference
+                android:title="@string/settings_openhab_screen_dim_time_title"
+                android:key="default_openhab_screen_dim_time"
+                android:defaultValue="5"
+                android:dependency="default_openhab_screen_dim"
+                android:summary="%s"
+                android:entries="@array/screen_dim_time"
+                android:entryValues="@array/screen_dim_time_values" />
+        </PreferenceScreen>
         <ListPreference
-            android:key="default_openhab_theme"
-            android:title="@string/settings_openhab_theme"
-            android:defaultValue="@string/theme_value_light"
-            android:entries="@array/themeArray"
-            android:entryValues="@array/themeValues" />
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="default_openhab_screentimeroff"
-            android:summary="@string/settings_openhab_screentimeroff_summary"
-            android:title="@string/settings_openhab_screentimeroff" />
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="default_openhab_fullscreen"
-            android:summary="@string/settings_openhab_fullscreen_summary"
-            android:title="@string/settings_openhab_fullscreen" />
+        android:key="default_openhab_theme"
+        android:title="@string/settings_openhab_theme"
+        android:defaultValue="@string/theme_value_light"
+        android:entries="@array/themeArray"
+        android:entryValues="@array/themeValues" />
         <ListPreference
             android:title="@string/settings_openhab_icon_format"
             android:key="iconFormatType"


### PR DESCRIPTION
Sets the display brightness to 0, when the user is inactive for some
time and restore it on interaction or stop.
I moved the display settings related to the hardware display to a
new section.

Fix #39

That might be not enough, since the lowest brightness is still too bright on some devices. Maybe we could use some other methods to dim the display or change the theme to a dark theme.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>