### PR TITLE
Fix checkstyle Indentation module

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -168,9 +168,9 @@
              value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
         </module>
         <module name="Indentation">
-            <property name="basicOffset" value="2"/>
+            <property name="basicOffset" value="4"/>
             <property name="braceAdjustment" value="0"/>
-            <property name="caseIndent" value="2"/>
+            <property name="caseIndent" value="4"/>
             <property name="throwsIndent" value="4"/>
             <property name="lineWrappingIndentation" value="4"/>
             <property name="arrayInitIndent" value="2"/>


### PR DESCRIPTION
This change was a great improvement to a local checkstyle run on MainActivity. I tried it in two repos, but stickler is still throwing tons of indent rule violations.
This has two possible reasons:

1. The checkstyle config is cached
2. It checkstyle config from the PR branch is taken

Anyway I would like to merge this one and @maniac103 please rebase #650 after this is merged.