### PR TITLE
Use sitemap labels instead of name in the sitemap selection dialog

### DIFF
--- a/mobile/src/androidTest/java/org/openhab/habdroid/TestWithIntro.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/TestWithIntro.java
@@ -12,7 +12,7 @@ public abstract class TestWithIntro extends ProgressbarAwareTest {
         PreferenceManager
                 .getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
                 .edit()
-                .putString(Constants.PREFERENCE_SITEMAP, "")
+                .putString(Constants.PREFERENCE_SITEMAP_NAME, "")
                 .putBoolean(Constants.PREFERENCE_FIRST_START, true)
                 .commit();
 

--- a/mobile/src/androidTest/java/org/openhab/habdroid/TestWithoutIntro.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/TestWithoutIntro.java
@@ -14,9 +14,10 @@ public abstract class TestWithoutIntro extends ProgressbarAwareTest {
                 .getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
                 .edit();
 
-        edit.putString(Constants.PREFERENCE_SITEMAP, "");
+        edit.putString(Constants.PREFERENCE_SITEMAP_NAME, "");
         if (preselectSitemap()) {
-            edit.putString(Constants.PREFERENCE_SITEMAP, "demo");
+            edit.putString(Constants.PREFERENCE_SITEMAP_NAME, "demo");
+            edit.putString(Constants.PREFERENCE_SITEMAP_LABEL, "Main Menu");
         }
 
         edit.putBoolean(Constants.PREFERENCE_FIRST_START, false).commit();

--- a/mobile/src/androidTest/java/org/openhab/habdroid/ui/BasicWidgetTest.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/ui/BasicWidgetTest.java
@@ -49,12 +49,12 @@ public class BasicWidgetTest extends TestWithoutIntro {
 
         // does it contain "demo"?
         ViewInteraction textView = onView(
-                Matchers.allOf(withId(android.R.id.text1), withText("demo"),
+                Matchers.allOf(withId(android.R.id.text1), withText("Main Menu"),
                         childAtPosition(
                                 IsInstanceOf.<View>instanceOf(android.widget.ListView.class),
                                 0),
                         isDisplayed()));
-        textView.check(matches(withText("demo")));
+        textView.check(matches(withText("Main Menu")));
 
         // click on demo
         DataInteraction appCompatTextView = onData(anything())

--- a/mobile/src/androidTest/java/org/openhab/habdroid/ui/IntroActivityTest.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/ui/IntroActivityTest.java
@@ -27,6 +27,7 @@ import static org.openhab.habdroid.TestUtils.childAtPosition;
 @LargeTest
 @RunWith(AndroidJUnit4.class)
 public class IntroActivityTest extends TestWithIntro {
+
     @Test
     public void appShowsIntro() {
         ViewInteraction textView = onView(

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -773,7 +773,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                 // Check if we have a sitemap configured to use
                 SharedPreferences settings =
                         PreferenceManager.getDefaultSharedPreferences(OpenHABMainActivity.this);
-                String configuredSitemap = settings.getString(Constants.PREFERENCE_SITEMAP, "");
+                String configuredSitemap = settings.getString(Constants.PREFERENCE_SITEMAP_NAME, "");
                 // If we have sitemap configured
                 if (configuredSitemap.length() > 0) {
                     // Configured sitemap is on the list we got, open it!
@@ -787,7 +787,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                         if (mSitemapList.size() == 1) {
                             Log.d(TAG, "Got only one sitemap");
                             SharedPreferences.Editor preferencesEditor = settings.edit();
-                            preferencesEditor.putString(Constants.PREFERENCE_SITEMAP, mSitemapList.get(0).getName());
+                            preferencesEditor.putString(Constants.PREFERENCE_SITEMAP_NAME, mSitemapList.get(0).getName());
                             preferencesEditor.apply();
                             openSitemap(mSitemapList.get(0).getHomepageLink());
                         } else {
@@ -801,7 +801,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                     if (mSitemapList.size() == 1) {
                         Log.d(TAG, "Got only one sitemap");
                         SharedPreferences.Editor preferencesEditor = settings.edit();
-                        preferencesEditor.putString(Constants.PREFERENCE_SITEMAP, mSitemapList.get(0).getName());
+                        preferencesEditor.putString(Constants.PREFERENCE_SITEMAP_NAME, mSitemapList.get(0).getName());
                         preferencesEditor.apply();
                         openSitemap(mSitemapList.get(0).getHomepageLink());
                     } else {
@@ -815,10 +815,8 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
 
     private void showSitemapSelectionDialog(final List<OpenHABSitemap> sitemapList) {
         Log.d(TAG, "Opening sitemap selection dialog");
-        final List<String> sitemapNameList = new ArrayList<String>();
         final List<String> sitemapLabelList = new ArrayList<String>();
         for (int i = 0; i < sitemapList.size(); i++) {
-            sitemapNameList.add(sitemapList.get(i).getName());
             sitemapLabelList.add(sitemapList.get(i).getLabel());
         }
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(OpenHABMainActivity.this);
@@ -827,11 +825,12 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
             selectSitemapDialog = dialogBuilder.setItems(sitemapLabelList.toArray(new CharSequence[sitemapLabelList.size()]),
                     new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int item) {
-                            Log.d(TAG, "Selected sitemap " + sitemapNameList.get(item));
+                            Log.d(TAG, "Selected sitemap " + sitemapList.get(item).getName());
                             SharedPreferences settings =
                                     PreferenceManager.getDefaultSharedPreferences(OpenHABMainActivity.this);
                             SharedPreferences.Editor preferencesEditor = settings.edit();
-                            preferencesEditor.putString(Constants.PREFERENCE_SITEMAP, sitemapList.get(item).getName());
+                            preferencesEditor.putString(Constants.PREFERENCE_SITEMAP_NAME, sitemapList.get(item).getName());
+                            preferencesEditor.putString(Constants.PREFERENCE_SITEMAP_LABEL, sitemapList.get(item).getLabel());
                             preferencesEditor.apply();
                             openSitemap(sitemapList.get(item).getHomepageLink());
                         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -816,13 +816,15 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
     private void showSitemapSelectionDialog(final List<OpenHABSitemap> sitemapList) {
         Log.d(TAG, "Opening sitemap selection dialog");
         final List<String> sitemapNameList = new ArrayList<String>();
+        final List<String> sitemapLabelList = new ArrayList<String>();
         for (int i = 0; i < sitemapList.size(); i++) {
             sitemapNameList.add(sitemapList.get(i).getName());
+            sitemapLabelList.add(sitemapList.get(i).getLabel());
         }
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(OpenHABMainActivity.this);
         dialogBuilder.setTitle(getString(R.string.mainmenu_openhab_selectsitemap));
         try {
-            selectSitemapDialog = dialogBuilder.setItems(sitemapNameList.toArray(new CharSequence[sitemapNameList.size()]),
+            selectSitemapDialog = dialogBuilder.setItems(sitemapLabelList.toArray(new CharSequence[sitemapLabelList.size()]),
                     new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int item) {
                             Log.d(TAG, "Selected sitemap " + sitemapNameList.get(item));

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
@@ -168,11 +168,13 @@ public class OpenHABPreferencesActivity extends AppCompatActivity {
                     (Constants.PREFERENCE_CLEAR_DEFAULT_SITEMAP);
 
             String currentDefaultSitemap = clearDefaultSitemapPreference.getSharedPreferences().getString(Constants
-                    .PREFERENCE_SITEMAP, "");
+                    .PREFERENCE_SITEMAP_NAME, "");
+            String currentDefaultSitemapLabel = clearDefaultSitemapPreference.getSharedPreferences().getString(Constants
+                    .PREFERENCE_SITEMAP_LABEL, "");
             if (currentDefaultSitemap.isEmpty()) {
                 onNoDefaultSitemap(clearDefaultSitemapPreference);
             } else {
-                clearDefaultSitemapPreference.setSummary(getString(R.string.settings_current_default_sitemap, currentDefaultSitemap));
+                clearDefaultSitemapPreference.setSummary(getString(R.string.settings_current_default_sitemap, currentDefaultSitemapLabel));
             }
 
             subScreenLocalConn.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
@@ -232,7 +234,8 @@ public class OpenHABPreferencesActivity extends AppCompatActivity {
                 @Override
                 public boolean onPreferenceClick(Preference preference) {
                     SharedPreferences.Editor edit = preference.getSharedPreferences().edit();
-                    edit.putString(Constants.PREFERENCE_SITEMAP, "");
+                    edit.putString(Constants.PREFERENCE_SITEMAP_NAME, "");
+                    edit.putString(Constants.PREFERENCE_SITEMAP_LABEL, "");
                     edit.apply();
 
                     onNoDefaultSitemap(preference);

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
@@ -15,7 +15,8 @@ public class Constants {
     public static final String PREFERENCE_LOCAL_PASSWORD        = "default_openhab_password";
     public static final String PREFERENCE_REMOTE_PASSWORD       = "default_openhab_remote_password";
     public static final String PREFERENCE_REMOTE_USERNAME       = "default_openhab_remote_username";
-    public static final String PREFERENCE_SITEMAP               = "default_openhab_sitemap";
+    public static final String PREFERENCE_SITEMAP_NAME          = "default_openhab_sitemap";
+    public static final String PREFERENCE_SITEMAP_LABEL         = "default_openhab_sitemap_label";
     public static final String PREFERENCE_SSLCERT               = "default_openhab_sslcert";
     public static final String PREFERENCE_SSLHOST               = "default_openhab_sslhost";
     public static final String PREFERENCE_ALTURL                = "default_openhab_alturl";


### PR DESCRIPTION
Fix #595

The sitemap name is also shown in the settings. @FlorianSW Whats the best way to show the label there?