### PR TITLE
Correctly map he, yi and id language codes

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,6 +4,9 @@ files:
     languages_mapping:
       two_letters_code:
         pt-BR: pt-rBR
+        he: iw
+        yi: ji
+        id: in
   - source: /assets/store_descriptions/en-US/strings.xml
     translation: /assets/store_descriptions/%locale%/%original_file_name%
   - source: /mobile/src/beta/res/values/strings.xml
@@ -11,13 +14,22 @@ files:
     languages_mapping:
       two_letters_code:
         pt-BR: pt-rBR
+        he: iw
+        yi: ji
+        id: in
   - source: /mobile/src/foss/res/values/strings.xml
     translation: /mobile/src/foss/res/values-%two_letters_code%/%original_file_name%
     languages_mapping:
       two_letters_code:
         pt-BR: pt-rBR
+        he: iw
+        yi: ji
+        id: in
   - source: /mobile/src/full/res/values/strings.xml
     translation: /mobile/src/full/res/values-%two_letters_code%/%original_file_name%
     languages_mapping:
       two_letters_code:
         pt-BR: pt-rBR
+        he: iw
+        yi: ji
+        id: in


### PR DESCRIPTION
I locally renamed the values-he folder to values-iw and now the app is in Hebrew for @gargamelonly
Fixes #838

See https://developer.android.com/reference/java/util/Locale.html under "Legacy language codes".

@ThomDietrich Can you review my changes?