### PR TITLE
Fix NPE when closing snackbar when already navigated back

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
@@ -251,8 +251,7 @@ public class OpenHABWidgetListFragment extends Fragment
                     @Override
                     public void onClick(View v) {
                         PreferenceManager
-                                .getDefaultSharedPreferences(
-                                        OpenHABWidgetListFragment.this.getActivity())
+                                .getDefaultSharedPreferences(v.getContext())
                                 .edit()
                                 .putBoolean(PREFERENCE_SWIPE_REFRESH_EXPLAINED, true)
                                 .apply();


### PR DESCRIPTION
Instaed of using the getActivity method of an object, which may already
been outdated and return null in this case, use the View#getContext method
to get the current context of the on click action when closing the "swipe
to refresh" explanation snackbar.

Fixes #707