### PR TITLE
Don't persist highlighted page link to fragment arguments.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
@@ -63,6 +63,7 @@ public class OpenHABWidgetListFragment extends Fragment
     private String mTitle;
     private List<OpenHABWidget> mWidgets;
     private SwipeRefreshLayout refreshLayout;
+    private String mHighlightedPageLink;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -279,7 +280,7 @@ public class OpenHABWidgetListFragment extends Fragment
     }
 
     public void setHighlightedPageLink(String highlightedPageLink) {
-        getArguments().putString("highlightedPageLink", highlightedPageLink);
+        mHighlightedPageLink = highlightedPageLink;
         if (openHABWidgetAdapter == null) {
             return;
         }
@@ -302,7 +303,7 @@ public class OpenHABWidgetListFragment extends Fragment
 
         if (openHABWidgetAdapter != null) {
             openHABWidgetAdapter.update(widgets);
-            setHighlightedPageLink(getArguments().getString("highlightedPageLink"));
+            setHighlightedPageLink(mHighlightedPageLink);
             refreshLayout.setRefreshing(false);
         }
         if (mActivity != null && mIsVisible) {


### PR DESCRIPTION
Otherwise, the highlight is used when two-pane controller is replaced by
one-pane controller after device rotation, but we never want one-pane
layout to have those highlights. As the two-pane controller reapplies
the highlight when restoring fragments, storing the link as instance
member is sufficient.

Fixes #791