### PR TITLE
Simplify widget list selection highlight code.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
@@ -80,7 +80,7 @@ public class OpenHABWidgetAdapter extends RecyclerView.Adapter<OpenHABWidgetAdap
     private static final String TAG = "OpenHABWidgetAdapter";
 
     public interface ItemClickListener {
-        boolean onItemClicked(OpenHABWidget item); // true -> select position
+        void onItemClicked(OpenHABWidget item);
         void onItemLongClicked(OpenHABWidget item);
     }
 
@@ -284,20 +284,12 @@ public class OpenHABWidgetAdapter extends RecyclerView.Adapter<OpenHABWidgetAdap
         notifyItemChanged(position);
     }
 
-    public int getSelectedPosition() {
-        return mSelectedPosition;
-    }
-
     @Override
     public void onClick(View view) {
         ViewHolder holder = (ViewHolder) view.getTag();
         int position = holder.getAdapterPosition();
         if (position != RecyclerView.NO_POSITION) {
-            int oldSelectedPosition = mSelectedPosition;
-            setSelectedPosition(position);
-            if (!mItemClickListener.onItemClicked(mItems.get(position))) {
-                setSelectedPosition(oldSelectedPosition);
-            }
+            mItemClickListener.onItemClicked(mItems.get(position));
         }
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
@@ -115,12 +115,11 @@ public class OpenHABWidgetListFragment extends Fragment
     }
 
     @Override
-    public boolean onItemClicked(OpenHABWidget openHABWidget) {
+    public void onItemClicked(OpenHABWidget openHABWidget) {
         OpenHABLinkedPage linkedPage = openHABWidget.linkedPage();
         if (mActivity != null && linkedPage != null) {
             mActivity.onWidgetSelected(linkedPage, OpenHABWidgetListFragment.this);
         }
-        return linkedPage != null;
     }
 
     @Override
@@ -335,14 +334,6 @@ public class OpenHABWidgetListFragment extends Fragment
             return mTitle;
         }
         return getArguments().getString("title");
-    }
-
-    public void clearSelection() {
-        Log.d(TAG, "clearSelection() " + this.displayPageUrl);
-        Log.d(TAG, "isAdded = " + isAdded());
-        if (openHABWidgetAdapter != null) {
-            openHABWidgetAdapter.setSelectedPosition(-1);
-        }
     }
 
     private void stopVisibleViewHolders() {


### PR DESCRIPTION
Don't temporarily set highlight on click, but only if really needed in
two-pane layout.

Closes #718
