### PR TITLE
Properly clear fragments and view pool after connection changes.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -581,6 +581,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements
                 mController.updateConnection(null, null);
             }
         }
+        mViewPool.clear();
         updateSitemapDrawerItems();
         invalidateOptionsMenu();
         updateTitle();

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
@@ -274,8 +274,10 @@ public abstract class ContentController implements PageConnectionHolderFragment.
         } else {
             mNoConnectionFragment = null;
         }
+        resetState();
         updateFragmentState(FragmentUpdateReason.PAGE_UPDATE);
-        updateConnectionState();
+        // Make sure dropped fragments are destroyed immediately to get their views recycled
+        mFm.executePendingTransactions();
     }
 
     /**


### PR DESCRIPTION
Makes sure no HTTP connections to the previous connection are made.