### PR TITLE
Update short description

### DIFF
--- a/assets/store_descriptions/en-US/strings.xml
+++ b/assets/store_descriptions/en-US/strings.xml
@@ -24,7 +24,7 @@
     <about_foundation>The openHAB Foundation e.V. is a nonprofit organization with the mission to educate the public about the possibilities and benefits of free and open smart home solutions. Learn about the mission and the services of the foundation under https://www.openhabfoundation.org</about_foundation>
     <important_note>Important note</important_note>
     <oh_server>You need an openHAB server for this app</oh_server>
-    <short_description>openHAB client for Android</short_description>
+    <short_description>Home Automation client</short_description>
     <fdroid>The builds on F-Droid have map view support, GCM and crash reporting removed and will not be able to receive push notifications from openHAB Cloud.</fdroid>
     <fdroid_beta>You can install the beta version alongside the stable version: [[org.openhab.habdroid]]</fdroid_beta>
     <fdroid_privacy_policy>Privacy policy: https://www.openhabfoundation.org/privacy</fdroid_privacy_policy>

--- a/assets/store_descriptions/en-US/strings.xml
+++ b/assets/store_descriptions/en-US/strings.xml
@@ -24,7 +24,7 @@
     <about_foundation>The openHAB Foundation e.V. is a nonprofit organization with the mission to educate the public about the possibilities and benefits of free and open smart home solutions. Learn about the mission and the services of the foundation under https://www.openhabfoundation.org</about_foundation>
     <important_note>Important note</important_note>
     <oh_server>You need an openHAB server for this app</oh_server>
-    <short_description>Home Automation client</short_description>
+    <short_description>Vendor and technology agnostic open source home automation</short_description>
     <fdroid>The builds on F-Droid have map view support, GCM and crash reporting removed and will not be able to receive push notifications from openHAB Cloud.</fdroid>
     <fdroid_beta>You can install the beta version alongside the stable version: [[org.openhab.habdroid]]</fdroid_beta>
     <fdroid_privacy_policy>Privacy policy: https://www.openhabfoundation.org/privacy</fdroid_privacy_policy>


### PR DESCRIPTION
As a replacement for #881, update the description in the source rather than the intermediary file.

As noted in the original PR, the short description shows up in F-Droid as:

openHAB - openHAB client for Android

It's more useful to describe what the application is.