### PR TITLE
Travis: Run with Google Play Services for Voice Recognition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ jdk: oraclejdk8
 env:
   global:
   - secure: fMBUkSsCBTw/U907w7Xm/yNzw4lq9yt7zFy0JyEZrA543LI7zQRIclIOtsDTUs0bwY+4KI08MNoYPLJ4TQhSJaH4wQ8b9C5TRsqXNfc0V718TcuYqSXqU6VPRVtX46/fCEWv/HAs0ksUKrHIlpWOwLPQpYDcKxwwlUndaakYKJ8=
+  - ADB_INSTALL_TIMEOUT=8
 
 before_cache:
 - cd ${TRAVIS_BUILD_DIR}/gradle/caches/
@@ -24,8 +25,17 @@ android:
   - platform-tools
   - tools
   - android-22
-  - sys-img-armeabi-v7a-android-22
-  
+  - extra-google-google_play_services
+  - extra-google-m2repository
+  - extra-android-m2repository
+  - extra-android-support
+  - addon-google_apis-google-22 # Google play services
+  - sys-img-armeabi-v7a-google_apis-22
+
+licenses:
+  - android-sdk-license-.+
+  - google-gdk-license-.+
+
 install:
 - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2"
 - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2"
@@ -35,11 +45,11 @@ install:
 # Emulator Management: Create, Start and Wait
 before_script:
 - android list device
-- echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a -d "5.4in FWVGA"
-- emulator -avd test -no-audio -no-window &
+- android list target
+- echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a --tag google_apis -d "5.4in FWVGA"
+- emulator -avd test -no-window &
 - android-wait-for-emulator
 - adb shell input keyevent 82 &
-- android list target
 
 script:
 - ./gradlew build connectedCheck test jacocoTestReport

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ env:
   global:
   - secure: fMBUkSsCBTw/U907w7Xm/yNzw4lq9yt7zFy0JyEZrA543LI7zQRIclIOtsDTUs0bwY+4KI08MNoYPLJ4TQhSJaH4wQ8b9C5TRsqXNfc0V718TcuYqSXqU6VPRVtX46/fCEWv/HAs0ksUKrHIlpWOwLPQpYDcKxwwlUndaakYKJ8=
   - ADB_INSTALL_TIMEOUT=8
+  matrix:
+    - ANDROID_TARGET=android-22 ANDROID_ABI=armeabi-v7a
+    - ANDROID_TARGET=android-27 ANDROID_ABI=armeabi-v7a
 
 before_cache:
 - cd ${TRAVIS_BUILD_DIR}/gradle/caches/
@@ -24,17 +27,12 @@ android:
   - build-tools-25.0.2
   - platform-tools
   - tools
-  - android-22
   - extra-google-google_play_services
   - extra-google-m2repository
   - extra-android-m2repository
   - extra-android-support
-  - addon-google_apis-google-22 # Google play services
-  - sys-img-armeabi-v7a-google_apis-22
-
-licenses:
-  - android-sdk-license-.+
-  - google-gdk-license-.+
+  - $ANDROID_TARGET
+  - sys-img-$ANDROID_ABI-$ANDROID_TARGET
 
 install:
 - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2"
@@ -46,7 +44,7 @@ install:
 before_script:
 - android list device
 - android list target
-- echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a --tag google_apis -d "5.4in FWVGA"
+- echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI -d "5.4in FWVGA"
 - emulator -avd test -no-window &
 - android-wait-for-emulator
 - adb shell input keyevent 82 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   - ADB_INSTALL_TIMEOUT=8
   matrix:
     - ANDROID_TARGET=android-22 ANDROID_ABI=armeabi-v7a
-    - ANDROID_TARGET=android-27 ANDROID_ABI=armeabi-v7a
+    - ANDROID_TARGET=android-25 ANDROID_ABI=armeabi-v7a
 
 before_cache:
 - cd ${TRAVIS_BUILD_DIR}/gradle/caches/
@@ -30,7 +30,6 @@ android:
   - extra-google-google_play_services
   - extra-google-m2repository
   - extra-android-m2repository
-  - extra-android-support
   - $ANDROID_TARGET
   - sys-img-$ANDROID_ABI-$ANDROID_TARGET
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ env:
   - secure: fMBUkSsCBTw/U907w7Xm/yNzw4lq9yt7zFy0JyEZrA543LI7zQRIclIOtsDTUs0bwY+4KI08MNoYPLJ4TQhSJaH4wQ8b9C5TRsqXNfc0V718TcuYqSXqU6VPRVtX46/fCEWv/HAs0ksUKrHIlpWOwLPQpYDcKxwwlUndaakYKJ8=
   - ADB_INSTALL_TIMEOUT=8
   matrix:
-    - ANDROID_TARGET=android-22 ANDROID_ABI=armeabi-v7a
-    - ANDROID_TARGET=android-25 ANDROID_ABI=armeabi-v7a
+    - ANDROID_TARGET=android-22 ANDROID_ABI=armeabi-v7a SYS_IMG=sys-img-$ANDROID_ABI-$ANDROID_TARGET
+    - ANDROID_TARGET=android-25 ANDROID_ABI=google_apis/armeabi-v7a SYS_IMG=sys-img-armeabi-v7a-google_apis-25
 
 before_cache:
 - cd ${TRAVIS_BUILD_DIR}/gradle/caches/
@@ -31,7 +31,7 @@ android:
   - extra-google-m2repository
   - extra-android-m2repository
   - $ANDROID_TARGET
-  - sys-img-$ANDROID_ABI-$ANDROID_TARGET
+  - $SYS_IMG
 
 install:
 - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2"
@@ -44,7 +44,7 @@ before_script:
 - android list device
 - android list target
 - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI -d "5.4in FWVGA"
-- emulator -avd test -no-window &
+- emulator -avd test -engine classic -no-window &
 - android-wait-for-emulator
 - adb shell input keyevent 82 &
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - secure: fMBUkSsCBTw/U907w7Xm/yNzw4lq9yt7zFy0JyEZrA543LI7zQRIclIOtsDTUs0bwY+4KI08MNoYPLJ4TQhSJaH4wQ8b9C5TRsqXNfc0V718TcuYqSXqU6VPRVtX46/fCEWv/HAs0ksUKrHIlpWOwLPQpYDcKxwwlUndaakYKJ8=
   - ADB_INSTALL_TIMEOUT=8
   matrix:
+    - ANDROID_TARGET=android-19 ANDROID_ABI=armeabi-v7a SYS_IMG=sys-img-$ANDROID_ABI-$ANDROID_TARGET
     - ANDROID_TARGET=android-22 ANDROID_ABI=armeabi-v7a SYS_IMG=sys-img-$ANDROID_ABI-$ANDROID_TARGET
     - ANDROID_TARGET=android-25 ANDROID_ABI=google_apis/armeabi-v7a SYS_IMG=sys-img-armeabi-v7a-google_apis-25
 


### PR DESCRIPTION
Getting the Voice recognition running is only possible, if at least one
handler handles the RecognitionService.SERVICE_INTERFACE intent. The
easiest way to achive this is to run the instrumented test on an emulator
which actually has the Google Play services installed.

This commit changes the travis-ci configuration so that the emulator
started has the Play services installed. It also adds some extras, which
are already pre-installed, but accoridng to the travis documentation[1]
should be explicitly mentioned to ensure build stability. However, for the
current build they don't change anything. The extras are namely:

extra-android-support
extra-google-google_play_services
extra-google-m2repository
extra-android-m2repository

[1]
https://docs.travis-ci.com/user/languages/android/#Pre-installed-components