### PR TITLE
Disallow # and \ in store descriptions

### DIFF
--- a/assets/store_descriptions/generate_and_validate.sh
+++ b/assets/store_descriptions/generate_and_validate.sh
@@ -24,7 +24,7 @@ do
     if [ -f "${folder}/strings.sh" ]
     then
         lang=${folder#${string_base}/}
-        if egrep '\||;|http:' "${folder}/strings.sh" --color=always
+        if egrep '\||;|http:|\\' "${folder}/strings.sh" --color=always || [ $(grep '#' "${folder}/strings.sh" | wc -l) -gt 2 ]
         then
             echo "Prohibited char found in $lang, exiting" 1>&2
             exit 1


### PR DESCRIPTION
The intention behind this commit is to disallow new line or similar
chars in store descriptions.

Since crowdin inserts two lines comments, we need to check if sharp count > 2

@ThomDietrich 