### PR TITLE
Make app_name for beta builds translatable

### DIFF
--- a/mobile/src/beta/res/values/strings.xml
+++ b/mobile/src/beta/res/values/strings.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="app_name" translatable="false">openHAB Beta</string>
+    <!-- Attention translators! Do NOT submit localized strings through GitHub Pull Request. -->
+    <!-- See: https://github.com/openhab/openhab-android/blob/master/README.md#localization -->
+
+    <!-- Name used for beta builds -->
+    <string name="app_name">openHAB Beta</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -4,7 +4,6 @@
     <!-- See: https://github.com/openhab/openhab-android/blob/master/README.md#localization -->
 
     <!-- General app strings -->
-    <string name="app_name" translatable="false">openHAB</string>
     <string name="openhab_service_type" translatable="false">_openhab-server._tcp.local.</string>
     <string name="main_menu">Main menu</string>
     <string name="app_preferences_name">Settings</string>

--- a/mobile/src/stable/res/values/strings.xml
+++ b/mobile/src/stable/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+    <string name="app_name" translatable="false">openHAB</string>
+</resources>


### PR DESCRIPTION
There might be a language where the word "Beta" is usually translated.
Is it in English `openHAB Beta` or `openHAB beta`?