### PR TITLE
 Add note about privacy policy

### DIFF
--- a/assets/store_descriptions/en-US/strings.xml
+++ b/assets/store_descriptions/en-US/strings.xml
@@ -27,7 +27,7 @@
     <short_description>openHAB client for Android</short_description>
     <fdroid>The builds on F-Droid have map view support, GCM and crash reporting removed and will not be able to receive push notifications from openHAB Cloud.</fdroid>
     <fdroid_beta>You can install the beta version alongside the stable version: [[org.openhab.habdroid]]</fdroid_beta>
-    <fdroid_privacy_policy>Privacy policy: http://www.openhabfoundation.org/privacy</fdroid_privacy_policy>
+    <fdroid_privacy_policy>Privacy policy: https://www.openhabfoundation.org/privacy</fdroid_privacy_policy>
     <fdroid_anti_features>Anti Features</fdroid_anti_features>
     <fdroid_anti_features_text>The app is flagged with the "NonFreeAsset" flag, because the openHAB icon is not under a free license.</fdroid_anti_features_text>
 </strings>

--- a/assets/store_descriptions/en-US/strings.xml
+++ b/assets/store_descriptions/en-US/strings.xml
@@ -27,4 +27,7 @@
     <short_description>openHAB client for Android</short_description>
     <fdroid>The builds on F-Droid have map view support, GCM and crash reporting removed and will not be able to receive push notifications from openHAB Cloud.</fdroid>
     <fdroid_beta>You can install the beta version alongside the stable version: [[org.openhab.habdroid]]</fdroid_beta>
+    <fdroid_privacy_policy>Privacy policy: http://www.openhabfoundation.org/privacy</fdroid_privacy_policy>
+    <fdroid_anti_features>Anti Features</fdroid_anti_features>
+    <fdroid_anti_features_text>The app is flagged with the "NonFreeAsset" flag, because the openHAB icon is not under a free license.</fdroid_anti_features_text>
 </strings>

--- a/assets/store_descriptions/generate_and_validate.py
+++ b/assets/store_descriptions/generate_and_validate.py
@@ -58,6 +58,10 @@ for file in stringsFiles:
     fullDescription += getString('translation') + "\n\n"
     fullDescription += "<b>" + getString('foundation') + "</b>\n\n"
     fullDescription += getString('about_foundation') + "\n"
+    if "fdroid" in sys.argv[1]:
+        fullDescription += "<b>" + getString('fdroid_anti_features') + "</b>\n\n"
+        fullDescription += getString('fdroid_anti_features_text') + "\n\n\n"
+        fullDescription += getString('fdroid_privacy_policy')
 
     if len(fullDescription) > 4000:
         print("Full description of " + lang + " is too long: " + str(len(fullDescription)) + " chars")

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
@@ -182,7 +182,7 @@ public class AboutActivity extends AppCompatActivity implements
             appCard.addItem(new MaterialAboutActionItem.Builder()
                     .text(R.string.about_privacy_policy)
                     .icon(R.drawable.ic_security_grey_24dp)
-                    .setOnClickAction(MaterialAboutItemOnClickRedirect("http://www.openhabfoundation.org/privacy"))
+                    .setOnClickAction(MaterialAboutItemOnClickRedirect("https://www.openhabfoundation.org/privacy"))
                     .build());
 
             MaterialAboutCard.Builder ohServerCard = new MaterialAboutCard.Builder();
@@ -251,7 +251,7 @@ public class AboutActivity extends AppCompatActivity implements
             ohCommunityCard.addItem(new MaterialAboutActionItem.Builder()
                     .text(R.string.about_foundation)
                     .icon(R.drawable.ic_people_grey_24dp)
-                    .setOnClickAction(MaterialAboutItemOnClickRedirect("http://www.openhabfoundation.org/"))
+                    .setOnClickAction(MaterialAboutItemOnClickRedirect("https://www.openhabfoundation.org/"))
                     .build());
 
             return new MaterialAboutList.Builder()

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
@@ -179,6 +179,11 @@ public class AboutActivity extends AppCompatActivity implements
                         }
                     })
                     .build());
+            appCard.addItem(new MaterialAboutActionItem.Builder()
+                    .text(R.string.about_privacy_policy)
+                    .icon(R.drawable.ic_security_grey_24dp)
+                    .setOnClickAction(MaterialAboutItemOnClickRedirect("http://www.openhabfoundation.org/privacy"))
+                    .build());
 
             MaterialAboutCard.Builder ohServerCard = new MaterialAboutCard.Builder();
             ohServerCard.title(R.string.about_server);

--- a/mobile/src/main/res/drawable/ic_security_grey_24dp.xml
+++ b/mobile/src/main/res/drawable/ic_security_grey_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#9E9E9E"
+        android:pathData="M12,1L3,5v6c0,5.55 3.84,10.74 9,12 5.16,-1.26 9,-6.45 9,-12L21,5l-9,-4zM12,11.99h7c-0.53,4.12 -3.28,7.79 -7,8.94L12,12L5,12L5,6.3l7,-3.11v8.8z"/>
+</vector>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -163,6 +163,7 @@
     <string name="about_community">openHAB community</string>
     <string name="about_server">openHAB server</string>
     <string name="about_translation">Help us translating openHAB</string>
+    <string name="about_privacy_policy">Privacy policy</string>
 
     <string name="settings_debug_messages_summary">Passwords will be shown in clear text!</string>
     <string name="settings_debug_messages_title">Show debug messages</string>


### PR DESCRIPTION
## In-app
A link to the privacy policy has been added to the about page:
![screenshot_2018-05-15-16-56-26](https://user-images.githubusercontent.com/22525368/40065591-6e01b8b0-5862-11e8-929c-535647d223f0.png)

## F-Droid
In the Play Store it is possible to add a link to the privacy policy as
metadata, but in F-Droid you cannot, so we have to add it to the
description.

The note about the anti features is nice to have. It explains why the
app entry contains the line "The app has features you may not like."


@kaikreuzer Can I use https for all links to openhabfoundation.org?