### PR TITLE
Add AboutLibraries to the App

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -75,10 +75,17 @@ dependencies {
     compile 'com.github.BigBadaboom:androidsvg:418cf676849b200cacf3465478079f39709fe5b1'
     compile 'com.github.apl-devs:appintro:v4.2.2'
 
+    // This should already be included in the aboutlibraries dependency, however, it somehow isn't
+    compile "com.android.support:cardview-v7:26.1.0"
+    compile('com.mikepenz:aboutlibraries:6.0.1@aar') {
+        transitive = true
+    }
+
     //crash reporting
     compile('com.crashlytics.sdk.android:crashlytics:2.7.1@aar') {
         transitive = true
     }
+
     compile 'com.google.firebase:firebase-core:11.4.2'
 
     testCompile 'org.mockito:mockito-core:2.7.6'

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABAboutActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABAboutActivity.java
@@ -16,6 +16,8 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.mikepenz.aboutlibraries.LibsBuilder;
+
 import org.openhab.habdroid.R;
 import org.openhab.habdroid.core.OpenHABVoiceService;
 import org.openhab.habdroid.util.Util;
@@ -127,12 +129,14 @@ public class OpenHABAboutActivity extends AppCompatActivity {
                     infoFragment.setArguments(bundle);
 
                     return infoFragment;
+                case 2:
+                    return new LibsBuilder().supportFragment();
             }
         }
 
         @Override
         public int getCount() {
-            return 2;
+            return 3;
         }
 
         @Override
@@ -142,6 +146,8 @@ public class OpenHABAboutActivity extends AppCompatActivity {
                     return mContext.getString(R.string.about_title);
                 case 1:
                     return mContext.getString(R.string.title_activity_openhabinfo);
+                case 2:
+                    return mContext.getString(R.string.title_activity_libraries);
             }
         }
     }

--- a/mobile/src/main/res/layout/fragment_about.xml
+++ b/mobile/src/main/res/layout/fragment_about.xml
@@ -15,5 +15,6 @@
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/pager"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:padding="10dp"/>
 </LinearLayout>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="error_http_code_511">Network authentication is required (HTTP response code 511)</string>
     <string name="title_activity_openhabwritetag">Write NFC tag</string>
     <string name="title_activity_openhabinfo">openHAB Information</string>
+    <string name="title_activity_libraries">Used Libraries</string>
     <string name="info_write_tag">Touch the tag and keep it close until the confirmation message appear</string>
     <string name="info_write_tag_progress">Writing the tag</string>
     <string name="info_write_tag_finished">Successfully finished</string>

--- a/mobile/src/main/res/values/themes.xml
+++ b/mobile/src/main/res/values/themes.xml
@@ -38,6 +38,17 @@
         <item name="themedDrawerBackground">?android:colorBackground</item>
         <item name="themedHeaderTextColor">@color/colorAccent_themeDark</item>
 
+        <item name="about_libraries_window_background">
+            @color/about_libraries_window_background_dark
+        </item>
+        <item name="about_libraries_card">@color/about_libraries_card_dark</item>
+        <item name="about_libraries_title_openSource">
+            @color/about_libraries_title_openSource_dark
+        </item>
+        <item name="about_libraries_text_openSource">
+            @color/about_libraries_text_openSource_dark
+        </item>
+
         <item name="chartTheme">dark</item>
     </style>
 
@@ -58,6 +69,17 @@
 
         <item name="themedDrawerBackground">@color/black</item>
         <item name="themedHeaderTextColor">@color/colorAccent_themeDark</item>
+
+        <item name="about_libraries_window_background">
+            @color/about_libraries_window_background_dark
+        </item>
+        <item name="about_libraries_card">@color/about_libraries_card_dark</item>
+        <item name="about_libraries_title_openSource">
+            @color/about_libraries_title_openSource_dark
+        </item>
+        <item name="about_libraries_text_openSource">
+            @color/about_libraries_text_openSource_dark
+        </item>
 
         <item name="chartTheme">black</item>
     </style>
@@ -98,6 +120,17 @@
 
         <item name="themedDrawerBackground">?android:colorBackground</item>
         <item name="themedHeaderTextColor">@color/colorAccent_themeDark</item>
+
+        <item name="about_libraries_window_background">
+            @color/about_libraries_window_background_dark
+        </item>
+        <item name="about_libraries_card">@color/about_libraries_card_dark</item>
+        <item name="about_libraries_title_openSource">
+            @color/about_libraries_title_openSource_dark
+        </item>
+        <item name="about_libraries_text_openSource">
+            @color/about_libraries_text_openSource_dark
+        </item>
 
         <item name="chartTheme">dark</item>
     </style>


### PR DESCRIPTION
This dependency allows us to easily show information about libraries used
in the app, including the name, the description and a link to the info
page (source code, or any other website).