### PR TITLE
Report error during load of sitemap back to user

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -635,6 +635,10 @@ public class OpenHABMainActivity extends AppCompatActivity implements
         setProgressIndicatorVisible(false);
     }
 
+    public void openNavigationDrawer() {
+        mDrawerLayout.openDrawer(Gravity.START);
+    }
+
     private void setupDrawer() {
         mDrawerLayout = findViewById(R.id.drawer_layout);
         mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout,

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
@@ -46,12 +46,15 @@ import org.openhab.habdroid.ui.OpenHABNotificationFragment;
 import org.openhab.habdroid.ui.OpenHABPreferencesActivity;
 import org.openhab.habdroid.ui.OpenHABWidgetListFragment;
 
+import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.Stack;
+
+import okhttp3.Headers;
 
 /**
  * Controller class for the content area of {@link OpenHABMainActivity}
@@ -412,6 +415,18 @@ public abstract class ContentController implements PageConnectionHolderFragment.
         }
     }
 
+    @Override
+    public void onLoadFailure(int statusCode, Headers headers, byte[] responseBody, Throwable e) {
+        int errorMsgRes = R.string.error_sitemap_generic_load_error;
+        if (statusCode == HttpURLConnection.HTTP_NOT_FOUND) {
+            errorMsgRes = R.string.error_sitemap_not_found;
+        }
+        mNoConnectionFragment = SitemapLoadFailureFragment
+                .newInstance(mActivity.getString(errorMsgRes, e.getMessage()));
+        updateFragmentState(FragmentUpdateReason.PAGE_UPDATE);
+        mActivity.updateTitle();
+    }
+
     protected abstract void updateFragmentState(FragmentUpdateReason reason);
     protected abstract OpenHABWidgetListFragment getFragmentForTitle();
 
@@ -511,6 +526,20 @@ public abstract class ContentController implements PageConnectionHolderFragment.
             case PAGE_ENTER: return FragmentTransaction.TRANSIT_FRAGMENT_OPEN;
             case BACK_NAVIGATION: return FragmentTransaction.TRANSIT_FRAGMENT_CLOSE;
             default: return FragmentTransaction.TRANSIT_FRAGMENT_FADE;
+        }
+    }
+
+    public static class SitemapLoadFailureFragment extends StatusFragment {
+        public static SitemapLoadFailureFragment newInstance(CharSequence message) {
+            SitemapLoadFailureFragment f = new SitemapLoadFailureFragment();
+            f.setArguments(buildArgs(message, R.drawable.ic_openhab_appicon_24dp /* FIXME */,
+                    R.string.select_another_sitemap, false));
+            return f;
+        }
+
+        @Override
+        public void onClick(View view) {
+            ((OpenHABMainActivity) getActivity()).openNavigationDrawer();
         }
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.java
@@ -69,6 +69,11 @@ public class PageConnectionHolderFragment extends Fragment {
          * @param widget Updated widget
          */
         void onWidgetUpdated(OpenHABWidget widget);
+
+        /**
+         * Let parent know about a failure during the load of data.
+         */
+        void onLoadFailure(int statusCode, Headers headers, byte[] responseBody, Throwable error);
     }
 
     private Map<String, ConnectionHandler> mConnections = new HashMap<>();
@@ -254,7 +259,8 @@ public class PageConnectionHolderFragment extends Fragment {
             Log.d(TAG, "Data load for " + mUrl + " failed", error);
             mAtmosphereTrackingId = null;
             mLongPolling = false;
-            load();
+
+            mCallback.onLoadFailure(statusCode, headers, responseBody, error);
         }
 
         @Override

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -68,6 +68,8 @@
     <!-- Error messages -->
     <string name="error_no_url">Please check that openHAB is running or configure openHAB URL or remote URL</string>
     <string name="error_empty_sitemap_list">openHAB returned empty sitemap list</string>
+    <string name="error_sitemap_generic_load_error">The sitemap could not be loaded. The following error occurred: %1$s</string>
+    <string name="error_sitemap_not_found">The sitemap could not be found on the server. Please select another one from the left navigation menu.</string>
     <string name="error_network_not_available">Network is not available</string>
     <string name="error_http_connection_failed">Connection unsuccessful. An unexpected response was received while trying to connect to the configured openHAB server (Received HTTP response code: %d)</string>
     <string name="error_no_uuid">Unable to get openHAB UUID, connection failed</string>
@@ -180,6 +182,7 @@
     <string name="intro_themes">Themes</string>
     <string name="intro_themes_description">Choose between several themes</string>
     <string name="try_again_button">Try again</string>
+    <string name="select_another_sitemap">Select another sitemap</string>
     <string name="network_error">Network error</string>
     <string name="go_to_settings_button">Go to settings</string>
     <string name="configuration_missing">Your openHAB server could not be discovered automatically. Please configure its IP address or host name in the server settings.</string>


### PR DESCRIPTION
Instead of retrying indefinitely to load the sitemap, the user now get's
an error message, that the sitemap could not be loaded (e.g. because it
can not be found anymore). The main action here is to select another
sitemap.

Fixes #741

Signed-off-by: Florian <florian.schmidt.welzow@t-online.de>