### PR TITLE
Change default theme to basic ui like theme

### DIFF
--- a/mobile/src/main/res/values/arrays.xml
+++ b/mobile/src/main/res/values/arrays.xml
@@ -8,19 +8,19 @@
     </string-array>
 
     <string-array name="themeArray">
-        <item>@string/theme_name_light</item>
-        <item>@string/theme_name_dark</item>
-        <item>@string/theme_name_black</item>
         <item>@string/theme_name_basic_ui</item>
         <item>@string/theme_name_basic_ui_dark</item>
+        <item>@string/theme_name_black</item>
+        <item>@string/theme_name_light</item>
+        <item>@string/theme_name_dark</item>
     </string-array>
 
     <string-array name="themeValues">
-        <item>@string/theme_value_light</item>
-        <item>@string/theme_value_dark</item>
-        <item>@string/theme_value_black</item>
         <item>@string/theme_value_basic_ui</item>
         <item>@string/theme_value_basic_ui_dark</item>
+        <item>@string/theme_value_black</item>
+        <item>@string/theme_value_light</item>
+        <item>@string/theme_value_dark</item>
     </string-array>
 
     <string-array name="iconTypeNames">

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -131,11 +131,11 @@
     <string name="theme_value_black" translatable="false">black</string>
     <string name="theme_value_basic_ui" translatable="false">basicui</string>
     <string name="theme_value_basic_ui_dark" translatable="false">basicuidark</string>
-    <string name="theme_name_light">Light</string>
-    <string name="theme_name_dark">Dark</string>
-    <string name="theme_name_black">Black/AMOLED</string>
-    <string name="theme_name_basic_ui">Basic UI</string>
-    <string name="theme_name_basic_ui_dark">Basic UI dark</string>
+    <string name="theme_name_light">Classic</string>
+    <string name="theme_name_dark">Classic dark</string>
+    <string name="theme_name_black">Black</string>
+    <string name="theme_name_basic_ui">Bright</string>
+    <string name="theme_name_basic_ui_dark">Dark</string>
 
     <!-- NFC toggle -->
     <string name="nfc_action_on">On</string>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -31,7 +31,7 @@
         <ListPreference
             android:key="default_openhab_theme"
             android:title="@string/settings_openhab_theme"
-            android:defaultValue="@string/theme_value_light"
+            android:defaultValue="@string/theme_value_basic_ui"
             android:summary="%s"
             android:entries="@array/themeArray"
             android:entryValues="@array/themeValues" />


### PR DESCRIPTION
* Change default theme
* Rename theme names
* Reorder themes in settings dialog

Fixes #713 

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>

Intro is still orange and I would like to keep it in orange, since it's the primary openHAB color.
Should it also be changed to blue?