### PR TITLE
Move versionCode and versionName to build.gradle file

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -31,6 +31,8 @@ android {
         applicationId "org.openhab.habdroid"
         minSdkVersion 14
         targetSdkVersion 25
+        versionCode 53
+        versionName "2.1.4-beta"
         multiDexEnabled true
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.openhab.habdroid"
-    android:versionCode="53"
-    android:versionName="2.1.4-beta" >
+    package="org.openhab.habdroid">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/travis/bump-versioncode.sh
+++ b/travis/bump-versioncode.sh
@@ -8,9 +8,9 @@ then
     exit 1
 fi
 
-manifest="mobile/src/main/AndroidManifest.xml"
+gradle_file="mobile/build.gradle"
 
-currentVersionCode=$(grep 'android:versionCode' $manifest | sed -r 's/(.*)"(.*)"/\2/')
+currentVersionCode=$(grep 'versionCode' $gradle_file | sed -r 's/(.*) (.*)$/\2/')
 let currentVersionCode++
 
 if [ -z "$TRAVIS_TAG" ]
@@ -27,7 +27,7 @@ else
     TRAVIS_TAG="${TRAVIS_TAG%-release}"
     echo "New version code is $currentVersionCode and name $TRAVIS_TAG"
     echo "Replace versionCode"
-    sed --in-place -r "s/android:versionCode=\"(.*)\"/android:versionCode=\"${currentVersionCode}\"/" $manifest
+    sed --in-place -r "s/versionCode (.*)/versionCode ${currentVersionCode}/" $gradle_file
     echo "Replace versionName"
-    sed --in-place -r "s/android:versionName=\"(.*)\"/android:versionName=\"${TRAVIS_TAG}\"/" $manifest
+    sed --in-place -r "s/versionName \"(.*)\"/versionName \"${TRAVIS_TAG}\"/" $gradle_file
 fi

--- a/travis/uploads.sh
+++ b/travis/uploads.sh
@@ -20,7 +20,7 @@ fi
 git config --local user.name "openhab-bot"
 git config --local user.email "bot@openhab.org"
 echo "Git add"
-git add fastlane/metadata/* "mobile/src/main/AndroidManifest.xml"
+git add fastlane/metadata/* "mobile/build.gradle"
 echo "Git commit"
 git commit -m "Bump version to $TRAVIS_TAG and update fastlane metadata"
 echo "Git tag"


### PR DESCRIPTION
With the previous setup F-Droid isn't able to pick up beta builds as it
needs versionName, versionCode and applicationId in one file.

See https://gitlab.com/fdroid/fdroiddata/issues/1196

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>