### PR TITLE
Update short description

### DIFF
--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-openHAB client for Android
+Home Automation client


### PR DESCRIPTION
The short description shows up in F-Droid as:

openHAB - openHAB client for Android

It's more useful to describe what the application is.