### PR TITLE
Fix padding in about libraries fragment

### DIFF
--- a/mobile/src/main/res/values/dimens.xml
+++ b/mobile/src/main/res/values/dimens.xml
@@ -1,8 +1,8 @@
 <resources>
 
     <!-- Default screen margins, per the Android Design guidelines. -->
-    <dimen name="activity_horizontal_margin">0dp</dimen>
-    <dimen name="activity_vertical_margin">0dp</dimen>
+    <dimen name="activity_horizontal_margin">8dp</dimen>
+    <dimen name="activity_vertical_margin">8dp</dimen>
     <dimen name="widgetlist_fragment_left_margin">0dp</dimen>
     <dimen name="widgetlist_fragment_right_margin">0dp</dimen>
     <dimen name="widgetlist_divider_left_margin">0dp</dimen>


### PR DESCRIPTION
After:
![screenshot_2018-03-04-14-12-48](https://user-images.githubusercontent.com/22525368/36946044-25912cc0-1fb7-11e8-8cbe-52672b20db7f.png)
Before:
![screenshot_2018-03-04-14-14-24](https://user-images.githubusercontent.com/22525368/36946045-25b3046c-1fb7-11e8-8108-3e5b9d373975.png)

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>