### PR TITLE
Make instrumentation tests more independant from each other

### DIFF
--- a/mobile/src/androidTest/java/org/openhab/habdroid/TestUtils.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/TestUtils.java
@@ -1,0 +1,30 @@
+package org.openhab.habdroid;
+
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+public final class TestUtils {
+    public static Matcher<View> childAtPosition(
+            final Matcher<View> parentMatcher, final int position) {
+
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Child at position " + position + " in parent ");
+                parentMatcher.describeTo(description);
+            }
+
+            @Override
+            public boolean matchesSafely(View view) {
+                ViewParent parent = view.getParent();
+                return parent instanceof ViewGroup && parentMatcher.matches(parent)
+                        && view.equals(((ViewGroup) parent).getChildAt(position));
+            }
+        };
+    }
+}

--- a/mobile/src/androidTest/java/org/openhab/habdroid/ui/BasicWidgetTest.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/ui/BasicWidgetTest.java
@@ -1,7 +1,9 @@
 package org.openhab.habdroid.ui;
 
 
+import android.preference.PreferenceManager;
 import android.support.constraint.ConstraintLayout;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.DataInteraction;
 import android.support.test.espresso.IdlingResource;
 import android.support.test.espresso.ViewInteraction;
@@ -18,11 +20,13 @@ import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openhab.habdroid.OpenHABProgressbarIdlingResource;
 import org.openhab.habdroid.R;
+import org.openhab.habdroid.util.Constants;
 
 import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
@@ -45,48 +49,25 @@ import static org.hamcrest.Matchers.is;
 public class BasicWidgetTest {
 
     @Rule
-    public ActivityTestRule<OpenHABMainActivity> mActivityTestRule = new ActivityTestRule<>(OpenHABMainActivity.class);
+    public ActivityTestRule<OpenHABMainActivity> mActivityTestRule = new ActivityTestRule<>
+            (OpenHABMainActivity.class, true, false);
 
     private IdlingResource mProgressbarIdlingResource;
 
+    @Before
+    public void setup() {
+        PreferenceManager
+                .getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
+                .edit()
+                .putString(Constants.PREFERENCE_SITEMAP, "")
+                .putBoolean(Constants.PREFERENCE_FIRST_START, false)
+                .commit();
+
+        mActivityTestRule.launchActivity(null);
+    }
+
     @Test
     public void openHABMainActivityTest2() throws InterruptedException {
-        // click next
-        ViewInteraction appCompatImageButton = onView(
-                allOf(withId(R.id.next),
-                        childAtPosition(
-                                allOf(withId(R.id.bottomContainer),
-                                        childAtPosition(
-                                                withId(R.id.bottom),
-                                                1)),
-                                3),
-                        isDisplayed()));
-        appCompatImageButton.perform(click());
-
-        // click next
-        ViewInteraction appCompatImageButton2 = onView(
-                allOf(withId(R.id.next),
-                        childAtPosition(
-                                allOf(withId(R.id.bottomContainer),
-                                        childAtPosition(
-                                                withId(R.id.bottom),
-                                                1)),
-                                3),
-                        isDisplayed()));
-        appCompatImageButton2.perform(click());
-
-        // close intro
-        ViewInteraction appCompatButton = onView(
-                allOf(withId(R.id.done), withText("DONE"),
-                        childAtPosition(
-                                allOf(withId(R.id.bottomContainer),
-                                        childAtPosition(
-                                                withId(R.id.bottom),
-                                                1)),
-                                4),
-                        isDisplayed()));
-        appCompatButton.perform(click());
-
         View progressBar = mActivityTestRule.getActivity().findViewById(R.id.toolbar_progress_bar);
         mProgressbarIdlingResource = new OpenHABProgressbarIdlingResource("Progressbar " +
                 "IdleResource", progressBar);

--- a/mobile/src/androidTest/java/org/openhab/habdroid/ui/BasicWidgetTest.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/ui/BasicWidgetTest.java
@@ -11,13 +11,8 @@ import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.suitebuilder.annotation.LargeTest;
 import android.view.View;
-import android.view.ViewGroup;
-import android.view.ViewParent;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
-import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.After;
 import org.junit.Before;
@@ -43,6 +38,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.is;
+import static org.openhab.habdroid.TestUtils.childAtPosition;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
@@ -67,7 +63,7 @@ public class BasicWidgetTest {
     }
 
     @Test
-    public void openHABMainActivityTest2() throws InterruptedException {
+    public void openHABMainActivityTest() throws InterruptedException {
         View progressBar = mActivityTestRule.getActivity().findViewById(R.id.toolbar_progress_bar);
         mProgressbarIdlingResource = new OpenHABProgressbarIdlingResource("Progressbar " +
                 "IdleResource", progressBar);
@@ -276,24 +272,5 @@ public class BasicWidgetTest {
     public void unregisterIdlingResource() {
         if (mProgressbarIdlingResource != null)
             unregisterIdlingResources(mProgressbarIdlingResource);
-    }
-
-    private static Matcher<View> childAtPosition(
-            final Matcher<View> parentMatcher, final int position) {
-
-        return new TypeSafeMatcher<View>() {
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("Child at position " + position + " in parent ");
-                parentMatcher.describeTo(description);
-            }
-
-            @Override
-            public boolean matchesSafely(View view) {
-                ViewParent parent = view.getParent();
-                return parent instanceof ViewGroup && parentMatcher.matches(parent)
-                        && view.equals(((ViewGroup) parent).getChildAt(position));
-            }
-        };
     }
 }

--- a/mobile/src/androidTest/java/org/openhab/habdroid/ui/CheckIntroAndCancel.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/ui/CheckIntroAndCancel.java
@@ -1,6 +1,8 @@
 package org.openhab.habdroid.ui;
 
 
+import android.preference.PreferenceManager;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.ViewInteraction;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
@@ -14,15 +16,20 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.IsInstanceOf;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openhab.habdroid.R;
+import org.openhab.habdroid.util.Constants;
 
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.*;
-import static android.support.test.espresso.assertion.ViewAssertions.*;
-import static android.support.test.espresso.matcher.ViewMatchers.*;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withParent;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 
 @LargeTest
@@ -30,7 +37,19 @@ import static org.hamcrest.Matchers.allOf;
 public class CheckIntroAndCancel {
 
     @Rule
-    public ActivityTestRule<OpenHABMainActivity> mActivityTestRule = new ActivityTestRule<>(OpenHABMainActivity.class);
+    public ActivityTestRule<OpenHABMainActivity> mActivityTestRule = new ActivityTestRule<>
+            (OpenHABMainActivity.class, true, false);
+
+    @Before
+    public void setup() {
+        PreferenceManager
+                .getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
+                .edit()
+                .putBoolean(Constants.PREFERENCE_FIRST_START, true)
+                .commit();
+
+        mActivityTestRule.launchActivity(null);
+    }
 
     @Test
     public void appShowsIntro() {

--- a/mobile/src/androidTest/java/org/openhab/habdroid/ui/IntroActivityTest.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/ui/IntroActivityTest.java
@@ -3,27 +3,28 @@ package org.openhab.habdroid.ui;
 
 import android.preference.PreferenceManager;
 import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.IdlingResource;
 import android.support.test.espresso.ViewInteraction;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.suitebuilder.annotation.LargeTest;
 import android.view.View;
-import android.view.ViewGroup;
-import android.view.ViewParent;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
+import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
-import org.hamcrest.TypeSafeMatcher;
 import org.hamcrest.core.IsInstanceOf;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.openhab.habdroid.OpenHABProgressbarIdlingResource;
 import org.openhab.habdroid.R;
 import org.openhab.habdroid.util.Constants;
 
 import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.registerIdlingResources;
+import static android.support.test.espresso.Espresso.unregisterIdlingResources;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -31,20 +32,24 @@ import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withParent;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
+import static org.openhab.habdroid.TestUtils.childAtPosition;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
-public class CheckIntroAndCancel {
+public class IntroActivityTest {
 
     @Rule
     public ActivityTestRule<OpenHABMainActivity> mActivityTestRule = new ActivityTestRule<>
             (OpenHABMainActivity.class, true, false);
+
+    private IdlingResource mProgressbarIdlingResource;
 
     @Before
     public void setup() {
         PreferenceManager
                 .getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
                 .edit()
+                .putString(Constants.PREFERENCE_SITEMAP, "")
                 .putBoolean(Constants.PREFERENCE_FIRST_START, true)
                 .commit();
 
@@ -113,22 +118,65 @@ public class CheckIntroAndCancel {
         linearLayout.check(matches(isDisplayed()));
     }
 
-    private static Matcher<View> childAtPosition(
-            final Matcher<View> parentMatcher, final int position) {
+    @Test
+    public void goThroughInto() {
+        // click next
+        ViewInteraction appCompatImageButton = onView(
+                CoreMatchers.allOf(withId(R.id.next),
+                        childAtPosition(
+                                CoreMatchers.allOf(withId(R.id.bottomContainer),
+                                        childAtPosition(
+                                                withId(R.id.bottom),
+                                                1)),
+                                3),
+                        isDisplayed()));
+        appCompatImageButton.perform(click());
 
-        return new TypeSafeMatcher<View>() {
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("Child at position " + position + " in parent ");
-                parentMatcher.describeTo(description);
-            }
+        // click next
+        ViewInteraction appCompatImageButton2 = onView(
+                CoreMatchers.allOf(withId(R.id.next),
+                        childAtPosition(
+                                CoreMatchers.allOf(withId(R.id.bottomContainer),
+                                        childAtPosition(
+                                                withId(R.id.bottom),
+                                                1)),
+                                3),
+                        isDisplayed()));
+        appCompatImageButton2.perform(click());
 
-            @Override
-            public boolean matchesSafely(View view) {
-                ViewParent parent = view.getParent();
-                return parent instanceof ViewGroup && parentMatcher.matches(parent)
-                        && view.equals(((ViewGroup) parent).getChildAt(position));
-            }
-        };
+        // close intro
+        ViewInteraction appCompatButton = onView(
+                CoreMatchers.allOf(withId(R.id.done), withText("DONE"),
+                        childAtPosition(
+                                CoreMatchers.allOf(withId(R.id.bottomContainer),
+                                        childAtPosition(
+                                                withId(R.id.bottom),
+                                                1)),
+                                4),
+                        isDisplayed()));
+        appCompatButton.perform(click());
+
+        View progressBar = mActivityTestRule.getActivity().findViewById(R.id.toolbar_progress_bar);
+        mProgressbarIdlingResource = new OpenHABProgressbarIdlingResource("Progressbar " +
+                "IdleResource", progressBar);
+        registerIdlingResources(mProgressbarIdlingResource);
+
+        // do we have sitemap selection popup?
+        ViewInteraction linearLayout = onView(
+                Matchers.allOf(IsInstanceOf.<View>instanceOf(android.widget.LinearLayout.class),
+                        childAtPosition(
+                                Matchers.allOf(IsInstanceOf.<View>instanceOf(android.widget.LinearLayout.class),
+                                        childAtPosition(
+                                                IsInstanceOf.<View>instanceOf(android.widget.LinearLayout.class),
+                                                0)),
+                                0),
+                        isDisplayed()));
+        linearLayout.check(matches(isDisplayed()));
+    }
+
+    @After
+    public void unregisterIdlingResource() {
+        if (mProgressbarIdlingResource != null)
+            unregisterIdlingResources(mProgressbarIdlingResource);
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -307,7 +307,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         }
 
         //  Create a new boolean and preference and set it to true
-        boolean isFirstStart = mSettings.getBoolean("firstStart", true);
+        boolean isFirstStart = mSettings.getBoolean(Constants.PREFERENCE_FIRST_START, true);
 
         SharedPreferences.Editor prefsEdit = sharedPrefs.edit();
         //  If the activity has never started before...

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
@@ -34,6 +34,7 @@ public class Constants {
             "default_openhab_clear_default_sitemap";
     public static final String DEFAULT_GCM_SENDER_ID            = "737820980945";
     public static final String PREFERENCE_COMPAREABLEVERSION    = "versionAsInt";
+    public static final String PREFERENCE_FIRST_START           = "firstStart";
 
     public static final String SUBSCREEN_LOCAL_CONNECTION     = "default_openhab_local_connection";
     public static final String SUBSCREEN_REMOTE_CONNECTION    = "default_openhab_remote_connection";


### PR DESCRIPTION
Some tests may require some additional or specific preferences to be set
to specific values in order to work correctly.

To achieve that, this commit adds a Before method to both instrumentation
tests, which will set these required preferences before starting the
activity. It also removes the "go through intro" from the BasicWigetTest2,
which is already tested in the CheckIntroAndCancel test, so there's no
need to test it again. It is also out of scope of the test case.