### PR TITLE
Make absolutely sure fragment updates are deferred until onStart().

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -169,6 +169,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements
     private ContentController mController;
     private InitState mInitState = InitState.QUERY_SERVER_PROPS;
     private Call mPendingCall;
+    private boolean mStarted;
 
     /**
      * Daydreaming gets us into a funk when in fullscreen, this allows us to
@@ -367,7 +368,8 @@ public class OpenHABMainActivity extends AppCompatActivity implements
         switch (action) {
             case NfcAdapter.ACTION_NDEF_DISCOVERED:
             case Intent.ACTION_VIEW:
-                onNfcTag(intent.getData());
+                mPendingNfcData = intent.getData();
+                openPendingNfcPageIfNeeded();
                 break;
             case ACTION_NOTIFICATION_SELECTED:
                 CloudMessagingHelper.onNotificationSelected(this, intent);
@@ -456,10 +458,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements
         mSelectedSitemap = null;
 
         // Handle pending NFC tag if initial connection determination finished
-        if (mPendingNfcData != null && (mConnection != null || failureReason != null)) {
-            onNfcTag(mPendingNfcData);
-            mPendingNfcData = null;
-        }
+        openPendingNfcPageIfNeeded();
 
         if (newConnection != null) {
             handleConnectionChange();
@@ -502,15 +501,13 @@ public class OpenHABMainActivity extends AppCompatActivity implements
     @Override
     public void onCloudConnectionChanged(CloudConnection connection) {
         updateNotificationDrawerItem();
-        if (mPendingOpenNotifications && connection != null) {
-            openNotifications();
-            mPendingOpenNotifications = false;
-        }
+        openNotificationsPageIfNeeded();
     }
 
     @Override
     protected void onStart() {
         super.onStart();
+        mStarted = true;
         if (mConnection != null) {
             if (mInitState == InitState.QUERY_SERVER_PROPS) {
                 mController.clearServerCommunicationFailure();
@@ -520,6 +517,8 @@ public class OpenHABMainActivity extends AppCompatActivity implements
                 loadSitemapList(true);
             }
         }
+        openPendingNfcPageIfNeeded();
+        openNotificationsPageIfNeeded();
     }
 
     /**
@@ -528,6 +527,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements
     @Override
     public void onStop() {
         Log.d(TAG, "onStop()");
+        mStarted = false;
         super.onStop();
         if(selectSitemapDialog != null && selectSitemapDialog.isShowing()) {
             selectSitemapDialog.dismiss();
@@ -676,6 +676,42 @@ public class OpenHABMainActivity extends AppCompatActivity implements
         Drawable wrapped = DrawableCompat.wrap(icon);
         DrawableCompat.setTintList(wrapped, mDrawerIconTintList);
         return wrapped;
+    }
+
+    private void openNotificationsPageIfNeeded() {
+        if (mPendingOpenNotifications && mStarted &&
+                ConnectionFactory.getConnection(Connection.TYPE_CLOUD) != null) {
+            openNotifications();
+            mPendingOpenNotifications = false;
+        }
+    }
+
+    private void openPendingNfcPageIfNeeded() {
+        if (mPendingNfcData == null || mConnection == null || !mStarted) {
+            return;
+        }
+
+        Log.d(TAG, "NFC Scheme = " + mPendingNfcData.getScheme());
+        Log.d(TAG, "NFC Host = " + mPendingNfcData.getHost());
+        Log.d(TAG, "NFC Path = " + mPendingNfcData.getPath());
+        String nfcItem = mPendingNfcData.getQueryParameter("item");
+        String nfcCommand = mPendingNfcData.getQueryParameter("command");
+
+        // If there is no item parameter it means tag contains only sitemap page url
+        if (TextUtils.isEmpty(nfcItem)) {
+            Log.d(TAG, "This is a sitemap tag without parameters");
+            // Form the new sitemap page url
+            String newPageUrl = String.format(Locale.US, "%srest/sitemaps%s",
+                    mConnection.getOpenHABUrl(), mPendingNfcData.getPath());
+            mController.openPage(newPageUrl);
+        } else {
+            Log.d(TAG, "Target item = " + nfcItem);
+            String url = String.format(Locale.US, "%srest/items/%s",
+                    mConnection.getOpenHABUrl(), nfcItem);
+            Util.sendItemCommand(mConnection.getAsyncHttpClient(), url, nfcCommand);
+            finish();
+        }
+        mPendingNfcData = null;
     }
 
     private void openAbout() {
@@ -931,11 +967,8 @@ public class OpenHABMainActivity extends AppCompatActivity implements
     private void onNotificationSelected(Intent intent) {
         Log.d(TAG, "Notification was selected");
 
-        if (ConnectionFactory.getConnection(Connection.TYPE_CLOUD) != null) {
-            openNotifications();
-        } else {
-            mPendingOpenNotifications = true;
-        }
+        mPendingOpenNotifications = true;
+        openNotificationsPageIfNeeded();
 
         if (intent.hasExtra(EXTRA_MESSAGE)) {
             new AlertDialog.Builder(this)
@@ -943,42 +976,6 @@ public class OpenHABMainActivity extends AppCompatActivity implements
                     .setMessage(intent.getStringExtra(EXTRA_MESSAGE))
                     .setPositiveButton(getString(android.R.string.ok), null)
                     .show();
-        }
-    }
-
-    /**
-     * This method processes new intents generated by NFC subsystem
-     *
-     * @param nfcData - a data which NFC subsystem got from the NFC tag
-     */
-    private void onNfcTag(Uri nfcData) {
-        if (nfcData == null) {
-            return;
-        }
-        if (mConnection == null) {
-            mPendingNfcData = nfcData;
-            return;
-        }
-
-        Log.d(TAG, "NFC Scheme = " + nfcData.getScheme());
-        Log.d(TAG, "NFC Host = " + nfcData.getHost());
-        Log.d(TAG, "NFC Path = " + nfcData.getPath());
-        String nfcItem = nfcData.getQueryParameter("item");
-        String nfcCommand = nfcData.getQueryParameter("command");
-
-        // If there is no item parameter it means tag contains only sitemap page url
-        if (TextUtils.isEmpty(nfcItem)) {
-            Log.d(TAG, "This is a sitemap tag without parameters");
-            // Form the new sitemap page url
-            String newPageUrl = String.format(Locale.US, "%srest/sitemaps%s",
-                    mConnection.getOpenHABUrl(), nfcData.getPath());
-            mController.openPage(newPageUrl);
-        } else {
-            Log.d(TAG, "Target item = " + nfcItem);
-            String url = String.format(Locale.US, "%srest/items/%s",
-                    mConnection.getOpenHABUrl(), nfcItem);
-            Util.sendItemCommand(mConnection.getAsyncHttpClient(), url, nfcCommand);
-            finish();
         }
     }
 


### PR DESCRIPTION
PR #789 attempted to fix this already, but was incomplete: if a
notification was clicked and the cloud connection already was resolved
at the time the activity was created (which may or may not have
happened, as activity creation in main thread and cloud connection
resolving in update thread race against each other), fragment updates
happened even though the activity wasn't started yet. Fix this by
tracking explicitly whether the activity is started, and deferring
updates until then.

Closes #853
