### PR TITLE
Improve connection retry UX.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -400,7 +400,15 @@ public class OpenHABMainActivity extends AppCompatActivity implements
         queryServerProperties();
     }
 
-    public void queryServerProperties() {
+    public void retryServerPropertyQuery() {
+        mController.clearServerCommunicationFailure();
+        if (mPendingCall != null) {
+            mPendingCall.cancel();
+        }
+        queryServerProperties();
+    }
+
+    private void queryServerProperties() {
         final String url = "/rest/bindings";
         mInitState = InitState.QUERY_SERVER_PROPS;
         mPendingCall = mConnection.getAsyncHttpClient().get(url, new DefaultHttpResponseHandler() {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
@@ -522,7 +522,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
 
         @Override
         public void onClick(View view) {
-            ((OpenHABMainActivity) getActivity()).queryServerProperties();
+            ((OpenHABMainActivity) getActivity()).retryServerPropertyQuery();
         }
     }
 


### PR DESCRIPTION
Show a spinning wheel during the retry, and don't allow multiple server
queries to be active at the same time.
