### PR TITLE
WIP: Listen for broadcasts

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -117,7 +117,7 @@
             </intent-filter>
         </receiver>
 
-        <service android:name=".core.ForegroundService" />
+        <service android:name=".core.CustomBroadcastListenerService" />
         <!--    This is temp disabled because of a bug in GMS 6.5
                 <meta-data android:name="com.google.android.gms.analytics.globalConfigResource"
                     android:resource="@xml/global_tracker" /> -->

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -78,7 +78,6 @@
         <activity android:name="org.openhab.habdroid.ui.IntroActivity"
             android:label="@string/app_intro"/>
         <activity android:name="de.duenndns.ssl.MemorizingActivity" />
-
         <service
             android:name=".core.OpenHABVoiceService"
             android:exported="false" />

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -71,9 +71,6 @@
 
                 <data android:scheme="openhab" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED"/>
-            </intent-filter>
         </activity>
         <activity
             android:name="org.openhab.habdroid.ui.OpenHABWriteTagActivity"
@@ -81,6 +78,7 @@
         <activity android:name="org.openhab.habdroid.ui.IntroActivity"
             android:label="@string/app_intro"/>
         <activity android:name="de.duenndns.ssl.MemorizingActivity" />
+
         <service
             android:name=".core.OpenHABVoiceService"
             android:exported="false" />
@@ -110,6 +108,13 @@
             <meta-data
                 android:name="android.appwidget.provider"
                 android:resource="@xml/voice_widget_info" />
+        </receiver>
+
+        <receiver android:name=".core.BootCompletedReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <category android:name="android.intent.category.HOME" />
+            </intent-filter>
         </receiver>
 
         <service android:name=".core.ForegroundService" />

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
 
     <uses-permission android:name="org.openhab.habdroid.gcm.permission.C2D_MESSAGE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <uses-feature
         android:name="android.hardware.location.gps"
@@ -70,6 +71,9 @@
 
                 <data android:scheme="openhab" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+            </intent-filter>
         </activity>
         <activity
             android:name="org.openhab.habdroid.ui.OpenHABWriteTagActivity"
@@ -107,6 +111,8 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/voice_widget_info" />
         </receiver>
+
+        <service android:name=".core.ForegroundService" />
         <!--    This is temp disabled because of a bug in GMS 6.5
                 <meta-data android:name="com.google.android.gms.analytics.globalConfigResource"
                     android:resource="@xml/global_tracker" /> -->

--- a/mobile/src/main/java/org/openhab/habdroid/core/BootCompletedReceiver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/BootCompletedReceiver.java
@@ -14,7 +14,6 @@ public class BootCompletedReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        Log.e(TAG, "fooooo");
         if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
             try {
                 Intent i = new Intent(context, OpenHABMainActivity.class);

--- a/mobile/src/main/java/org/openhab/habdroid/core/BootCompletedReceiver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/BootCompletedReceiver.java
@@ -3,9 +3,12 @@ package org.openhab.habdroid.core;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
-import org.openhab.habdroid.ui.OpenHABMainActivity;
+import org.openhab.habdroid.util.Constants;
 
 import static org.openhab.habdroid.core.CustomBroadcastReceiver.CUSTOM_BROADCAST_RECEIVER_INTENT;
 
@@ -14,12 +17,21 @@ public class BootCompletedReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
+        if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction()) ||
+                CUSTOM_BROADCAST_RECEIVER_INTENT.equals(intent.getAction())) {
             try {
-                Intent i = new Intent(context, OpenHABMainActivity.class);
-                i.setAction(CUSTOM_BROADCAST_RECEIVER_INTENT);
-                context.startActivity(i);
+                SharedPreferences mSettings = PreferenceManager.getDefaultSharedPreferences(context);
+                Intent i = new Intent(context, CustomBroadcastListenerService.class);
+                i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
+                if (mSettings.getBoolean(Constants.PREFERENCE_CUSTOM_BROADCAST, false)) {
+                    Log.d(TAG, "start cbr");
+                    i.setAction(Constants.ACTION.STARTFOREGROUND_ACTION);
+                } else {
+                    Log.d(TAG, "stop cbr");
+                    i.setAction(Constants.ACTION.STOPFOREGROUND_ACTION);
+                }
+                context.startService(i);
             } catch (Exception e) {
                 Log.e(TAG, e.toString());
             }

--- a/mobile/src/main/java/org/openhab/habdroid/core/BootCompletedReceiver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/BootCompletedReceiver.java
@@ -1,0 +1,29 @@
+package org.openhab.habdroid.core;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import org.openhab.habdroid.ui.OpenHABMainActivity;
+
+import static org.openhab.habdroid.core.CustomBroadcastReceiver.CUSTOM_BROADCAST_RECEIVER_INTENT;
+
+public class BootCompletedReceiver extends BroadcastReceiver {
+    private static final String TAG = BootCompletedReceiver.class.getSimpleName();
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Log.e(TAG, "fooooo");
+        if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
+            try {
+                Intent i = new Intent(context, OpenHABMainActivity.class);
+                i.setAction(CUSTOM_BROADCAST_RECEIVER_INTENT);
+                context.startActivity(i);
+
+            } catch (Exception e) {
+                Log.e(TAG, e.toString());
+            }
+        }
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastListenerService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastListenerService.java
@@ -16,8 +16,9 @@ import org.openhab.habdroid.R;
 import org.openhab.habdroid.ui.OpenHABMainActivity;
 import org.openhab.habdroid.util.Constants;
 
-public class ForegroundService extends Service {
-    private static final String TAG = "ForegroundService";
+public class CustomBroadcastListenerService extends Service {
+    private static final String TAG = "CBLService";
+    private static boolean cbrRunning = false;
 
     @Override
     public void onCreate() {
@@ -30,7 +31,13 @@ public class ForegroundService extends Service {
         CustomBroadcastReceiver cbr = new CustomBroadcastReceiver();
         if (intent.getAction().equals(Constants.ACTION.STARTFOREGROUND_ACTION)) {
             Log.i(TAG, "Received Start Foreground Intent ");
-            String broadcast = (String) intent.getExtras().get("broadcast");
+            SharedPreferences mSettings = PreferenceManager.getDefaultSharedPreferences(this);
+            String broadcast = mSettings.getString(Constants.PREFERENCE_CUSTOM_BROADCAST_BROADCAST, "");
+            String item = mSettings.getString(Constants.PREFERENCE_CUSTOM_BROADCAST_ITEM, "");
+            String intent_extra = mSettings.getString(Constants.PREFERENCE_CUSTOM_BROADCAST_EXTRA, "button_id");
+            CustomBroadcastReceiver.item = item;
+            CustomBroadcastReceiver.intent_extra = intent_extra;
+
             IntentFilter cbr_intent = new IntentFilter();
             cbr_intent.addAction(broadcast);
             registerReceiver(cbr, cbr_intent);
@@ -39,16 +46,12 @@ public class ForegroundService extends Service {
             notificationIntent.setAction(Constants.ACTION.MAIN_ACTION);
             notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
 
-            PendingIntent pendingIntent =
-                    PendingIntent.getActivity(this, 0, notificationIntent, 0);
-
             Notification notification = new NotificationCompat.Builder(this)
                     .setContentTitle(getString(R.string.settings_custom_broadcast_listening))
                     .setContentText(getString(R.string.notification_last_broadcast_none))
                     .setSmallIcon(R.drawable.icon_blank)
                     .setPriority(Notification.PRIORITY_LOW)
                     .setColor(ResourcesCompat.getColor(getResources(), R.color.openhab_orange, null))
-                    .setContentIntent(pendingIntent)
                     .setOngoing(true).build();
 
             startForeground(Constants.NOTIFICATION_ID.FOREGROUND_SERVICE, notification);

--- a/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastListenerService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastListenerService.java
@@ -18,7 +18,6 @@ import org.openhab.habdroid.util.Constants;
 
 public class CustomBroadcastListenerService extends Service {
     private static final String TAG = "CBLService";
-    private static boolean cbrRunning = false;
 
     @Override
     public void onCreate() {
@@ -30,7 +29,7 @@ public class CustomBroadcastListenerService extends Service {
     public int onStartCommand(Intent intent, int flags, int startId) {
         CustomBroadcastReceiver cbr = new CustomBroadcastReceiver();
         if (intent.getAction().equals(Constants.ACTION.STARTFOREGROUND_ACTION)) {
-            Log.i(TAG, "Received Start Foreground Intent ");
+            Log.i(TAG, "Received Start Foreground Intent");
             SharedPreferences mSettings = PreferenceManager.getDefaultSharedPreferences(this);
             String broadcast = mSettings.getString(Constants.PREFERENCE_CUSTOM_BROADCAST_BROADCAST, "");
             String item = mSettings.getString(Constants.PREFERENCE_CUSTOM_BROADCAST_ITEM, "");

--- a/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastListenerService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastListenerService.java
@@ -43,7 +43,6 @@ public class CustomBroadcastListenerService extends Service {
             registerReceiver(cbr, cbr_intent);
 
             Intent notificationIntent = new Intent(this, OpenHABMainActivity.class);
-            notificationIntent.setAction(Constants.ACTION.MAIN_ACTION);
             notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
 
             Notification notification = new NotificationCompat.Builder(this)

--- a/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
@@ -31,6 +31,7 @@ import static org.openhab.habdroid.ui.OpenHABMainActivity.mAsyncHttpClient;
 
 public class CustomBroadcastReceiver extends BroadcastReceiver {
     private final static String TAG = CustomBroadcastReceiver.class.getSimpleName();
+    public final static String CUSTOM_BROADCAST_RECEIVER_INTENT = "org.openhab.habdroid.cbr";
 
     private static void updateNotification(String text, Context context) {
         Intent notificationIntent = new Intent(context, OpenHABMainActivity.class);

--- a/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.icu.text.SimpleDateFormat;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
@@ -32,14 +33,13 @@ import static org.openhab.habdroid.ui.OpenHABMainActivity.mAsyncHttpClient;
 public class CustomBroadcastReceiver extends BroadcastReceiver {
     private final static String TAG = CustomBroadcastReceiver.class.getSimpleName();
     public final static String CUSTOM_BROADCAST_RECEIVER_INTENT = "org.openhab.habdroid.cbr";
+    public static String item;
+    public static String intent_extra;
 
     private static void updateNotification(String text, Context context) {
         Intent notificationIntent = new Intent(context, OpenHABMainActivity.class);
         notificationIntent.setAction(Constants.ACTION.MAIN_ACTION);
         notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-
-        PendingIntent pendingIntent =
-                PendingIntent.getActivity(context, 0, notificationIntent, 0);
 
         Notification notification;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
@@ -49,7 +49,6 @@ public class CustomBroadcastReceiver extends BroadcastReceiver {
                     .setSmallIcon(R.drawable.icon_blank)
                     .setPriority(Notification.PRIORITY_LOW)
                     .setColor(ResourcesCompat.getColor(context.getResources(), R.color.openhab_orange, null))
-                    .setContentIntent(pendingIntent)
                     .setOngoing(true).build();
         } else {
             notification = new NotificationCompat.Builder(context)
@@ -57,7 +56,6 @@ public class CustomBroadcastReceiver extends BroadcastReceiver {
                     .setContentText(text)
                     .setSmallIcon(R.drawable.icon_blank)
                     .setColor(ResourcesCompat.getColor(context.getResources(), R.color.openhab_orange, null))
-                    .setContentIntent(pendingIntent)
                     .setOngoing(true).build();
         }
         NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
@@ -68,23 +66,20 @@ public class CustomBroadcastReceiver extends BroadcastReceiver {
     public void onReceive(final Context context, Intent intent) {
         Log.d(TAG, "onReceive()");
         try {
-            SharedPreferences mSettings = PreferenceManager.getDefaultSharedPreferences(context);
-            String extra = mSettings.getString(Constants.PREFERENCE_CUSTOM_BROADCAST_EXTRA, "button_id");
 
-            if (intent.hasExtra(extra)) {
-                Log.d(TAG, "Button: " + intent.getExtras().get(extra));
-
+            if (intent.hasExtra(intent_extra)) {
                 final String state;
                 try {
-                    state = intent.getExtras().get(extra).toString();
+                    state = intent.getExtras().get(intent_extra).toString();
                 } catch (NullPointerException e) {
                     e.printStackTrace();
                     return;
                 }
-                String item = mSettings.getString(Constants.PREFERENCE_CUSTOM_BROADCAST_ITEM, "");
+
+                Log.d(TAG, "Value: " + state);
 
                 final String currentTime;
-                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                     currentTime = new SimpleDateFormat("HH:mm:ss").format(new Date());
                 } else {
                     currentTime = Calendar.getInstance().getTime().toString();

--- a/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
@@ -38,7 +38,6 @@ public class CustomBroadcastReceiver extends BroadcastReceiver {
 
     private static void updateNotification(String text, Context context) {
         Intent notificationIntent = new Intent(context, OpenHABMainActivity.class);
-        notificationIntent.setAction(Constants.ACTION.MAIN_ACTION);
         notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
 
         Notification notification;

--- a/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
@@ -1,0 +1,126 @@
+package org.openhab.habdroid.core;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.icu.text.SimpleDateFormat;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.support.annotation.Nullable;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.res.ResourcesCompat;
+import android.util.Log;
+import android.widget.Toast;
+
+import org.openhab.habdroid.R;
+import org.openhab.habdroid.ui.OpenHABMainActivity;
+import org.openhab.habdroid.util.Constants;
+import org.openhab.habdroid.util.MyHttpClient;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import okhttp3.Call;
+import okhttp3.Headers;
+
+import static org.openhab.habdroid.ui.OpenHABMainActivity.mAsyncHttpClient;
+
+public class CustomBroadcastReceiver extends BroadcastReceiver {
+    private final static String TAG = CustomBroadcastReceiver.class.getSimpleName();
+
+    private static void updateNotification(String text, Context context) {
+        Intent notificationIntent = new Intent(context, OpenHABMainActivity.class);
+        notificationIntent.setAction(Constants.ACTION.MAIN_ACTION);
+        notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+
+        PendingIntent pendingIntent =
+                PendingIntent.getActivity(context, 0, notificationIntent, 0);
+
+        Notification notification;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
+            notification = new NotificationCompat.Builder(context)
+                    .setContentTitle(context.getString(R.string.settings_custom_broadcast_listening))
+                    .setContentText(text)
+                    .setSmallIcon(R.drawable.icon_blank)
+                    .setPriority(Notification.PRIORITY_LOW)
+                    .setColor(ResourcesCompat.getColor(context.getResources(), R.color.openhab_orange, null))
+                    .setContentIntent(pendingIntent)
+                    .setOngoing(true).build();
+        } else {
+            notification = new NotificationCompat.Builder(context)
+                    .setContentTitle(context.getString(R.string.settings_custom_broadcast_listening))
+                    .setContentText(text)
+                    .setSmallIcon(R.drawable.icon_blank)
+                    .setColor(ResourcesCompat.getColor(context.getResources(), R.color.openhab_orange, null))
+                    .setContentIntent(pendingIntent)
+                    .setOngoing(true).build();
+        }
+        NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        nm.notify(Constants.NOTIFICATION_ID.FOREGROUND_SERVICE, notification);
+    }
+
+    @Override
+    public void onReceive(final Context context, Intent intent) {
+        Log.d(TAG, "onReceive()");
+        try {
+            SharedPreferences mSettings = PreferenceManager.getDefaultSharedPreferences(context);
+            String extra = mSettings.getString(Constants.PREFERENCE_CUSTOM_BROADCAST_EXTRA, "button_id");
+
+            if (intent.hasExtra(extra)) {
+                Log.d(TAG, "Button: " + intent.getExtras().get(extra));
+
+                final String state;
+                try {
+                    state = intent.getExtras().get(extra).toString();
+                } catch (NullPointerException e) {
+                    e.printStackTrace();
+                    return;
+                }
+                String item = mSettings.getString(Constants.PREFERENCE_CUSTOM_BROADCAST_ITEM, "");
+
+                final String currentTime;
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                    currentTime = new SimpleDateFormat("HH:mm:ss").format(new Date());
+                } else {
+                    currentTime = Calendar.getInstance().getTime().toString();
+                }
+
+                try {
+                    mAsyncHttpClient.post(OpenHABMainActivity.openHABBaseUrl + "rest/items/" + item, state, "text/plain;charset=UTF-8", new MyHttpClient.TextResponseHandler() {
+                        @Override
+                        public void onFailure(Call call, int statusCode, Headers headers, String responseString, Throwable error) {
+                            Log.e(TAG, "Got command error " + error.getMessage());
+                            String message = String.format(context.getString(R.string.notification_last_broadcast_failed), currentTime, state);
+                            if (statusCode == 404) {
+                                message = context.getString(R.string.error_custom_broadcast_item_not_found);
+                            }
+                            updateNotification(message, context);
+                            if (responseString != null)
+                                Log.e(TAG, "Error response = " + responseString);
+                        }
+
+                        @Override
+                        public void onSuccess(Call call, int statusCode, Headers headers, String responseString) {
+                            String message = String.format(context.getString(R.string.notification_last_broadcast_success), currentTime, state);
+                            updateNotification(message, context);
+                            Log.d(TAG, "Command was sent successfully");
+                        }
+                    });
+                } catch (RuntimeException e) {
+                    if (e.getMessage() != null)
+                        Log.e(TAG, e.getMessage());
+                }
+            } else {
+                String message = context.getString(R.string.error_custom_broadcast_extra_not_found);
+                updateNotification(message, context);
+                Log.d(TAG, "Extra not found");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/core/ForegroundService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/ForegroundService.java
@@ -1,0 +1,80 @@
+package org.openhab.habdroid.core;
+
+import android.app.Notification;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.SharedPreferences;
+import android.os.IBinder;
+import android.preference.PreferenceManager;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.res.ResourcesCompat;
+import android.util.Log;
+
+import org.openhab.habdroid.R;
+import org.openhab.habdroid.ui.OpenHABMainActivity;
+import org.openhab.habdroid.util.Constants;
+
+public class ForegroundService extends Service {
+    private static final String TAG = "ForegroundService";
+
+    @Override
+    public void onCreate() {
+        Log.d(TAG, "onCreate()");
+        super.onCreate();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        CustomBroadcastReceiver cbr = new CustomBroadcastReceiver();
+        if (intent.getAction().equals(Constants.ACTION.STARTFOREGROUND_ACTION)) {
+            Log.i(TAG, "Received Start Foreground Intent ");
+            String broadcast = (String) intent.getExtras().get("broadcast");
+            IntentFilter cbr_intent = new IntentFilter();
+            cbr_intent.addAction(broadcast);
+            registerReceiver(cbr, cbr_intent);
+
+            Intent notificationIntent = new Intent(this, OpenHABMainActivity.class);
+            notificationIntent.setAction(Constants.ACTION.MAIN_ACTION);
+            notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+
+            PendingIntent pendingIntent =
+                    PendingIntent.getActivity(this, 0, notificationIntent, 0);
+
+            Notification notification = new NotificationCompat.Builder(this)
+                    .setContentTitle(getString(R.string.settings_custom_broadcast_listening))
+                    .setContentText(getString(R.string.notification_last_broadcast_none))
+                    .setSmallIcon(R.drawable.icon_blank)
+                    .setPriority(Notification.PRIORITY_LOW)
+                    .setColor(ResourcesCompat.getColor(getResources(), R.color.openhab_orange, null))
+                    .setContentIntent(pendingIntent)
+                    .setOngoing(true).build();
+
+            startForeground(Constants.NOTIFICATION_ID.FOREGROUND_SERVICE, notification);
+
+        } else if (intent.getAction().equals(Constants.ACTION.STOPFOREGROUND_ACTION)) {
+            // No API call available to check if a broadcast receiver is running: https://stackoverflow.com/questions/2682043/how-to-check-if-receiver-is-registered-in-android/3568906#3568906
+            try {
+                Log.e(TAG, "stop cbr");
+                unregisterReceiver(cbr);
+            } catch (IllegalArgumentException ignored) {}
+            Log.i(TAG, "Received Stop Foreground Intent");
+            stopForeground(true);
+            stopSelf();
+        }
+        return START_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        Log.i(TAG, "onDestroy()");
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        // Used only in case of bound services.
+        return null;
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -11,7 +11,6 @@ package org.openhab.habdroid.ui;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
-import android.app.Notification;
 import android.app.PendingIntent;
 import android.app.ProgressDialog;
 import android.content.ActivityNotFoundException;
@@ -47,7 +46,6 @@ import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Gravity;
-import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -75,7 +73,6 @@ import org.openhab.habdroid.core.notifications.GoogleCloudMessageConnector;
 import org.openhab.habdroid.core.notifications.NotificationSettings;
 import org.openhab.habdroid.model.OpenHABLinkedPage;
 import org.openhab.habdroid.model.OpenHABSitemap;
-import org.openhab.habdroid.model.thing.ThingType;
 import org.openhab.habdroid.ui.drawer.OpenHABDrawerAdapter;
 import org.openhab.habdroid.ui.drawer.OpenHABDrawerItem;
 import org.openhab.habdroid.util.Constants;
@@ -110,6 +107,8 @@ import de.duenndns.ssl.MemorizingResponder;
 import de.duenndns.ssl.MemorizingTrustManager;
 import okhttp3.Call;
 import okhttp3.Headers;
+
+import static org.openhab.habdroid.core.CustomBroadcastReceiver.CUSTOM_BROADCAST_RECEIVER_INTENT;
 
 public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSelectedListener,
         OpenHABTrackerReceiver, MemorizingResponder {
@@ -342,7 +341,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
             } else if (intent.getAction().equals("android.intent.action.VIEW")) {
                 Log.d(TAG, "This is URL Action");
                 mNfcData = intent.getDataString();
-            } else if (intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED)) {
+            } else if (intent.getAction().equals(CUSTOM_BROADCAST_RECEIVER_INTENT)) {
                 Log.d(TAG, "Boot broadcast");
                 setupCustomBroadcastReceiver();
             }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -62,8 +62,8 @@ import com.loopj.android.image.WebImageCache;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.openhab.habdroid.R;
+import org.openhab.habdroid.core.CustomBroadcastListenerService;
 import org.openhab.habdroid.core.GcmIntentService;
-import org.openhab.habdroid.core.ForegroundService;
 import org.openhab.habdroid.core.NetworkConnectivityInfo;
 import org.openhab.habdroid.core.NotificationDeletedBroadcastReceiver;
 import org.openhab.habdroid.core.OpenHABTracker;
@@ -352,13 +352,12 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         // Custom broadcast receiver
         if (mSettings.getBoolean(Constants.PREFERENCE_CUSTOM_BROADCAST, false)) {
             Log.d(TAG, "start cbr");
-            Intent startIntent = new Intent(this, ForegroundService.class);
+            Intent startIntent = new Intent(this, CustomBroadcastListenerService.class);
             startIntent.setAction(Constants.ACTION.STARTFOREGROUND_ACTION);
-            startIntent.putExtra("broadcast", mSettings.getString(Constants.PREFERENCE_CUSTOM_BROADCAST_BROADCAST, ""));
             startService(startIntent);
         } else {
             Log.d(TAG, "stop cbr");
-            Intent stopIntent = new Intent(this, ForegroundService.class);
+            Intent stopIntent = new Intent(this, CustomBroadcastListenerService.class);
             stopIntent.setAction(Constants.ACTION.STOPFOREGROUND_ACTION);
             startService(stopIntent);
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -62,7 +62,9 @@ import com.loopj.android.image.WebImageCache;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.openhab.habdroid.R;
+import org.openhab.habdroid.core.BootCompletedReceiver;
 import org.openhab.habdroid.core.CustomBroadcastListenerService;
+import org.openhab.habdroid.core.CustomBroadcastReceiver;
 import org.openhab.habdroid.core.GcmIntentService;
 import org.openhab.habdroid.core.NetworkConnectivityInfo;
 import org.openhab.habdroid.core.NotificationDeletedBroadcastReceiver;
@@ -107,8 +109,6 @@ import de.duenndns.ssl.MemorizingResponder;
 import de.duenndns.ssl.MemorizingTrustManager;
 import okhttp3.Call;
 import okhttp3.Headers;
-
-import static org.openhab.habdroid.core.CustomBroadcastReceiver.CUSTOM_BROADCAST_RECEIVER_INTENT;
 
 public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSelectedListener,
         OpenHABTrackerReceiver, MemorizingResponder {
@@ -323,7 +323,9 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
             sharedPrefs.edit().putBoolean("firstStart", false).apply();
         }
 
-        setupCustomBroadcastReceiver();
+        final Intent i = new Intent(OpenHABMainActivity.this, BootCompletedReceiver.class);
+        i.setAction(CustomBroadcastReceiver.CUSTOM_BROADCAST_RECEIVER_INTENT);
+        sendBroadcast(i);
     }
 
     private void processIntent(Intent intent) {
@@ -341,25 +343,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
             } else if (intent.getAction().equals("android.intent.action.VIEW")) {
                 Log.d(TAG, "This is URL Action");
                 mNfcData = intent.getDataString();
-            } else if (intent.getAction().equals(CUSTOM_BROADCAST_RECEIVER_INTENT)) {
-                Log.d(TAG, "Boot broadcast");
-                setupCustomBroadcastReceiver();
             }
-        }
-    }
-
-    private void setupCustomBroadcastReceiver() {
-        // Custom broadcast receiver
-        if (mSettings.getBoolean(Constants.PREFERENCE_CUSTOM_BROADCAST, false)) {
-            Log.d(TAG, "start cbr");
-            Intent startIntent = new Intent(this, CustomBroadcastListenerService.class);
-            startIntent.setAction(Constants.ACTION.STARTFOREGROUND_ACTION);
-            startService(startIntent);
-        } else {
-            Log.d(TAG, "stop cbr");
-            Intent stopIntent = new Intent(this, CustomBroadcastListenerService.class);
-            stopIntent.setAction(Constants.ACTION.STOPFOREGROUND_ACTION);
-            startService(stopIntent);
         }
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -11,6 +11,7 @@ package org.openhab.habdroid.ui;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
+import android.app.Notification;
 import android.app.PendingIntent;
 import android.app.ProgressDialog;
 import android.content.ActivityNotFoundException;
@@ -64,6 +65,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.openhab.habdroid.R;
 import org.openhab.habdroid.core.GcmIntentService;
+import org.openhab.habdroid.core.ForegroundService;
 import org.openhab.habdroid.core.NetworkConnectivityInfo;
 import org.openhab.habdroid.core.NotificationDeletedBroadcastReceiver;
 import org.openhab.habdroid.core.OpenHABTracker;
@@ -166,9 +168,9 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
 
     // Loopj
 //    private static MyAsyncHttpClient mAsyncHttpClient;
-    private static MyAsyncHttpClient mAsyncHttpClient;
+    public static MyAsyncHttpClient mAsyncHttpClient;
     // Base URL of current openHAB connection
-    private String openHABBaseUrl = "http://demo.openhab.org:8080/";
+    public static String openHABBaseUrl = "http://demo.openhab.org:8080/";
     // openHAB username
     private String openHABUsername = "";
     // openHAB password
@@ -321,6 +323,8 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
 
             sharedPrefs.edit().putBoolean("firstStart", false).apply();
         }
+
+        setupCustomBroadcastReceiver();
     }
 
     private void processIntent(Intent intent) {
@@ -338,7 +342,26 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
             } else if (intent.getAction().equals("android.intent.action.VIEW")) {
                 Log.d(TAG, "This is URL Action");
                 mNfcData = intent.getDataString();
+            } else if (intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED)) {
+                Log.d(TAG, "Boot broadcast");
+                setupCustomBroadcastReceiver();
             }
+        }
+    }
+
+    private void setupCustomBroadcastReceiver() {
+        // Custom broadcast receiver
+        if (mSettings.getBoolean(Constants.PREFERENCE_CUSTOM_BROADCAST, false)) {
+            Log.d(TAG, "start cbr");
+            Intent startIntent = new Intent(this, ForegroundService.class);
+            startIntent.setAction(Constants.ACTION.STARTFOREGROUND_ACTION);
+            startIntent.putExtra("broadcast", mSettings.getString(Constants.PREFERENCE_CUSTOM_BROADCAST_BROADCAST, ""));
+            startService(startIntent);
+        } else {
+            Log.d(TAG, "stop cbr");
+            Intent stopIntent = new Intent(this, ForegroundService.class);
+            stopIntent.setAction(Constants.ACTION.STOPFOREGROUND_ACTION);
+            startService(stopIntent);
         }
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
@@ -46,7 +46,6 @@ public class Constants {
     public static final String PREFERENCE_CUSTOM_BROADCAST_ITEM = "default_openhab_custom_broadcast_item";
 
     public interface ACTION {
-        public static String MAIN_ACTION = "org.openhab.habdroid.action.main";
         public static String STARTFOREGROUND_ACTION = "org.openhab.habdroid.action.startforeground";
         public static String STOPFOREGROUND_ACTION = "org.openhab.habdroid.action.stopforeground";
     }

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
@@ -40,4 +40,18 @@ public class Constants {
             public static final int ALWAYS = 5;
         }
     }
+    public static final String PREFERENCE_CUSTOM_BROADCAST    = "default_openhab_custom_broadcast_enabled";
+    public static final String PREFERENCE_CUSTOM_BROADCAST_BROADCAST = "default_openhab_custom_broadcast";
+    public static final String PREFERENCE_CUSTOM_BROADCAST_EXTRA = "default_openhab_custom_broadcast_extra";
+    public static final String PREFERENCE_CUSTOM_BROADCAST_ITEM = "default_openhab_custom_broadcast_item";
+
+    public interface ACTION {
+        public static String MAIN_ACTION = "org.openhab.habdroid.action.main";
+        public static String STARTFOREGROUND_ACTION = "org.openhab.habdroid.action.startforeground";
+        public static String STOPFOREGROUND_ACTION = "org.openhab.habdroid.action.stopforeground";
+    }
+
+    public interface NOTIFICATION_ID {
+        public static int FOREGROUND_SERVICE = 101;
+    }
 }

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -151,4 +151,19 @@
     <string name="intro_whatis">A vendor and technology agnostic open source automation software for your home</string>
     <string name="intro_themes">Themes</string>
     <string name="intro_themes_description">Choose between several themes</string>
+    <string name="settings_custom_broadcast_enabled_title">Receive custom broadcast</string>
+    <string name="settings_custom_broadcast_enabled_summary">Can be used to receive Android broadcasts, e. g. from Gadgetbridge or Tasker</string>
+    <string name="settings_custom_broadcast_broadcast" translatable="false">nodomain.freeyourgadget.gadgetbridge.mibandButtonPressed</string>
+    <string name="settings_custom_broadcast_title">Broadcast to receive</string>
+    <string name="settings_custom_broadcast_item_title">Item to change</string>
+    <string name="settings_custom_broadcast_item_summary">Item state will be set to number of button presses</string>
+    <string name="settings_custom_broadcast">Custom broadcast receiver</string>
+    <string name="error_custom_broadcast_item_not_found">Item for custom broadcasts is incorrect</string>
+    <string name="settings_custom_broadcast_listening">Listening for broadcasts</string>
+    <string name="notification_last_broadcast_success" formatted="false">Last broadcast at %s with value "%s" was successful</string>
+    <string name="notification_last_broadcast_failed" formatted="false">Last broadcast at %s with value "%s" failed</string>
+    <string name="notification_last_broadcast_none">No broadcast received since start</string>
+    <string name="settings_custom_broadcast_extra" translatable="false">button_id</string>
+    <string name="settings_custom_broadcast_extra_title">Intent extra</string>
+    <string name="error_custom_broadcast_extra_not_found">Received intent without configured extra</string>
 </resources>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -83,6 +83,29 @@
             android:summary="@string/settings_openhab_fullscreen_summary"
             android:title="@string/settings_openhab_fullscreen" />
     </PreferenceCategory>
+    <PreferenceCategory android:title="@string/settings_custom_broadcast">
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="default_openhab_custom_broadcast_enabled"
+            android:summary="@string/settings_custom_broadcast_enabled_summary"
+            android:title="@string/settings_custom_broadcast_enabled_title" />
+        <EditTextPreference
+            android:defaultValue="@string/settings_custom_broadcast_broadcast"
+            android:key="default_openhab_custom_broadcast"
+            android:dependency="default_openhab_custom_broadcast_enabled"
+            android:title="@string/settings_custom_broadcast_title" />
+        <EditTextPreference
+            android:defaultValue="@string/settings_custom_broadcast_extra"
+            android:key="default_openhab_custom_broadcast_extra"
+            android:dependency="default_openhab_custom_broadcast_enabled"
+            android:title="@string/settings_custom_broadcast_extra_title" />
+        <EditTextPreference
+            android:defaultValue="@string/empty_string"
+            android:key="default_openhab_custom_broadcast_item"
+            android:dependency="default_openhab_custom_broadcast_enabled"
+            android:summary="@string/settings_custom_broadcast_item_summary"
+            android:title="@string/settings_custom_broadcast_item_title" />
+    </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_misc_title">
         <RingtonePreference
             android:key="default_openhab_alertringtone"


### PR DESCRIPTION
This PR gives the user the ability to set up a custom broadcast
receiver that changes an item on receive.

This was designed to send Mi Band 2 button presses to the openHAB
server. This will only work if an app is installed, that send broadcasts
on button presses. Since Gadgetbridge does so, it is the default
broadcast.

I had to create a foreground service, that starts the receiver.
Otherwise it would be killed by the os. Foreground services have to show
a notification, but it shown as low priority, so it shouldnt disturb the
user.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>

Reopen #388 
Related #257 

@kubawolanin I dont have tasker, so can you try if it is possible to send android broadcasts? If so, you can change one item.
[mobile-foss-debug.zip](https://github.com/openhab/openhab.android/files/1507074/mobile-foss-debug.zip)

Todo:
- [ ] Test if it works with tasker
- [ ] Start after boot
- [ ] Add better scalled icon for notification
- [ ] Add dropdown to select item
- [x] Change strings to let it sound more generall and less mi band