### PR TITLE
Improve look'n'feel of frame widget.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
@@ -198,6 +198,9 @@ public class OpenHABWidgetAdapter extends RecyclerView.Adapter<OpenHABWidgetAdap
     public void onBindViewHolder(ViewHolder holder, int position) {
         holder.stop();
         holder.bind(mItems.get(position));
+        if (holder instanceof FrameViewHolder) {
+            ((FrameViewHolder) holder).setShownAsFirst(position == 0);
+        }
         holder.itemView.setActivated(mSelectedPosition == position);
         holder.itemView.setOnClickListener(mItemClickListener != null ? this : null);
         holder.itemView.setOnLongClickListener(mItemClickListener != null ? this : null);
@@ -363,11 +366,15 @@ public class OpenHABWidgetAdapter extends RecyclerView.Adapter<OpenHABWidgetAdap
     }
 
     public static class FrameViewHolder extends ViewHolder {
+        private final View mDivider;
+        private final View mSpacer;
         private final TextView mLabelView;
 
         FrameViewHolder(LayoutInflater inflater, ViewGroup parent, Connection conn) {
             super(inflater, parent, R.layout.openhabwidgetlist_frameitem, conn);
             mLabelView = itemView.findViewById(R.id.widgetlabel);
+            mDivider = itemView.findViewById(R.id.divider);
+            mSpacer = itemView.findViewById(R.id.spacer);
             itemView.setClickable(false);
         }
 
@@ -377,6 +384,11 @@ public class OpenHABWidgetAdapter extends RecyclerView.Adapter<OpenHABWidgetAdap
             updateTextViewColor(mLabelView, widget.valueColor());
             // hide empty frames
             itemView.setVisibility(widget.label().isEmpty() ? View.GONE : View.VISIBLE);
+        }
+
+        public void setShownAsFirst(boolean shownAsFirst) {
+            mDivider.setVisibility(shownAsFirst ? View.GONE : View.VISIBLE);
+            mSpacer.setVisibility(shownAsFirst ? View.VISIBLE : View.GONE);
         }
     }
 

--- a/mobile/src/main/res/layout/openhabwidgetlist_frameitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_frameitem.xml
@@ -1,34 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:minHeight="50dp"
     android:paddingLeft="@dimen/widgetlist_item_left_margin"
     android:paddingRight="@dimen/widgetlist_item_right_margin"
     android:paddingStart="@dimen/widgetlist_item_left_margin"
     android:paddingEnd="@dimen/widgetlist_item_right_margin">
 
+    <android.support.v4.widget.Space
+        android:id="@+id/spacer"
+        android:layout_width="match_parent"
+        android:layout_height="8dp"
+        tools:visibility="gone" />
+
     <View
+        android:id="@+id/divider"
         android:layout_width="match_parent"
         android:layout_height="8dip"
-        android:layout_marginBottom="7dip"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
         android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-        android:background="?attr/frameWidgetDividerBackground"
-        android:gravity="top"
-        android:orientation="horizontal"
         android:layout_marginStart="@dimen/widgetlist_divider_left_margin"
-        android:layout_marginEnd="@dimen/widgetlist_divider_right_margin" />
+        android:layout_marginEnd="@dimen/widgetlist_divider_right_margin"
+        android:background="?attr/frameWidgetDividerBackground" />
 
     <TextView
         android:id="@+id/widgetlabel"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
         android:paddingLeft="8dp"
         android:paddingRight="8dp"
+        android:gravity="center_vertical"
+        android:minHeight="36dp"
         android:ellipsize="end"
         android:maxLines="2"
         android:textColor="?attr/themedHeaderTextColor"


### PR DESCRIPTION
Don't render divider shadow if frame is the first item, and center text
in the visible area.