### PR TITLE
Add codecov and run android tests via travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,15 @@ android:
 install:
 - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2"
 - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2"
-- "./gradlew --version"
+- ./gradlew --version
 - sdkmanager --list || true
 script:
-- "./gradlew clean build"
-- "./gradlew test"
+- ./gradlew clean assemble
+- ./gradlew test
+- echo "--" > .adjust_token
+- ./gradlew jacocoTestReport
+after_success:
+- bash <(curl -s https://codecov.io/bash)
 before_deploy:
 - openssl aes-256-cbc -K $encrypted_903a93ed2309_key -iv $encrypted_903a93ed2309_iv
   -in keystore.enc -out keystore -d
@@ -35,7 +39,7 @@ before_deploy:
 - jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore $HOME/keystore
   -storepass $storepass mobile-full-release-unsigned.apk sign
 - jarsigner -verify mobile-full-release-unsigned.apk
-- "${ANDROID_HOME}/build-tools/25.0.2/zipalign -v 4 mobile-full-release-unsigned.apk mobile-full-release.apk"
+- ${ANDROID_HOME}/build-tools/25.0.2/zipalign -v 4 mobile-full-release-unsigned.apk mobile-full-release.apk
 deploy:
   provider: releases
   prerelease: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 
 # Emulator Management: Create, Start and Wait
 before_script:
-- echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+- echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a -d pixel_xl
 - emulator -avd test -no-audio -no-window &
 - android-wait-for-emulator
 - adb shell input keyevent 82 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,9 @@ before_script:
 - emulator -avd test -no-audio -no-window &
 - android-wait-for-emulator
 - adb shell input keyevent 82 &
+- android list target
 
 script:
-- android list target
 - ./gradlew build connectedCheck test jacocoTestReport
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,34 +3,49 @@ jdk: oraclejdk8
 env:
   global:
   - secure: fMBUkSsCBTw/U907w7Xm/yNzw4lq9yt7zFy0JyEZrA543LI7zQRIclIOtsDTUs0bwY+4KI08MNoYPLJ4TQhSJaH4wQ8b9C5TRsqXNfc0V718TcuYqSXqU6VPRVtX46/fCEWv/HAs0ksUKrHIlpWOwLPQpYDcKxwwlUndaakYKJ8=
+
 before_cache:
 - cd ${TRAVIS_BUILD_DIR}/gradle/caches/
 - find . -name "*.lock" -exec rm -rfv {} \;
 - cd ${TRAVIS_BUILD_DIR}
+
 cache:
   directories:
   - "${TRAVIS_BUILD_DIR}/gradle/caches/"
   - "${TRAVIS_BUILD_DIR}/gradle/wrapper/dists/"
+  
 notifications:
   email: false
+
 android:
   components:
   - tools
   - build-tools-25.0.2
   - platform-tools
   - tools
+  - android-22
+  - sys-img-armeabi-v7a-android-22
+  
 install:
 - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2"
 - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2"
 - ./gradlew --version
 - sdkmanager --list || true
+
+# Emulator Management: Create, Start and Wait
+before_script:
+- echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+- emulator -avd test -no-audio -no-window &
+- android-wait-for-emulator
+- adb shell input keyevent 82 &
+
 script:
-- ./gradlew clean assemble
-- ./gradlew test
-- echo "--" > .adjust_token
-- ./gradlew jacocoTestReport
+- android list target
+- ./gradlew build connectedCheck test jacocoTestReport
+
 after_success:
 - bash <(curl -s https://codecov.io/bash)
+
 before_deploy:
 - openssl aes-256-cbc -K $encrypted_903a93ed2309_key -iv $encrypted_903a93ed2309_iv
   -in keystore.enc -out keystore -d
@@ -40,6 +55,7 @@ before_deploy:
   -storepass $storepass mobile-full-release-unsigned.apk sign
 - jarsigner -verify mobile-full-release-unsigned.apk
 - ${ANDROID_HOME}/build-tools/25.0.2/zipalign -v 4 mobile-full-release-unsigned.apk mobile-full-release.apk
+
 deploy:
   provider: releases
   prerelease: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
 # Emulator Management: Create, Start and Wait
 before_script:
 - android list device
-- echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a -d pixel_xl
+- echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a -d "5.4in FWVGA"
 - emulator -avd test -no-audio -no-window &
 - android-wait-for-emulator
 - adb shell input keyevent 82 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
 
 # Emulator Management: Create, Start and Wait
 before_script:
+- android list device
 - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a -d pixel_xl
 - emulator -avd test -no-audio -no-window &
 - android-wait-for-emulator

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.0.0'
         classpath 'com.google.gms:google-services:3.1.0'
         classpath 'io.fabric.tools:gradle:1.24.4'
+        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
+apply plugin: 'jacoco-android'
 
 android {
     buildToolsVersion '26.0.2'
@@ -28,6 +29,7 @@ android {
             buildConfigField 'boolean', IS_DEVELOPER, 'true'
             buildConfigField "java.util.Date", "buildTime", "new java.util.Date(" + System.currentTimeMillis() + "L)"
             pseudoLocalesEnabled true
+            testCoverageEnabled true
         }
     }
     productFlavors {


### PR DESCRIPTION
See this PR for an example: https://github.com/mueller-ma-bot/openhab.android/pull/1
I also tested Sputnik there, but this is not included in this PR.

@digitaldan This is just the config for codecov. To add it, go to their website and login via github.

Hopefully this will help to increase the code coverage. Current is ~6%