### PR TITLE
Extend dialogs in debug mode

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -105,6 +105,11 @@ import de.duenndns.ssl.MemorizingTrustManager;
 import okhttp3.Call;
 import okhttp3.Headers;
 
+import static org.openhab.habdroid.util.Constants.MESSAGES.DIALOG;
+import static org.openhab.habdroid.util.Constants.MESSAGES.LOGLEVEL.ALWAYS;
+import static org.openhab.habdroid.util.Constants.MESSAGES.LOGLEVEL.DEBUG;
+import static org.openhab.habdroid.util.Constants.MESSAGES.LOGLEVEL.NO_DEBUG;
+
 public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSelectedListener,
         OpenHABTrackerReceiver, MemorizingResponder {
 
@@ -115,36 +120,41 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
             setProgressIndicatorVisible(false);
             Log.e(TAG, "Error: " + error.toString());
             Log.e(TAG, "HTTP status code: " + statusCode);
+            String message;
             if (statusCode >= 400){
                 int resourceID;
                 try {
                     resourceID = getResources().getIdentifier("error_http_code_" + statusCode, "string", getPackageName());
-                    showMessageToUser(getString(resourceID), Constants.MESSAGES.DIALOG, Constants.MESSAGES.LOGLEVEL.ALWAYS);
+                    message = getString(resourceID);
                 } catch (android.content.res.Resources.NotFoundException e) {
-                    showMessageToUser(String.format(getString(R.string.error_http_connection_failed), statusCode), Constants.MESSAGES.DIALOG, Constants.MESSAGES.LOGLEVEL.ALWAYS);
+                    message = String.format(getString(R.string.error_http_connection_failed), statusCode);
                 }
             } else if (error instanceof UnknownHostException) {
                 Log.e(TAG, "Unable to resolve hostname");
-                showMessageToUser(getString(R.string.error_unable_to_resolve_hostname), Constants.MESSAGES.DIALOG, Constants.MESSAGES.LOGLEVEL.ALWAYS);
+                message = getString(R.string.error_unable_to_resolve_hostname);
             } else if (error instanceof SSLHandshakeException) {
                 // if ssl exception, check for some common problems
                 if (error.getCause() instanceof CertPathValidatorException) {
-                    showMessageToUser(getString(R.string.error_certificate_not_trusted), Constants.MESSAGES.DIALOG, Constants.MESSAGES.LOGLEVEL.ALWAYS);
+                    message = getString(R.string.error_certificate_not_trusted);
                 } else if (error.getCause() instanceof CertificateExpiredException) {
-                    showMessageToUser(getString(R.string.error_certificate_expired), Constants.MESSAGES.DIALOG, Constants.MESSAGES.LOGLEVEL.ALWAYS);
+                    message = getString(R.string.error_certificate_expired);
                 } else if (error.getCause() instanceof CertificateNotYetValidException) {
-                    showMessageToUser(getString(R.string.error_certificate_not_valid_yet), Constants.MESSAGES.DIALOG, Constants.MESSAGES.LOGLEVEL.ALWAYS);
+                    message = getString(R.string.error_certificate_not_valid_yet);
                 } else if (error.getCause() instanceof CertificateRevokedException) {
-                    showMessageToUser(getString(R.string.error_certificate_revoked), Constants.MESSAGES.DIALOG, Constants.MESSAGES.LOGLEVEL.ALWAYS);
+                    message = getString(R.string.error_certificate_revoked);
                 } else {
-                    showMessageToUser(getString(R.string.error_connection_sslhandshake_failed), Constants.MESSAGES.DIALOG, Constants.MESSAGES.LOGLEVEL.ALWAYS);
+                    message = getString(R.string.error_connection_sslhandshake_failed);
                 }
             } else if (error instanceof ConnectException) {
-                showMessageToUser(getString(R.string.error_connection_failed), Constants.MESSAGES.DIALOG, Constants.MESSAGES.LOGLEVEL.ALWAYS);
+                message = getString(R.string.error_connection_failed);
             } else {
                 Log.e(TAG, error.getClass().toString());
-                showMessageToUser(error.getMessage(), Constants.MESSAGES.DIALOG, Constants.MESSAGES.LOGLEVEL.ALWAYS);
+                message = error.getMessage();
             }
+            showMessageToUser(message, DIALOG, NO_DEBUG);
+            message += "\nURL: " + openHABBaseUrl + "\nUsername: " + openHABUsername + "\nPassword: " + openHABPassword;
+            message += "\nStacktrace:\n" + Log.getStackTraceString(error);
+            showMessageToUser(message,DIALOG, DEBUG);
         }
     }
 
@@ -597,7 +607,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
     }
 
     public void onError(String error) {
-        showMessageToUser(error, Constants.MESSAGES.DIALOG, Constants.MESSAGES.LOGLEVEL.ALWAYS);
+        showMessageToUser(error, DIALOG, ALWAYS);
     }
 
     /**
@@ -1074,7 +1084,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
     private void showAlertDialog(String alertMessage) {
         if (this.isFinishing())
             return;
-       showMessageToUser(alertMessage, Constants.MESSAGES.DIALOG, Constants.MESSAGES.LOGLEVEL.ALWAYS);
+       showMessageToUser(alertMessage, DIALOG, ALWAYS);
     }
 
     private void showCertificateDialog(final int decisionId, String certMessage) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -629,10 +629,9 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         String localUrl = mSettings.getString(Constants.PREFERENCE_URL, "");
 
         // if debug mode is enabled, show all messages, except those with logLevel 4
-        if(debugEnabled) {
-            if (logLevel == Constants.MESSAGES.LOGLEVEL.NO_DEBUG) {
-                return;
-            }
+        if((debugEnabled && logLevel == Constants.MESSAGES.LOGLEVEL.NO_DEBUG) ||
+                (!debugEnabled && logLevel == Constants.MESSAGES.LOGLEVEL.DEBUG)) {
+            return;
         } else {
             switch (logLevel) {
                 case Constants.MESSAGES.LOGLEVEL.REMOTE:

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -154,7 +154,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
             showMessageToUser(message, DIALOG, NO_DEBUG);
             message += "\nURL: " + openHABBaseUrl + "\nUsername: " + openHABUsername + "\nPassword: " + openHABPassword;
             message += "\nStacktrace:\n" + Log.getStackTraceString(error);
-            showMessageToUser(message,DIALOG, DEBUG);
+            showMessageToUser(message, DIALOG, DEBUG);
         }
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -632,25 +632,24 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         if((debugEnabled && logLevel == Constants.MESSAGES.LOGLEVEL.NO_DEBUG) ||
                 (!debugEnabled && logLevel == Constants.MESSAGES.LOGLEVEL.DEBUG)) {
             return;
-        } else {
-            switch (logLevel) {
-                case Constants.MESSAGES.LOGLEVEL.REMOTE:
-                    if (remoteUrl.length() > 1) {
-                        Log.d(TAG, "Remote URL set, show message: " + message);
-                    } else {
-                        Log.d(TAG, "No remote URL set, don't show message: " + message);
-                        return;
-                    }
-                    break;
-                case Constants.MESSAGES.LOGLEVEL.LOCAL:
-                    if (localUrl.length() > 1) {
-                        Log.d(TAG, "Local URL set, show message: " + message);
-                    } else {
-                        Log.d(TAG, "No local URL set, don't show message: " + message);
-                        return;
-                    }
-                    break;
-            }
+        }
+        switch (logLevel) {
+            case Constants.MESSAGES.LOGLEVEL.REMOTE:
+                if (remoteUrl.length() > 1) {
+                    Log.d(TAG, "Remote URL set, show message: " + message);
+                } else {
+                    Log.d(TAG, "No remote URL set, don't show message: " + message);
+                    return;
+                }
+                break;
+            case Constants.MESSAGES.LOGLEVEL.LOCAL:
+                if (localUrl.length() > 1) {
+                    Log.d(TAG, "Local URL set, show message: " + message);
+                } else {
+                    Log.d(TAG, "No local URL set, don't show message: " + message);
+                    return;
+                }
+                break;
         }
 
         switch (messageType) {

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -122,7 +122,6 @@
     <string name="error_http_code_511">Netzwerkauthentifizierung wird gefordert (HTTP-Statuscode 511)</string>
     <string name="error_network_type_unsupported">Netzwerktyp (%s) wird nicht unterstützt</string>
     <string name="unknown">Unbekannt</string>
-    <string name="settings_debug_messages_summary">Einige Meldungen enthalten mehr Informationen</string>
     <string name="settings_debug_messages_title">Debug-Meldungen anzeigen</string>
     <string name="error_couldnt_determine_openhab_url">Konnte openHAB-URL nicht ermitteln</string>
     <string name="error_unable_to_resolve_hostname">Fehler beim Auflösen des Hostnamens</string>

--- a/mobile/src/main/res/values-el/strings.xml
+++ b/mobile/src/main/res/values-el/strings.xml
@@ -118,7 +118,6 @@
     <string name="about_license_title">Άδεια</string>
     <string name="about_links">Σύνδεσμοι</string>
     <string name="about_links_list"><![CDATA[· <a href="https://github.com/openhab/openhab.android">Πηγαίος κώδικας εφαρμογής openHAB</a><br><br> · <a href="https://github.com/openhab/openhab.android/issues">Αναφορά Προβλήματος</a><br><br> · <a href="http://docs.openhab.org/">Έγγραφα τεκμηρίωσης του openHAB</a><br><br> · <a href="https://community.openhab.org/">Τόπος συζητήσεως κοινότητας</a>]]></string>
-    <string name="settings_debug_messages_summary">Μερικά μηνύματα λάθους περιέχουν περισσότερες πληροφορίες</string>
     <string name="settings_debug_messages_title">Προβολή μηνυμάτων αποσφαλμάτωσης</string>
     <string name="error_couldnt_determine_openhab_url">Αδυναμία προσδιορισμού του openHAB URL</string>
     <string name="unknown">Άγνωστο</string>

--- a/mobile/src/main/res/values-es/strings.xml
+++ b/mobile/src/main/res/values-es/strings.xml
@@ -104,7 +104,6 @@
     <string name="about_license_title">Licencia</string>
     <string name="about_links">Enlaces</string>
     <string name="about_links_list"><![CDATA[\u00B7 <a href="https://github.com/openhab/openhab.android">Código fuente de openHAB App</a><br><br> \u00B7 <a href="https://github.com/openhab/openhab.android/issues">Informar de un error</a><br><br> \u00B7 <a href="http://docs.openhab.org/">Documentación de openHAB</a><br><br> \u00B7 <a href="https://community.openhab.org/">Foro de la Comunidad</a>]]></string>
-    <string name="settings_debug_messages_summary">Algunos mensajes de error incluyen más información</string>
     <string name="settings_debug_messages_title">Mostrar mensajes de depuración</string>
     <string name="error_couldnt_determine_openhab_url">No se pudo determinar la URL de openHAB</string>
     <string name="unknown">Desconocido</string>

--- a/mobile/src/main/res/values-fr/strings.xml
+++ b/mobile/src/main/res/values-fr/strings.xml
@@ -100,7 +100,6 @@
     <string name="about_license_title">Licence</string>
     <string name="about_links">Liens</string>
     <string name="about_links_list"><![CDATA[\u00B7 <a href="https://github.com/openhab/openhab.android">Code source app openHAB</a><br><br> \u00B7 <a href="https://github.com/openhab/openhab.android/issues">Remonter un problème</a><br><br> \u00B7 <a href="http://docs.openhab.org/">Documentation openHAB</a><br><br> \u00B7 <a href="https://community.openhab.org/">Forum de discussion</a>]]></string>
-    <string name="settings_debug_messages_summary">Plus d\'information dans les messages d\'erreur</string>
     <string name="settings_debug_messages_title">Afficher des messages de debug</string>
     <string name="error_couldnt_determine_openhab_url">Impossible de détermine l\'URL openHAB</string>
     <string name="unknown">Inconnu</string>

--- a/mobile/src/main/res/values-lt/strings.xml
+++ b/mobile/src/main/res/values-lt/strings.xml
@@ -104,7 +104,6 @@
     <string name="info_demo_mode_short">Veikia demo režimu</string>
     <string name="intro_themes">Temos</string>
     <string name="mainmenu_openhab_voice_recognition">Balso atpažinimas</string>
-    <string name="settings_debug_messages_summary">Kai kurie klaidų pranešimai savyje turi daugiau informacijos</string>
     <string name="settings_debug_messages_title">Rodyti derinimo žinutes</string>
     <string name="settings_openhab_sslclientcert_howto_summary">Paspauskite čia, kad gautumėte informacijos, kaip nustatyti SSL autentifikaciją</string>
     <string name="intro_whatis">Nepriklausomas nuo gamintojų atviro kodo išmanių namų sprendimas</string>

--- a/mobile/src/main/res/values-ru/strings.xml
+++ b/mobile/src/main/res/values-ru/strings.xml
@@ -102,7 +102,6 @@
     <string name="about_license_title">Лицензия</string>
     <string name="about_links">Ссылки</string>
     <string name="about_links_list"><![CDATA[\u00B7 <a href="https://github.com/openhab/openhab.android">Иходный код приложения openHAB</a><br><br> \u00B7 <a href="https://github.com/openhab/openhab.android/issues">Сообщить о проблеме</a><br><br> \u00B7 <a href="http://docs.openhab.org/">Документация openHAB</a><br><br> \u00B7 <a href="https://community.openhab.org/">Сообщество openHAB</a>]]></string>
-    <string name="settings_debug_messages_summary">Некоторые сообщения об ошибках включают больше информации</string>
     <string name="settings_debug_messages_title">Показать debug сообщения</string>
     <string name="error_couldnt_determine_openhab_url">Не удалось определить адрес openHAB</string>
     <string name="unknown">Неизвестный</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -143,7 +143,7 @@
     <string name="about_links_list"><![CDATA[\u00B7 <a href="https://github.com/openhab/openhab.android">openHAB App source code</a><br><br> \u00B7 <a href="https://github.com/openhab/openhab.android/issues">Report a problem</a><br><br> \u00B7 <a href="http://docs.openhab.org/">openHAB Documentation</a><br><br> \u00B7 <a href="https://community.openhab.org/">Community Forum</a>]]></string>
     <string name="about_copyright" translatable="false">© 2012 - %s openHAB Foundation</string>
     <string name="about_version_string" translatable="false">%1$s - %2$s</string>
-    <string name="settings_debug_messages_summary">Some error messages include more information</string>
+    <string name="settings_debug_messages_summary">Passwords will be shown in clear text!</string>
     <string name="settings_debug_messages_title">Show debug messages</string>
     <string name="error_couldnt_determine_openhab_url">Couldn\'t determine openHAB URL</string>
     <string name="unknown">Unknown</string>


### PR DESCRIPTION
In debug mode url, username, password and stacktrace will be shown, when connections errors occure.