### PR TITLE
Remove unneeded try catch in voice command funtionality

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHABVoiceService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHABVoiceService.java
@@ -53,7 +53,7 @@ public class OpenHABVoiceService extends IntentService {
         try {
             connection = ConnectionFactory.getUsableConnection();
         } catch (ConnectionException e) {
-            Log.w(TAG, "Couldn't determine OpenHAB URL", e);
+            Log.w(TAG, "Couldn't determine openHAB URL", e);
         }
 
         if (connection != null) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -1020,16 +1020,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements
         speechIntent.putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1);
         speechIntent.putExtra(RecognizerIntent.EXTRA_RESULTS_PENDINGINTENT, openhabPendingIntent);
 
-        try {
-            startActivity(speechIntent);
-        } catch(ActivityNotFoundException e) {
-            // Speech not installed?
-            // todo url doesnt seem to work anymore
-            // not sure, if this is called
-            Intent browserIntent = new Intent(Intent.ACTION_VIEW,
-                    Uri.parse("https://market.android.com/details?id=com.google.android.voicesearch"));
-            startActivity(browserIntent);
-        }
+        startActivity(speechIntent);
     }
 
     public void showRefreshHintSnackbarIfNeeded() {


### PR DESCRIPTION
In line 897 it's checked wheter a speech recognizer is available. If
it's not the mic icon is hidden, so launchVoiceRecognition() cannot be
called.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>