### PR TITLE
Dont show lint results in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ install:
 script:
 - "./gradlew clean build"
 - "./gradlew test"
-after_script:
-- cat ${TRAVIS_BUILD_DIR}/*/build/reports/lint-results.xml
 before_deploy:
 - openssl aes-256-cbc -K $encrypted_903a93ed2309_key -iv $encrypted_903a93ed2309_iv
   -in keystore.enc -out keystore -d


### PR DESCRIPTION
I think no one reads ~3000 lines of lint errors and it blows up the
build log.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>