### PR TITLE
Display correct ssl error message

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -109,6 +109,7 @@ import static org.openhab.habdroid.util.Constants.MESSAGES.DIALOG;
 import static org.openhab.habdroid.util.Constants.MESSAGES.LOGLEVEL.ALWAYS;
 import static org.openhab.habdroid.util.Constants.MESSAGES.LOGLEVEL.DEBUG;
 import static org.openhab.habdroid.util.Constants.MESSAGES.LOGLEVEL.NO_DEBUG;
+import static org.openhab.habdroid.util.Util.exceptionHasCause;
 
 public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSelectedListener,
         OpenHABTrackerReceiver, MemorizingResponder {
@@ -134,13 +135,13 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                 message = getString(R.string.error_unable_to_resolve_hostname);
             } else if (error instanceof SSLHandshakeException) {
                 // if ssl exception, check for some common problems
-                if (error.getCause().getCause() instanceof CertPathValidatorException) {
+                if (exceptionHasCause(error, new CertPathValidatorException())) {
                     message = getString(R.string.error_certificate_not_trusted);
-                } else if (error.getCause().getCause() instanceof CertificateExpiredException) {
+                } else if (exceptionHasCause(error, new CertificateExpiredException())) {
                     message = getString(R.string.error_certificate_expired);
-                } else if (error.getCause().getCause() instanceof CertificateNotYetValidException) {
+                } else if (exceptionHasCause(error, new CertificateNotYetValidException())) {
                     message = getString(R.string.error_certificate_not_valid_yet);
-                } else if (error.getCause().getCause() instanceof CertificateRevokedException) {
+                } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && exceptionHasCause(error, new CertificateRevokedException(null, null, null, null))) {
                     message = getString(R.string.error_certificate_revoked);
                 } else {
                     message = getString(R.string.error_connection_sslhandshake_failed);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -95,7 +95,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -137,17 +136,16 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                 message = getString(R.string.error_unable_to_resolve_hostname);
             } else if (error instanceof SSLException) {
                 // if ssl exception, check for some common problems
-                if (exceptionHasCause(error, new CertPathValidatorException())) {
+                if (exceptionHasCause(error, CertPathValidatorException.class)) {
                     message = getString(R.string.error_certificate_not_trusted);
-                } else if (exceptionHasCause(error, new CertificateExpiredException())) {
+                } else if (exceptionHasCause(error, CertificateExpiredException.class)) {
                     message = getString(R.string.error_certificate_expired);
-                } else if (exceptionHasCause(error, new CertificateNotYetValidException())) {
+                } else if (exceptionHasCause(error, CertificateNotYetValidException.class)) {
                     message = getString(R.string.error_certificate_not_valid_yet);
                 } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
-                        && exceptionHasCause(error, new CertificateRevokedException(null, null,
-                            null, null))) {
+                        && exceptionHasCause(error, CertificateRevokedException.class)) {
                     message = getString(R.string.error_certificate_revoked);
-                } else if (exceptionHasCause(error, new SSLPeerUnverifiedException(null))) {
+                } else if (exceptionHasCause(error, SSLPeerUnverifiedException.class)) {
                     message = String.format(getString(R.string.error_certificate_wrong_host),
                             openHABBaseUrl);
                 } else {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -111,6 +111,7 @@ import static org.openhab.habdroid.util.Constants.MESSAGES.LOGLEVEL.ALWAYS;
 import static org.openhab.habdroid.util.Constants.MESSAGES.LOGLEVEL.DEBUG;
 import static org.openhab.habdroid.util.Constants.MESSAGES.LOGLEVEL.NO_DEBUG;
 import static org.openhab.habdroid.util.Util.exceptionHasCause;
+import static org.openhab.habdroid.util.Util.removeProtocolFromUrl;
 
 public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSelectedListener,
         OpenHABTrackerReceiver, MemorizingResponder {
@@ -147,7 +148,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                     message = getString(R.string.error_certificate_revoked);
                 } else if (exceptionHasCause(error, SSLPeerUnverifiedException.class)) {
                     message = String.format(getString(R.string.error_certificate_wrong_host),
-                            openHABBaseUrl);
+                            removeProtocolFromUrl(openHABBaseUrl));
                 } else {
                     message = getString(R.string.error_connection_sslhandshake_failed);
                 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -134,13 +134,13 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                 message = getString(R.string.error_unable_to_resolve_hostname);
             } else if (error instanceof SSLHandshakeException) {
                 // if ssl exception, check for some common problems
-                if (error.getCause() instanceof CertPathValidatorException) {
+                if (error.getCause().getCause() instanceof CertPathValidatorException) {
                     message = getString(R.string.error_certificate_not_trusted);
-                } else if (error.getCause() instanceof CertificateExpiredException) {
+                } else if (error.getCause().getCause() instanceof CertificateExpiredException) {
                     message = getString(R.string.error_certificate_expired);
-                } else if (error.getCause() instanceof CertificateNotYetValidException) {
+                } else if (error.getCause().getCause() instanceof CertificateNotYetValidException) {
                     message = getString(R.string.error_certificate_not_valid_yet);
-                } else if (error.getCause() instanceof CertificateRevokedException) {
+                } else if (error.getCause().getCause() instanceof CertificateRevokedException) {
                     message = getString(R.string.error_certificate_revoked);
                 } else {
                     message = getString(R.string.error_connection_sslhandshake_failed);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -94,7 +94,9 @@ import java.security.cert.CertificateRevokedException;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -133,7 +135,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
             } else if (error instanceof UnknownHostException) {
                 Log.e(TAG, "Unable to resolve hostname");
                 message = getString(R.string.error_unable_to_resolve_hostname);
-            } else if (error instanceof SSLHandshakeException) {
+            } else if (error instanceof SSLException) {
                 // if ssl exception, check for some common problems
                 if (exceptionHasCause(error, new CertPathValidatorException())) {
                     message = getString(R.string.error_certificate_not_trusted);
@@ -141,8 +143,13 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                     message = getString(R.string.error_certificate_expired);
                 } else if (exceptionHasCause(error, new CertificateNotYetValidException())) {
                     message = getString(R.string.error_certificate_not_valid_yet);
-                } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && exceptionHasCause(error, new CertificateRevokedException(null, null, null, null))) {
+                } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+                        && exceptionHasCause(error, new CertificateRevokedException(null, null,
+                            null, null))) {
                     message = getString(R.string.error_certificate_revoked);
+                } else if (exceptionHasCause(error, new SSLPeerUnverifiedException(null))) {
+                    message = String.format(getString(R.string.error_certificate_wrong_host),
+                            openHABBaseUrl);
                 } else {
                     message = getString(R.string.error_connection_sslhandshake_failed);
                 }

--- a/mobile/src/main/java/org/openhab/habdroid/util/Util.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Util.java
@@ -146,4 +146,14 @@ public class Util {
         }
         activity.setTheme(themeRes);
     }
+
+    public static boolean exceptionHasCause(Throwable error, Throwable cause) {
+        while (error != null) {
+            if (error.getClass().equals(cause.getClass())) {
+                return true;
+            }
+            error = error.getCause();
+        }
+        return false;
+    }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/util/Util.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Util.java
@@ -11,6 +11,7 @@ package org.openhab.habdroid.util;
 
 import android.app.Activity;
 import android.content.Context;
+import android.net.Uri;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.util.Log;
@@ -64,6 +65,11 @@ public class Util {
             Log.e(TAG, "normalizeUrl: invalid URL");
         }
         return normalizedUrl;
+    }
+
+    public static String removeProtocolFromUrl(String url) {
+        Uri uri = Uri.parse(url);
+        return uri.getHost();
     }
 
     public static List<OpenHABSitemap> parseSitemapList(Document document) {

--- a/mobile/src/main/java/org/openhab/habdroid/util/Util.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Util.java
@@ -147,9 +147,9 @@ public class Util {
         activity.setTheme(themeRes);
     }
 
-    public static boolean exceptionHasCause(Throwable error, Throwable cause) {
+    public static boolean exceptionHasCause(Throwable error, Class<? extends Throwable> cause) {
         while (error != null) {
-            if (error.getClass().equals(cause.getClass())) {
+            if (error.getClass().equals(cause)) {
                 return true;
             }
             error = error.getCause();

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
     <string name="error_certificate_expired">SSL certificate has been expired. Please get a new certificate or disable certificate validation during SSL handshake</string>
     <string name="error_certificate_not_valid_yet">SSL certificate is not valid yet. Please get a correct certificate or disable certificate validation during SSL handshake. Also check if the clock on your device is set correctly</string>
     <string name="error_certificate_revoked">SSL certificate has been revoked. Please get a new certificate or disable certificate validation during SSL handshake</string>
+    <string name="error_certificate_wrong_host">SSL certificate is not valid for %s</string>
     <string name="error_http_code_401">Authentication failed. Please check the configured username and password respectively the provided SSL client certificate (HTTP response code 401)</string>
     <string name="error_http_code_403">Authentication failed. Please check the configured username and password respectively the provided SSL client certificate (HTTP response code 403)</string>
     <string name="error_http_code_407">Authentication failed. Please check the configured username and password respectively the provided SSL client certificate (HTTP response code 407)</string>

--- a/mobile/src/test/java/org/openhab/habdroid/util/UtilTest.java
+++ b/mobile/src/test/java/org/openhab/habdroid/util/UtilTest.java
@@ -10,8 +10,10 @@ import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.security.cert.CertPathValidatorException;
 import java.util.List;
 
+import javax.net.ssl.SSLException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -151,5 +153,16 @@ public class UtilTest {
                     throw new IllegalArgumentException("Wrong id");
         }
         return new JSONArray(jsonString);
+    }
+
+    @Test
+    public void testexceptionHasCause() {
+        Exception cause = new CertPathValidatorException();
+        Exception e = new SSLException(cause);
+
+        assertTrue("The exception is caused by CertPathValidatorException, so testexceptionHasCause() should return true",
+                Util.exceptionHasCause(e, CertPathValidatorException.class));
+        assertFalse("The exception is not caused by ArrayIndexOutOfBoundsException, so testexceptionHasCause() should return false",
+                Util.exceptionHasCause(e, ArrayIndexOutOfBoundsException.class));
     }
 }


### PR DESCRIPTION
The cause of the error a CertificateException and its cause is
CertPathValidatorException, so we need to call .getCause twice.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>