### PR TITLE
Add beta note to play store description

### DIFF
--- a/assets/store_descriptions/en-US/strings.xml
+++ b/assets/store_descriptions/en-US/strings.xml
@@ -30,4 +30,6 @@
     <fdroid_privacy_policy>Privacy policy: https://www.openhabfoundation.org/privacy</fdroid_privacy_policy>
     <fdroid_anti_features>Anti Features</fdroid_anti_features>
     <fdroid_anti_features_text>The app is flagged with the "NonFreeAsset" flag, because the openHAB icon is not under a free license.</fdroid_anti_features_text>
+    <beta>Try out new features and give early feedback!</beta>
+    <play_beta>You can install the beta version alongside the stable version.</play_beta>
 </strings>

--- a/assets/store_descriptions/generate_and_validate.py
+++ b/assets/store_descriptions/generate_and_validate.py
@@ -37,7 +37,11 @@ for file in stringsFiles:
         fullDescription += getString('fdroid') + "\n\n"
     elif sys.argv[1] == "fdroidBeta":
         fullDescription += getString('fdroid') + "\n"
+        fullDescription += getString('beta') + "\n"
         fullDescription += getString('fdroid_beta') + "\n\n"
+    elif sys.argv[1] == "playBeta":
+        fullDescription += getString('beta') + "\n"
+        fullDescription += getString('play_beta') + "\n\n"
     fullDescription += "<b>" + getString('important_note') + "</b>\n\n"
     fullDescription += getString('oh_server') + "\n\n"
     fullDescription += getString('whatis') + "\n"
@@ -59,7 +63,7 @@ for file in stringsFiles:
     fullDescription += "<b>" + getString('foundation') + "</b>\n\n"
     fullDescription += getString('about_foundation') + "\n"
     if "fdroid" in sys.argv[1]:
-        fullDescription += "<b>" + getString('fdroid_anti_features') + "</b>\n\n"
+        fullDescription += "\n<b>" + getString('fdroid_anti_features') + "</b>\n\n"
         fullDescription += getString('fdroid_anti_features_text') + "\n\n\n"
         fullDescription += getString('fdroid_privacy_policy')
 

--- a/assets/store_descriptions/generate_and_validate.py
+++ b/assets/store_descriptions/generate_and_validate.py
@@ -70,12 +70,12 @@ for file in stringsFiles:
         fullDescription += getString('fdroid_privacy_policy')
 
     if len(fullDescription) > 4000:
-        print("Full description of " + lang + " is too long: " + str(len(fullDescription)) + " chars")
+        print("Full description of " + lang + " is too long: " + str(len(fullDescription)) + " > 4000 chars")
         exitCode += 1
 
     shortDescription = getString('short_description')
     if len(shortDescription) > 80:
-        print("Short description of " + lang + " is too long: " + str(len(shortDescription)) + " chars")
+        print("Short description of " + lang + " is too long: " + str(len(shortDescription)) + " > 80 chars")
         exitCode += 1
 
 
@@ -94,7 +94,7 @@ for file in stringsFiles:
     if intro != getEnglishString('intro'):
         playDevSiteDescription += lang + ": " + intro + "\n"
         if len(intro) > 140:
-            print("Intro string of " + lang + " is too long: " + str(len(getString('intro'))) + " chars")
+            print("Intro string of " + lang + " is too long: " + str(len(getString('intro'))) + " > 140 chars")
             exitCode += 1
 
 print("\n\n" + playDevSiteDescription)

--- a/assets/store_descriptions/generate_and_validate.py
+++ b/assets/store_descriptions/generate_and_validate.py
@@ -25,6 +25,8 @@ def getString(key):
         string = getEnglishString(key)
     return(string)
 
+playDevSiteDescription = "Play Store developer site description:\n"
+
 stringsFiles = glob.glob('assets/store_descriptions/*/strings.xml')
 for file in stringsFiles:
     tree = ET.parse(file)
@@ -73,8 +75,9 @@ for file in stringsFiles:
 
     shortDescription = getString('short_description')
     if len(shortDescription) > 80:
-        print("Short description of " + lang + " is too long: " + str(len(fullDescription)) + " chars")
+        print("Short description of " + lang + " is too long: " + str(len(shortDescription)) + " chars")
         exitCode += 1
+
 
     newpath = r'fastlane/metadata/android/' + lang + '/'
     if not os.path.exists(newpath):
@@ -87,4 +90,12 @@ for file in stringsFiles:
     f.write(shortDescription)
     f.close()
 
+    intro = getString('intro')
+    if intro != getEnglishString('intro'):
+        playDevSiteDescription += lang + ": " + intro + "\n"
+        if len(intro) > 140:
+            print("Intro string of " + lang + " is too long: " + str(len(getString('intro'))) + " chars")
+            exitCode += 1
+
+print("\n\n" + playDevSiteDescription)
 exit(exitCode)


### PR DESCRIPTION
See https://github.com/openhab/openhab-android/issues/403#issuecomment-389934693

@kaikreuzer @digitaldan I created a developer page in the play store. It's basicly an image and website link added to the [default app listing](https://play.google.com/store/apps/developer?id=Twitter,+Inc.) of our apps.
For the preview I have taken an image from mysplash, so we don't have to credit the author and can use it for free: https://play.google.com/store/apps/dev?id=7475306295333689578 I think the usage of the openHAB logo for this image would be an over-use of it.