### PR TITLE
Display sitemap name when no label is present and add sitemap tests

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHABSitemap.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHABSitemap.java
@@ -11,6 +11,7 @@ package org.openhab.habdroid.model;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.NonNull;
 
 public abstract class OpenHABSitemap implements Parcelable {
 	private String name;
@@ -56,8 +57,8 @@ public abstract class OpenHABSitemap implements Parcelable {
         this.icon = icon;
     }
 
-    public String getLabel() {
-        return label;
+    public @NonNull String getLabel() {
+        return (label == null) ? getName() : label;
     }
 
     public void setLabel(String label) {

--- a/mobile/src/test/java/org/openhab/habdroid/model/OpenHABSitemapTest.java
+++ b/mobile/src/test/java/org/openhab/habdroid/model/OpenHABSitemapTest.java
@@ -1,0 +1,69 @@
+package org.openhab.habdroid.model;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OpenHABSitemapTest {
+    OpenHABSitemap sitemap1;
+    OpenHABSitemap sitemap2;
+
+    @Before
+    public void initSitemaps() throws JSONException {
+        String jsonString = "{\"name\":\"demo\",\"label\":\"Main Menu\",\"link\":\"http://demo.openhab.org:8080/rest/sitemaps/demo\",\"homepage\":{\"link\":\"http://demo.openhab.org:8080/rest/sitemaps/demo/demo\",\"leaf\":false,\"timeout\":false,\"widgets\":[]}}";
+        JSONObject jsonObject = new JSONObject(jsonString);
+        sitemap1 = new OpenHAB2Sitemap(jsonObject);
+
+        jsonString = "{\"name\":\"home\",\"icon\":\"home\",\"link\":\"http://demo.openhab.org:8080/rest/sitemaps/home\",\"homepage\":{\"link\":\"http://demo.openhab.org:8080/rest/sitemaps/home/home\",\"leaf\":true,\"timeout\":false,\"widgets\":[]}}";
+        jsonObject = new JSONObject(jsonString);
+        sitemap2 = new OpenHAB2Sitemap(jsonObject);
+    }
+
+    @Test
+    public void sitemapInstanceOf() {
+        assertTrue(sitemap1 instanceof OpenHAB2Sitemap);
+        assertTrue(sitemap2 instanceof OpenHAB2Sitemap);
+    }
+
+    @Test
+    public void sitemapLabelNonNull() {
+        assertEquals("Main Menu", sitemap1.getLabel());
+        assertEquals("home", sitemap2.getLabel());
+    }
+
+    @Test
+    public void testGetLink() {
+        assertEquals("http://demo.openhab.org:8080/rest/sitemaps/demo", sitemap1.getLink());
+        assertEquals("http://demo.openhab.org:8080/rest/sitemaps/home", sitemap2.getLink());
+    }
+
+    @Test
+    public void testGetHomepageLink() {
+        assertEquals("http://demo.openhab.org:8080/rest/sitemaps/demo/demo", sitemap1.getHomepageLink());
+        assertEquals("http://demo.openhab.org:8080/rest/sitemaps/home/home", sitemap2.getHomepageLink());
+    }
+
+    @Test
+    public void testGetIcon() {
+        assertNull(sitemap1.getIcon());
+        assertEquals("home", sitemap2.getIcon());
+    }
+
+    @Test
+    public void testGetIsLeaf() {
+        assertFalse(sitemap1.isLeaf());
+        assertFalse("Leaf isn't set in OpenHAB2Sitemap", sitemap2.isLeaf());
+    }
+
+    @Test
+    public void testGetName() {
+        assertEquals("demo", sitemap1.getName());
+        assertEquals("home", sitemap2.getName());
+    }
+}

--- a/mobile/src/test/java/org/openhab/habdroid/model/OpenHABSitemapTest.java
+++ b/mobile/src/test/java/org/openhab/habdroid/model/OpenHABSitemapTest.java
@@ -11,59 +11,53 @@ import static org.junit.Assert.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class OpenHABSitemapTest {
-    OpenHABSitemap sitemap1;
-    OpenHABSitemap sitemap2;
+    OpenHABSitemap demoSitemapWithLabel;
+    OpenHABSitemap homeSitemapWithoutLabel;
 
     @Before
     public void initSitemaps() throws JSONException {
         String jsonString = "{\"name\":\"demo\",\"label\":\"Main Menu\",\"link\":\"http://demo.openhab.org:8080/rest/sitemaps/demo\",\"homepage\":{\"link\":\"http://demo.openhab.org:8080/rest/sitemaps/demo/demo\",\"leaf\":false,\"timeout\":false,\"widgets\":[]}}";
         JSONObject jsonObject = new JSONObject(jsonString);
-        sitemap1 = new OpenHAB2Sitemap(jsonObject);
+        demoSitemapWithLabel = new OpenHAB2Sitemap(jsonObject);
 
         jsonString = "{\"name\":\"home\",\"icon\":\"home\",\"link\":\"http://demo.openhab.org:8080/rest/sitemaps/home\",\"homepage\":{\"link\":\"http://demo.openhab.org:8080/rest/sitemaps/home/home\",\"leaf\":true,\"timeout\":false,\"widgets\":[]}}";
         jsonObject = new JSONObject(jsonString);
-        sitemap2 = new OpenHAB2Sitemap(jsonObject);
-    }
-
-    @Test
-    public void sitemapInstanceOf() {
-        assertTrue(sitemap1 instanceof OpenHAB2Sitemap);
-        assertTrue(sitemap2 instanceof OpenHAB2Sitemap);
+        homeSitemapWithoutLabel = new OpenHAB2Sitemap(jsonObject);
     }
 
     @Test
     public void sitemapLabelNonNull() {
-        assertEquals("Main Menu", sitemap1.getLabel());
-        assertEquals("home", sitemap2.getLabel());
+        assertEquals("Main Menu", demoSitemapWithLabel.getLabel());
+        assertEquals("Sitemap without explicit label should return name for getLabel","home", homeSitemapWithoutLabel.getLabel());
     }
 
     @Test
     public void testGetLink() {
-        assertEquals("http://demo.openhab.org:8080/rest/sitemaps/demo", sitemap1.getLink());
-        assertEquals("http://demo.openhab.org:8080/rest/sitemaps/home", sitemap2.getLink());
+        assertEquals("http://demo.openhab.org:8080/rest/sitemaps/demo", demoSitemapWithLabel.getLink());
+        assertEquals("http://demo.openhab.org:8080/rest/sitemaps/home", homeSitemapWithoutLabel.getLink());
     }
 
     @Test
     public void testGetHomepageLink() {
-        assertEquals("http://demo.openhab.org:8080/rest/sitemaps/demo/demo", sitemap1.getHomepageLink());
-        assertEquals("http://demo.openhab.org:8080/rest/sitemaps/home/home", sitemap2.getHomepageLink());
+        assertEquals("http://demo.openhab.org:8080/rest/sitemaps/demo/demo", demoSitemapWithLabel.getHomepageLink());
+        assertEquals("http://demo.openhab.org:8080/rest/sitemaps/home/home", homeSitemapWithoutLabel.getHomepageLink());
     }
 
     @Test
     public void testGetIcon() {
-        assertNull(sitemap1.getIcon());
-        assertEquals("home", sitemap2.getIcon());
+        assertNull(demoSitemapWithLabel.getIcon());
+        assertEquals("home", homeSitemapWithoutLabel.getIcon());
     }
 
     @Test
     public void testGetIsLeaf() {
-        assertFalse(sitemap1.isLeaf());
-        assertFalse("Leaf isn't set in OpenHAB2Sitemap", sitemap2.isLeaf());
+        assertFalse("isLeaf is always false for openHAB 2 Sitemaps",demoSitemapWithLabel.isLeaf());
+        assertFalse("isLeaf is always false for openHAB 2 Sitemaps", homeSitemapWithoutLabel.isLeaf());
     }
 
     @Test
     public void testGetName() {
-        assertEquals("demo", sitemap1.getName());
-        assertEquals("home", sitemap2.getName());
+        assertEquals("demo", demoSitemapWithLabel.getName());
+        assertEquals("home", homeSitemapWithoutLabel.getName());
     }
 }

--- a/mobile/src/test/java/org/openhab/habdroid/util/UtilTest.java
+++ b/mobile/src/test/java/org/openhab/habdroid/util/UtilTest.java
@@ -45,9 +45,16 @@ public class UtilTest {
         List<OpenHABSitemap> sitemapList = Util.parseSitemapList(createSitemapDocument());
         assertFalse(sitemapList.isEmpty());
 
-        // Should be sorted, null first
-        assertEquals(null, sitemapList.get(0).getLabel());
-        assertEquals("Garden", sitemapList.get(1).getLabel());
+        // Should be sorted
+        assertEquals("Garden", sitemapList.get(0).getLabel());
+        assertEquals("Heating", sitemapList.get(1).getLabel());
+        assertEquals("Heatpump", sitemapList.get(2).getLabel());
+        assertEquals("Lighting", sitemapList.get(3).getLabel());
+        assertEquals("Scenes", sitemapList.get(4).getLabel());
+        assertEquals("Schedule", sitemapList.get(5).getLabel());
+        assertEquals("i AM DEfault", sitemapList.get(6).getLabel());
+        assertEquals("outside", sitemapList.get(7).getLabel());
+
         assertEquals(8, sitemapList.size());
     }
 
@@ -80,6 +87,6 @@ public class UtilTest {
     @Test
     public void getSitemapByName() throws Exception {
         assertEquals("i AM DEfault", Util.getSitemapByName(sitemapList(), "default").getLabel());
-        assertEquals(null, Util.getSitemapByName(sitemapList(), "outside").getLabel());
+        assertEquals("outside", Util.getSitemapByName(sitemapList(), "outside").getLabel());
     }
 }


### PR DESCRIPTION
Fixes #622

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>

I found out, that the field "leaf" isnt set in OpenHAB2Sitemap. Is this intended?