### PR TITLE
Set the correct default value of icon format ListPreference

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
@@ -17,6 +17,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.support.v4.app.ListFragment;
 import android.text.TextUtils;
 import android.util.Log;
@@ -127,8 +128,7 @@ public class OpenHABWidgetListFragment extends ListFragment {
         Log.d(TAG, "onActivityCreated()");
         Log.d(TAG, "isAdded = " + isAdded());
         mActivity = (OpenHABMainActivity)getActivity();
-        final String iconFormat = PreferenceManager.getDefaultSharedPreferences(mActivity).getString("iconFormatType","PNG");
-        openHABWidgetDataSource = new OpenHABWidgetDataSource(iconFormat);
+        openHABWidgetDataSource = new OpenHABWidgetDataSource(getIconFormat());
         openHABWidgetAdapter = new OpenHABWidgetAdapter(getActivity(),
                 R.layout.openhabwidgetlist_genericitem, widgetList);
         getListView().setAdapter(openHABWidgetAdapter);
@@ -208,6 +208,11 @@ public class OpenHABWidgetListFragment extends ListFragment {
             Log.d(TAG, "More then 1 column, setting selector on");
             getListView().setChoiceMode(ListView.CHOICE_MODE_SINGLE);
         }
+    }
+
+    @NonNull
+    private String getIconFormat() {
+        return PreferenceManager.getDefaultSharedPreferences(mActivity).getString("iconFormatType","PNG");
     }
 
     @Override

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -38,7 +38,7 @@
         <ListPreference
             android:title="@string/settings_openhab_icon_format"
             android:key="iconFormatType"
-            android:defaultValue="@string/settings_openhab_icon_format_png"
+            android:defaultValue="@string/settings_openhab_icon_format_value_png"
             android:summary="%s"
             android:entries="@array/iconTypeNames"
             android:entryValues="@array/iconTypeValues" />


### PR DESCRIPTION
The default value does not need to be one of the elements in entries, but
one of the elements entryValues, otherwise the default value returned by
SharedPreferences#getString() will be the display value, not the correct
value itself.

Fixes #670