### PR TITLE
Change svg height/width to "100%"

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/util/AsyncHttpClient.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/AsyncHttpClient.java
@@ -84,6 +84,9 @@ public class AsyncHttpClient extends HttpClient {
             double width = viewBox != null ? viewBox.width() : mDefaultSize;
             double height = viewBox != null ? viewBox.height() : mDefaultSize;
 
+            svg.setDocumentHeight("100%");
+            svg.setDocumentWidth("100%");
+
             Bitmap bitmap = Bitmap.createBitmap(
                     (int) Math.ceil(width), (int) Math.ceil(height), Bitmap.Config.ARGB_8888);
             Canvas canvas = new Canvas(bitmap);


### PR DESCRIPTION
Otherwise the icons are cut when their height/width is higher than the
viewbox.

Fixes #728

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>