### PR TITLE
Create .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,30 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach, diff, flags, files, footer"
+  behavior: default
+  require_changes: no
+
+ignore:
+  - "doc"
+  - "**/*.md"


### PR DESCRIPTION
Fixes #632

If no yml is found, the default one is used: https://docs.codecov.io/docs/codecov-yaml I copied it and made the following changes:
* Exclude /doc and all .md files
* Change require_ci_to_pass to no

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>