### PR TITLE
Use about library fragment instead of activity.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
@@ -138,12 +139,23 @@ public class AboutActivity extends AppCompatActivity {
             appCard.addItem(new MaterialAboutActionItem.Builder()
                     .text(R.string.title_activity_libraries)
                     .icon(R.drawable.ic_developer_mode_grey_24dp)
-                    .setOnClickAction(() -> new LibsBuilder()
-                            .withActivityTheme(getTheme())
-                            .withFields(R.string.class.getFields())
-                            .withLicenseShown(true)
-                            .withAutoDetect(true)
-                            .start(context))
+                    .setOnClickAction(new MaterialAboutItemOnClickAction() {
+                        @Override
+                        public void onClick() {
+                            Fragment f = new LibsBuilder()
+                                    .withFields(R.string.class.getFields())
+                                    .withLicenseShown(true)
+                                    .withAutoDetect(true)
+                                    .supportFragment();
+                            getFragmentManager()
+                                    .beginTransaction()
+                                    .setCustomAnimations(R.anim.slide_in_right, R.anim.slide_out_left,
+                                            R.anim.slide_in_left, R.anim.slide_out_right)
+                                    .replace(R.id.about_container, f)
+                                    .addToBackStack(null)
+                                    .commit();
+                        }
+                    })
                     .build());
 
             MaterialAboutCard.Builder ohServerCard = new MaterialAboutCard.Builder();

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
@@ -4,7 +4,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.annotation.StringRes;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
@@ -39,7 +41,8 @@ import okhttp3.Headers;
 
 import static org.openhab.habdroid.util.Util.obfuscateString;
 
-public class AboutActivity extends AppCompatActivity {
+public class AboutActivity extends AppCompatActivity implements
+        FragmentManager.OnBackStackChangedListener{
     private final static String TAG = AboutActivity.class.getSimpleName();
 
     @Override
@@ -48,6 +51,7 @@ public class AboutActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_about);
+        getSupportFragmentManager().addOnBackStackChangedListener(this);
 
         Toolbar toolbar = findViewById(R.id.openhab_toolbar);
         setSupportActionBar(toolbar);
@@ -79,6 +83,16 @@ public class AboutActivity extends AppCompatActivity {
     public void finish() {
         super.finish();
         Util.overridePendingTransition(this, true);
+    }
+
+    @Override
+    public void onBackStackChanged() {
+        FragmentManager fm = getSupportFragmentManager();
+        int count = fm.getBackStackEntryCount();
+        @StringRes int titleResId = count > 0
+                ? fm.getBackStackEntryAt(count - 1).getBreadCrumbTitleRes()
+                : R.string.about_title;
+        setTitle(titleResId);
     }
 
     public static class AboutMainFragment extends MaterialAboutFragment {
@@ -152,6 +166,7 @@ public class AboutActivity extends AppCompatActivity {
                                     .setCustomAnimations(R.anim.slide_in_right, R.anim.slide_out_left,
                                             R.anim.slide_in_left, R.anim.slide_out_right)
                                     .replace(R.id.about_container, f)
+                                    .setBreadCrumbTitle(R.string.title_activity_libraries)
                                     .addToBackStack(null)
                                     .commit();
                         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
@@ -66,7 +66,7 @@ public class AboutActivity extends AppCompatActivity implements
                     .commit();
         }
 
-
+        updateTitle();
         setResult(RESULT_OK);
     }
 
@@ -87,6 +87,10 @@ public class AboutActivity extends AppCompatActivity implements
 
     @Override
     public void onBackStackChanged() {
+        updateTitle();
+    }
+
+    private void updateTitle() {
         FragmentManager fm = getSupportFragmentManager();
         int count = fm.getBackStackEntryCount();
         @StringRes int titleResId = count > 0


### PR DESCRIPTION
Doing so works around the about library activity not setting an action
bar overlay appropriate for dark action bars when using it together with
a custom activity theme.

Signed-off-by: Danny Baumann <dannybaumann@web.de>