### PR TITLE
Use SpeechRecognizer.isRecognitionAvailable() to check if available

### DIFF
--- a/mobile/src/androidTest/java/org/openhab/habdroid/ProgressbarAwareTest.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/ProgressbarAwareTest.java
@@ -1,0 +1,38 @@
+package org.openhab.habdroid;
+
+import android.support.test.espresso.IdlingResource;
+import android.support.test.rule.ActivityTestRule;
+import android.view.View;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.openhab.habdroid.ui.OpenHABMainActivity;
+
+import static android.support.test.espresso.Espresso.registerIdlingResources;
+import static android.support.test.espresso.Espresso.unregisterIdlingResources;
+
+public abstract class ProgressbarAwareTest {
+
+    @Rule
+    public ActivityTestRule<OpenHABMainActivity> mActivityTestRule = new ActivityTestRule<>
+            (OpenHABMainActivity.class, true, false);
+
+    private IdlingResource mProgressbarIdlingResource;
+
+    @Before
+    public void setup() {
+        mActivityTestRule.launchActivity(null);
+
+        View progressBar = mActivityTestRule.getActivity().findViewById(R.id.toolbar_progress_bar);
+        mProgressbarIdlingResource = new OpenHABProgressbarIdlingResource("Progressbar " +
+                "IdleResource", progressBar);
+        registerIdlingResources(mProgressbarIdlingResource);
+    }
+
+    @After
+    public void unregisterIdlingResource() {
+        if (mProgressbarIdlingResource != null)
+            unregisterIdlingResources(mProgressbarIdlingResource);
+    }
+}

--- a/mobile/src/androidTest/java/org/openhab/habdroid/TestWithIntro.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/TestWithIntro.java
@@ -1,0 +1,21 @@
+package org.openhab.habdroid;
+
+import android.preference.PreferenceManager;
+import android.support.test.InstrumentationRegistry;
+
+import org.openhab.habdroid.util.Constants;
+
+public abstract class TestWithIntro extends ProgressbarAwareTest {
+
+    @Override
+    public void setup() {
+        PreferenceManager
+                .getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
+                .edit()
+                .putString(Constants.PREFERENCE_SITEMAP, "")
+                .putBoolean(Constants.PREFERENCE_FIRST_START, true)
+                .commit();
+
+        super.setup();
+    }
+}

--- a/mobile/src/androidTest/java/org/openhab/habdroid/TestWithoutIntro.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/TestWithoutIntro.java
@@ -1,0 +1,30 @@
+package org.openhab.habdroid;
+
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.support.test.InstrumentationRegistry;
+
+import org.junit.Before;
+import org.openhab.habdroid.util.Constants;
+
+public abstract class TestWithoutIntro extends ProgressbarAwareTest {
+    @Before
+    public void setup() {
+        SharedPreferences.Editor edit = PreferenceManager
+                .getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
+                .edit();
+
+        edit.putString(Constants.PREFERENCE_SITEMAP, "");
+        if (preselectSitemap()) {
+            edit.putString(Constants.PREFERENCE_SITEMAP, "demo");
+        }
+
+        edit.putBoolean(Constants.PREFERENCE_FIRST_START, false).commit();
+
+        super.setup();
+    }
+
+    protected boolean preselectSitemap() {
+        return false;
+    }
+}

--- a/mobile/src/androidTest/java/org/openhab/habdroid/ui/BasicWidgetTest.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/ui/BasicWidgetTest.java
@@ -1,37 +1,26 @@
 package org.openhab.habdroid.ui;
 
 
-import android.preference.PreferenceManager;
 import android.support.constraint.ConstraintLayout;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.espresso.DataInteraction;
-import android.support.test.espresso.IdlingResource;
 import android.support.test.espresso.ViewInteraction;
-import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.suitebuilder.annotation.LargeTest;
 import android.view.View;
 
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openhab.habdroid.OpenHABProgressbarIdlingResource;
+import org.openhab.habdroid.TestWithoutIntro;
 import org.openhab.habdroid.R;
-import org.openhab.habdroid.util.Constants;
 
 import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.Espresso.registerIdlingResources;
-import static android.support.test.espresso.Espresso.unregisterIdlingResources;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
-import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withParent;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
@@ -42,33 +31,10 @@ import static org.openhab.habdroid.TestUtils.childAtPosition;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
-public class BasicWidgetTest {
-
-    @Rule
-    public ActivityTestRule<OpenHABMainActivity> mActivityTestRule = new ActivityTestRule<>
-            (OpenHABMainActivity.class, true, false);
-
-    private IdlingResource mProgressbarIdlingResource;
-
-    @Before
-    public void setup() {
-        PreferenceManager
-                .getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
-                .edit()
-                .putString(Constants.PREFERENCE_SITEMAP, "")
-                .putBoolean(Constants.PREFERENCE_FIRST_START, false)
-                .commit();
-
-        mActivityTestRule.launchActivity(null);
-    }
+public class BasicWidgetTest extends TestWithoutIntro {
 
     @Test
     public void openHABMainActivityTest() throws InterruptedException {
-        View progressBar = mActivityTestRule.getActivity().findViewById(R.id.toolbar_progress_bar);
-        mProgressbarIdlingResource = new OpenHABProgressbarIdlingResource("Progressbar " +
-                "IdleResource", progressBar);
-        registerIdlingResources(mProgressbarIdlingResource);
-
         // do we have sitemap selection popup?
         ViewInteraction linearLayout = onView(
                 Matchers.allOf(IsInstanceOf.<View>instanceOf(android.widget.LinearLayout.class),
@@ -107,10 +73,6 @@ public class BasicWidgetTest {
                                 1),
                         isDisplayed()));
         mainmenu.check(matches(withText("Main Menu")));
-
-        ViewInteraction voice = onView(
-                allOf(withId(R.id.mainmenu_voice_recognition), withContentDescription("Voice recognition"), isDisplayed()));
-        voice.check(matches(isDisplayed()));
 
         ViewInteraction firstfloor = onView(
                 allOf(withId(R.id.widgetlabel), withText("First Floor"),
@@ -251,11 +213,5 @@ public class BasicWidgetTest {
         ViewInteraction imageButton2 = onView(
                 Matchers.allOf(withId(R.id.rollershutterbutton_stop), isDisplayed()));
         imageButton2.check(matches(isDisplayed()));
-    }
-
-    @After
-    public void unregisterIdlingResource() {
-        if (mProgressbarIdlingResource != null)
-            unregisterIdlingResources(mProgressbarIdlingResource);
     }
 }

--- a/mobile/src/androidTest/java/org/openhab/habdroid/ui/IntroActivityTest.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/ui/IntroActivityTest.java
@@ -1,11 +1,7 @@
 package org.openhab.habdroid.ui;
 
 
-import android.preference.PreferenceManager;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.espresso.IdlingResource;
 import android.support.test.espresso.ViewInteraction;
-import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.suitebuilder.annotation.LargeTest;
 import android.view.View;
@@ -13,18 +9,12 @@ import android.view.View;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsInstanceOf;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openhab.habdroid.OpenHABProgressbarIdlingResource;
 import org.openhab.habdroid.R;
-import org.openhab.habdroid.util.Constants;
+import org.openhab.habdroid.TestWithIntro;
 
 import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.Espresso.registerIdlingResources;
-import static android.support.test.espresso.Espresso.unregisterIdlingResources;
 import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -36,26 +26,7 @@ import static org.openhab.habdroid.TestUtils.childAtPosition;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
-public class IntroActivityTest {
-
-    @Rule
-    public ActivityTestRule<OpenHABMainActivity> mActivityTestRule = new ActivityTestRule<>
-            (OpenHABMainActivity.class, true, false);
-
-    private IdlingResource mProgressbarIdlingResource;
-
-    @Before
-    public void setup() {
-        PreferenceManager
-                .getDefaultSharedPreferences(InstrumentationRegistry.getTargetContext())
-                .edit()
-                .putString(Constants.PREFERENCE_SITEMAP, "")
-                .putBoolean(Constants.PREFERENCE_FIRST_START, true)
-                .commit();
-
-        mActivityTestRule.launchActivity(null);
-    }
-
+public class IntroActivityTest extends TestWithIntro {
     @Test
     public void appShowsIntro() {
         ViewInteraction textView = onView(
@@ -156,11 +127,6 @@ public class IntroActivityTest {
                         isDisplayed()));
         appCompatButton.perform(click());
 
-        View progressBar = mActivityTestRule.getActivity().findViewById(R.id.toolbar_progress_bar);
-        mProgressbarIdlingResource = new OpenHABProgressbarIdlingResource("Progressbar " +
-                "IdleResource", progressBar);
-        registerIdlingResources(mProgressbarIdlingResource);
-
         // do we have sitemap selection popup?
         ViewInteraction linearLayout = onView(
                 Matchers.allOf(IsInstanceOf.<View>instanceOf(android.widget.LinearLayout.class),
@@ -172,11 +138,5 @@ public class IntroActivityTest {
                                 0),
                         isDisplayed()));
         linearLayout.check(matches(isDisplayed()));
-    }
-
-    @After
-    public void unregisterIdlingResource() {
-        if (mProgressbarIdlingResource != null)
-            unregisterIdlingResources(mProgressbarIdlingResource);
     }
 }

--- a/mobile/src/androidTest/java/org/openhab/habdroid/ui/VoiceRecognitionTest.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/ui/VoiceRecognitionTest.java
@@ -1,0 +1,45 @@
+package org.openhab.habdroid.ui;
+
+import android.speech.SpeechRecognizer;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.rule.ActivityTestRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openhab.habdroid.R;
+import org.openhab.habdroid.TestWithoutIntro;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.junit.Assume.assumeTrue;
+
+public class VoiceRecognitionTest extends TestWithoutIntro {
+
+    @Rule
+    public ActivityTestRule<OpenHABMainActivity> mActivityTestRule = new ActivityTestRule<>
+            (OpenHABMainActivity.class, true, false);
+
+    @Before
+    public void checkVoiceRecognitionAvailableOnDevice() {
+        assumeTrue("Voice recognition not available, skipping tests for it.",
+                SpeechRecognizer.isRecognitionAvailable(InstrumentationRegistry.getTargetContext()));
+    }
+
+    @Test
+    public void checkVoiceAvailbility () {
+        ViewInteraction voice = onView(
+                allOf(withId(R.id.mainmenu_voice_recognition), withContentDescription("Voice recognition"), isDisplayed()));
+        voice.check(matches(isDisplayed()));
+    }
+
+    @Override
+    protected boolean preselectSitemap() {
+        return true;
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -20,8 +20,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
@@ -33,6 +31,7 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.speech.RecognizerIntent;
+import android.speech.SpeechRecognizer;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.content.ContextCompat;
@@ -196,8 +195,6 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
     private OpenHABTracker mOpenHABTracker;
     // Progress dialog
     private ProgressDialog mProgressDialog;
-    // If Voice Recognition is enabled
-    private boolean mVoiceRecognitionEnabled = false;
     // NFC Launch data
     private String mNfcData;
     // Pending NFC page
@@ -256,8 +253,6 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false);
 
         SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(this);
-
-        checkVoiceRecognition();
 
         // Set the theme to one from preferences
         mSettings = PreferenceManager.getDefaultSharedPreferences(this);
@@ -869,7 +864,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         MenuItem voiceRecognitionItem = menu.findItem(R.id.mainmenu_voice_recognition);
-        voiceRecognitionItem.setVisible(mVoiceRecognitionEnabled);
+        voiceRecognitionItem.setVisible(SpeechRecognizer.isRecognitionAvailable(this));
         voiceRecognitionItem.getIcon()
                 .setColorFilter(ContextCompat.getColor(this, R.color.light), PorterDuff.Mode.SRC_IN);
         return true;
@@ -1122,16 +1117,6 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         i.putExtra(MemorizingTrustManager.DECISION_INTENT_ID, decisionId);
         i.putExtra(MemorizingTrustManager.DECISION_INTENT_CHOICE, decision);
         sendBroadcast(i);
-    }
-
-    public void checkVoiceRecognition() {
-        // Check if voice recognition is present
-        PackageManager pm = getPackageManager();
-        List<ResolveInfo> activities = pm.queryIntentActivities(new Intent(
-                RecognizerIntent.ACTION_RECOGNIZE_SPEECH), 0);
-        if (activities.size() != 0) {
-            mVoiceRecognitionEnabled = true;
-        }
     }
 
     public void makeDecision(int decisionId, String certMessage) {


### PR DESCRIPTION
Instead of quering for an intent, which is used for implementation, we'll
use official API to check, if voice recognition is available on the
device. This will change the intent checked from ACTION_RECOGNIZE_SPEECH
to SERVICE_INTERFACE.

Also: Extract the Voice recognition test from the BasicWidget test and
execute it only, if voice recognition is actually available on the
instrumented device.