### PR TITLE
Fix URL handling for cases where server URL contains path segments.

### DIFF
--- a/mobile/src/full/java/org/openhab/habdroid/core/GcmRegistrationService.java
+++ b/mobile/src/full/java/org/openhab/habdroid/core/GcmRegistrationService.java
@@ -84,7 +84,7 @@ public class GcmRegistrationService extends IntentService {
         String deviceId = Settings.Secure.getString(getContentResolver(), Settings.Secure.ANDROID_ID);
 
         String regUrl = String.format(Locale.US,
-                "/addAndroidRegistration?deviceId=%s&deviceModel=%s&regId=%s",
+                "addAndroidRegistration?deviceId=%s&deviceModel=%s&regId=%s",
                 deviceId, deviceModel, token);
 
         Log.d(TAG, "Register device at openHAB-cloud with URL: " + regUrl);

--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHABVoiceService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHABVoiceService.java
@@ -87,11 +87,11 @@ public class OpenHABVoiceService extends IntentService {
             return;
         }
 
-        SyncHttpClient.HttpStatusResult result = client.post("/voice/interpreters",
+        SyncHttpClient.HttpStatusResult result = client.post("voice/interpreters",
                 commandJson, "application/json").asStatus();
         if (result.statusCode == 404) {
             Log.d(TAG, "Voice interpreter endpoint returned 404, falling back to item");
-            result = client.post("/rest/items/VoiceCommand",
+            result = client.post("rest/items/VoiceCommand",
                     command, "text/plain;charset=UTF-8").asStatus();
         }
         if (result.isSuccessful()) {

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/CloudConnection.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/CloudConnection.java
@@ -34,7 +34,7 @@ public class CloudConnection extends DefaultConnection {
      */
     public static CloudConnection fromConnection(AbstractConnection connection) {
         final SyncHttpClient client = connection.getSyncHttpClient();
-        SyncHttpClient.HttpTextResult result = client.get("/api/v1/settings/notifications").asText();
+        SyncHttpClient.HttpTextResult result = client.get("api/v1/settings/notifications").asText();
         if (!result.isSuccessful()) {
             Log.e(TAG, "Error loading notification settings: " + result.error);
             return null;

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
@@ -274,7 +274,7 @@ public class AboutActivity extends AppCompatActivity implements
 
         private String getServerSecret() {
             SyncHttpClient.HttpTextResult result =
-                    mConnection.getSyncHttpClient().get("/static/secret").asText();
+                    mConnection.getSyncHttpClient().get("static/secret").asText();
             if (result.isSuccessful()) {
                 Log.d(TAG, "Got secret " + obfuscateString(result.response));
                 return result.response;
@@ -285,7 +285,7 @@ public class AboutActivity extends AppCompatActivity implements
         }
 
         private String getServerUuid() {
-            final String uuidUrl = mOpenHABVersion == 1 ? "/static/uuid" : "/rest/uuid";
+            final String uuidUrl = mOpenHABVersion == 1 ? "static/uuid" : "rest/uuid";
             SyncHttpClient.HttpTextResult result =
                     mConnection.getSyncHttpClient().get(uuidUrl).asText();
             if (result.isSuccessful()) {
@@ -298,7 +298,7 @@ public class AboutActivity extends AppCompatActivity implements
         }
 
         private String getApiVersion() {
-            String versionUrl = mOpenHABVersion == 1 ? "/static/version" : "/rest";
+            String versionUrl = mOpenHABVersion == 1 ? "static/version" : "rest";
             Log.d(TAG, "url = " + versionUrl);
             SyncHttpClient.HttpTextResult result =
                     mConnection.getSyncHttpClient().get(versionUrl).asText();

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -316,7 +316,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements
     }
 
     private void queryServerProperties() {
-        final String url = "/rest/bindings";
+        final String url = "rest/bindings";
         mInitState = InitState.QUERY_SERVER_PROPS;
         mPendingCall = mConnection.getAsyncHttpClient().get(url, new AsyncHttpClient.StringResponseHandler() {
             @Override
@@ -735,7 +735,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements
         Log.d(TAG, "Loading sitemap list from /rest/sitemaps");
 
         mInitState = InitState.LOAD_SITEMAPS;
-        mPendingCall = mConnection.getAsyncHttpClient().get("/rest/sitemaps", new AsyncHttpClient.StringResponseHandler() {
+        mPendingCall = mConnection.getAsyncHttpClient().get("rest/sitemaps", new AsyncHttpClient.StringResponseHandler() {
             @Override
             public void onFailure(Request request, int statusCode, Throwable error) {
                 handleServerCommunicationFailure(request, statusCode, error);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABNotificationFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABNotificationFragment.java
@@ -149,7 +149,7 @@ public class OpenHABNotificationFragment extends Fragment implements SwipeRefres
             return;
         }
         startProgressIndicator();
-        mRequestHandle = conn.getAsyncHttpClient().get("/api/v1/notifications?limit=20",
+        mRequestHandle = conn.getAsyncHttpClient().get("api/v1/notifications?limit=20",
                 new AsyncHttpClient.StringResponseHandler() {
             @Override
             public void onSuccess(String responseBody, Headers headers) {

--- a/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.java
@@ -110,10 +110,13 @@ public abstract class HttpClient {
     protected Call prepareCall(String url, String method, Map<String, String> additionalHeaders,
                                String requestBody, String mediaType) {
         Request.Builder requestBuilder = new Request.Builder();
-        if (mBaseUrl == null) {
-            requestBuilder.url(url);
+        HttpUrl absoluteUrl = HttpUrl.parse(url);
+        if (absoluteUrl != null) {
+            requestBuilder.url(absoluteUrl);
+        } else if (mBaseUrl != null) {
+            requestBuilder.url(mBaseUrl.newBuilder().addPathSegments(url).build());
         } else {
-            requestBuilder.url(mBaseUrl.newBuilder(url).build());
+            throw new IllegalArgumentException("Can't use relative URLs without base URL");
         }
         for (Map.Entry<String, String> entry : headers.entrySet()) {
             requestBuilder.addHeader(entry.getKey(), entry.getValue());

--- a/mobile/src/test/java/org/openhab/habdroid/core/connection/DefaultConnectionTest.java
+++ b/mobile/src/test/java/org/openhab/habdroid/core/connection/DefaultConnectionTest.java
@@ -154,7 +154,7 @@ public class DefaultConnectionTest {
 
     @Test
     public void testSyncResolveRelativeUrl() {
-        SyncHttpClient.HttpResult result = testConnection.getSyncHttpClient().get("/rest/test");
+        SyncHttpClient.HttpResult result = testConnection.getSyncHttpClient().get("rest/test");
         assertFalse("The request should never succeed in tests", result.isSuccessful());
         assertEquals(TEST_BASE_URL + "/rest/test", result.request.url().toString());
         result.close();


### PR DESCRIPTION
Previously those path segments were simply stripped off, so a base URL
in the form 'http://server.domain/some/path' with the endpoint
'/rest/bindings' became 'http://server.domain/rest/bindings'.
As the newly called method interprets a trailing slash in the URL as an
empty path segment, we have to strip off those trailing slashes from the
passed-in URLs, so that the example above resolves to
'http://server.domain/some/path/rest/bindings'.

Fixes issue reported at https://community.openhab.org/t/version-2-1-0-broken-wrong-url/43999