### PR TITLE
Always try to load images from cache first.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHABWidget.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHABWidget.java
@@ -117,8 +117,10 @@ public abstract class OpenHABWidget implements Parcelable {
         public abstract Builder height(int height);
 
         public OpenHABWidget build() {
-            // Consider a minimal refresh rate of 100 ms
-            refresh(Math.max(refresh(), 100));
+            // Consider a minimal refresh rate of 100 ms, but 0 is special and means 'no refresh'
+            if (refresh() > 0 && refresh() < 100) {
+                refresh(100);
+            }
             // Default period to 'D'
             if (period() == null || period().isEmpty()) {
                 period("D");
@@ -258,7 +260,7 @@ public abstract class OpenHABWidget implements Parcelable {
                 .minValue((float) widgetJson.optDouble("minValue", 0))
                 .maxValue((float) widgetJson.optDouble("maxValue", 100))
                 .step((float) widgetJson.optDouble("step", 1))
-                .refresh(Math.max(widgetJson.optInt("refresh"), 100))
+                .refresh(widgetJson.optInt("refresh"))
                 .period(widgetJson.optString("period", "D"))
                 .service(widgetJson.optString("service", ""))
                 .legend(widgetJson.has("legend") ? widgetJson.getBoolean("legend") : null)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
@@ -571,7 +571,7 @@ public class OpenHABWidgetAdapter extends RecyclerView.Adapter<OpenHABWidgetAdap
                     uri = Uri.parse(mConnection.getOpenHABUrl() + widget.url());
                 }
                 mImageView.setImageUrl(uri.toString(), mConnection.getUsername(),
-                        mConnection.getPassword(), false);
+                        mConnection.getPassword(), true);
                 mRefreshRate = widget.refresh();
             }
         }
@@ -910,7 +910,7 @@ public class OpenHABWidgetAdapter extends RecyclerView.Adapter<OpenHABWidgetAdap
                 Log.d(TAG, "Chart url = " + chartUrl);
 
                 mImageView.setImageUrl(chartUrl.toString(), mConnection.getUsername(),
-                        mConnection.getPassword(), false);
+                        mConnection.getPassword(), true);
                 mRefreshRate = widget.refresh();
             } else {
                 Log.e(TAG, "Chart item is null");

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
@@ -866,6 +866,7 @@ public class OpenHABWidgetAdapter extends RecyclerView.Adapter<OpenHABWidgetAdap
                 Connection conn, ColorMapper colorMapper) {
             super(inflater, parent, R.layout.openhabwidgetlist_chartitem, conn, colorMapper);
             mImageView = itemView.findViewById(R.id.chartimage);
+            mImageView.setEmptyAspectRatio(2.0f);
             mParentView = parent;
 
             WindowManager wm = (WindowManager) itemView.getContext().getSystemService(Context.WINDOW_SERVICE);

--- a/mobile/src/main/java/org/openhab/habdroid/util/MySmartImageView.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MySmartImageView.java
@@ -95,25 +95,25 @@ public class MySmartImageView extends SmartImageView {
         setImageUrl(url, username, password, true);
     }
 
-    public void setImageUrl(String url, String username, String password, boolean useImageCache) {
-        setImageUrl(url, username, password, useImageCache, null);
+    public void setImageUrl(String url, String username, String password, boolean forceLoad) {
+        setImageUrl(url, username, password, forceLoad, null);
     }
 
     public void setImageUrl(String url, String username, String password, Integer fallbackResource) {
-        setImageUrl(url, username, password, true, fallbackResource);
+        setImageUrl(url, username, password, false, fallbackResource);
     }
 
     public void setImageUrl(String url, String username, String password,
-            boolean useImageCache, Integer fallbackResource) {
-        setImageUrl(url, username, password, useImageCache, fallbackResource, fallbackResource);
+            boolean forceLoad, Integer fallbackResource) {
+        setImageUrl(url, username, password, forceLoad, fallbackResource, fallbackResource);
     }
 
     public void setImageUrl(String url, String username, String password,
             Integer fallbackResource, Integer loadingResource) {
-        setImageUrl(url, username, password, true, fallbackResource, loadingResource);
+        setImageUrl(url, username, password, false, fallbackResource, loadingResource);
     }
 
-    private void setImageUrl(String url, String username, String password, boolean useImageCache,
+    private void setImageUrl(String url, String username, String password, boolean forceLoad,
             Integer fallbackResource, Integer loadingResource) {
         if (TextUtils.equals(myImageUrl, url)
                 && TextUtils.equals(this.username, username)
@@ -131,9 +131,9 @@ public class MySmartImageView extends SmartImageView {
         if (cachedBitmap != null) {
             setImageBitmap(cachedBitmap);
         }
-        if (!useImageCache || cachedBitmap == null) {
+        if (forceLoad || cachedBitmap == null) {
             mRefreshHandler.removeMessages(0);
-            MyWebImage image = new MyWebImage(url, useImageCache, username, password);
+            MyWebImage image = new MyWebImage(url, forceLoad, username, password);
             if (fallbackResource == null) {
                 setImageDrawable(null);
             }

--- a/mobile/src/main/java/org/openhab/habdroid/util/MySmartImageView.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MySmartImageView.java
@@ -68,6 +68,7 @@ public class MySmartImageView extends SmartImageView {
     private String password;
     private int maxWidth;
     private int maxHeight;
+    private float mEmptyAspectRatio = 0;
 
     private long mRefreshInterval;
     private long mLastRefreshTimestamp;
@@ -149,6 +150,13 @@ public class MySmartImageView extends SmartImageView {
         setImage(image, imageCompletionListener);
     }
 
+    public void setEmptyAspectRatio(float ratio) {
+        mEmptyAspectRatio = ratio;
+        if (getDrawable() == null) {
+            requestLayout();
+        }
+    }
+
     public void setMaxSize(int maxWidth, int maxHeight) {
         this.maxWidth = maxWidth;
         this.maxHeight = maxHeight;
@@ -166,6 +174,20 @@ public class MySmartImageView extends SmartImageView {
         Log.i(TAG, "Cancel image Refresh for " + myImageUrl);
         mRefreshHandler.removeMessages(0);
         mRefreshInterval = 0;
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+        if (getMeasuredHeight() == 0 && mEmptyAspectRatio != 0) {
+            int specWidth = MeasureSpec.getSize(widthMeasureSpec);
+            switch (MeasureSpec.getMode(widthMeasureSpec)) {
+                case MeasureSpec.AT_MOST:
+                case MeasureSpec.EXACTLY:
+                    setMeasuredDimension(specWidth, (int) (1.0f * specWidth / mEmptyAspectRatio));
+                    break;
+            }
+        }
     }
 
     @Override

--- a/mobile/src/main/java/org/openhab/habdroid/util/MySmartImageView.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MySmartImageView.java
@@ -22,6 +22,7 @@ import android.view.ViewGroup;
 import com.loopj.android.image.SmartImageView;
 import com.loopj.android.image.SmartImageTask;
 import com.loopj.android.image.SmartImage;
+import com.loopj.android.image.WebImageCache;
 
 import java.lang.ref.WeakReference;
 
@@ -124,12 +125,15 @@ public class MySmartImageView extends SmartImageView {
         this.username = username;
         this.password = password;
 
-        MyWebImage image = new MyWebImage(url, useImageCache, username, password);
-        Bitmap cachedBitmap = image.getCachedBitmap();
+        WebImageCache cache = MyWebImage.getWebImageCache();
+        Bitmap cachedBitmap = cache != null ? cache.get(url) : null;
+
         if (cachedBitmap != null) {
             setImageBitmap(cachedBitmap);
-        } else {
+        }
+        if (!useImageCache || cachedBitmap == null) {
             mRefreshHandler.removeMessages(0);
+            MyWebImage image = new MyWebImage(url, useImageCache, username, password);
             setImage(image, fallbackResource, loadingResource, imageCompletionListener);
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/util/MySmartImageView.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MySmartImageView.java
@@ -134,6 +134,9 @@ public class MySmartImageView extends SmartImageView {
         if (!useImageCache || cachedBitmap == null) {
             mRefreshHandler.removeMessages(0);
             MyWebImage image = new MyWebImage(url, useImageCache, username, password);
+            if (fallbackResource == null) {
+                setImageDrawable(null);
+            }
             setImage(image, fallbackResource, loadingResource, imageCompletionListener);
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/util/MyWebImage.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MyWebImage.java
@@ -40,15 +40,15 @@ public class MyWebImage implements SmartImage {
     private static WebImageCache sWebImageCache;
 
     private String url;
-    private boolean useCache = true;
+    private boolean forceLoad = false;
     
     private String authUsername;
     private String authPassword;
     private boolean shouldAuth = false;
 
-    public MyWebImage(String url, boolean useCache, String username, String password) {
-    	this.url = url;
-    	this.useCache = useCache;
+    public MyWebImage(String url, boolean forceLoad, String username, String password) {
+        this.url = url;
+        this.forceLoad = forceLoad;
         this.setAuthentication(username, password);
     }
 
@@ -81,12 +81,12 @@ public class MyWebImage implements SmartImage {
                 // Try getting bitmap from cache first
         Bitmap bitmap = null;
         if(url != null) {
-            if (this.useCache)
+            if (!forceLoad)
             	bitmap = getWebImageCache(context).get(url);
-            if(bitmap == null) {
+            if (bitmap == null) {
             	Log.i("MyWebImage", "Cache for " + url + " is empty, getting image");
                 bitmap = getBitmapFromUrl(context, url);
-                if(bitmap != null && this.useCache) {
+                if (bitmap != null) {
                     getWebImageCache(context).put(url, bitmap);
                 }
             }

--- a/mobile/src/main/java/org/openhab/habdroid/util/MyWebImage.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MyWebImage.java
@@ -52,11 +52,6 @@ public class MyWebImage implements SmartImage {
         this.setAuthentication(username, password);
     }
 
-    public Bitmap getCachedBitmap() {
-        WebImageCache cache = useCache ? getWebImageCache() : null;
-        return cache != null ? cache.get(url) : null;
-    }
-
     /**
      * Returns the already initialized WebImageCache, if there's any. This method may return
      * null if {@link MyWebImage#getWebImageCache(Context ctx)} was not called so far.

--- a/mobile/src/test/java/org/openhab/habdroid/model/OpenHABWidgetTest.java
+++ b/mobile/src/test/java/org/openhab/habdroid/model/OpenHABWidgetTest.java
@@ -82,6 +82,7 @@ public class OpenHABWidgetTest {
     public void testGetRefresh() throws Exception {
         assertEquals(1000, sut1.get(0).refresh());
         assertEquals("Min refresh is 100, object has set refresh to 10", 100, sut2.get(0).refresh());
+        assertEquals("Missing refresh should equal 0", 0, sut3.get(0).refresh());
     }
 
     @Test


### PR DESCRIPTION
Do this even if the useImageCache flag is set to false and use that flag
only to decide whether to do a new GET request or not.
When not doing so, images will be (temporarily) shown in wrong spots
when scrolling lists up and down.

Fixes #829 and probably also #826.

Signed-off-by: Danny Baumann <dannybaumann@web.de>