### PR TITLE
Improve chart scaling.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
@@ -891,7 +891,7 @@ public class OpenHABWidgetAdapter extends RecyclerView.Adapter<OpenHABWidgetAdap
                 }
                 chartUrl.append("&period=").append(widget.period())
                         .append("&random=").append(mRandom.nextInt())
-                        .append("&dpi=").append(mDensity);
+                        .append("&dpi=").append(mDensity * 96 / 160);
                 if (!TextUtils.isEmpty(widget.service())) {
                     chartUrl.append("&service=").append(widget.service());
                 }


### PR DESCRIPTION
The server's density calculations are center around a default density of
96 dpi. In Android, the default is 160 dpi; thus the charts are scaled
too much (fonts and lines are disproportionally large/thick).
