### PR TITLE
Use HTML link in F-Droid description

### DIFF
--- a/assets/store_descriptions/en-US/strings.xml
+++ b/assets/store_descriptions/en-US/strings.xml
@@ -26,7 +26,7 @@
     <oh_server>You need an openHAB server for this app</oh_server>
     <short_description>Vendor and technology agnostic open source home automation</short_description>
     <fdroid>The builds on F-Droid have map view support, GCM and crash reporting removed and will not be able to receive push notifications from openHAB Cloud.</fdroid>
-    <fdroid_beta>You can install the beta version alongside the stable version: [[org.openhab.habdroid]]</fdroid_beta>
+    <fdroid_beta>You can install the beta version alongside the <a href="https://f-droid.org/packages/org.openhab.habdroid/">stable version</a>.</fdroid_beta>
     <fdroid_privacy_policy>Privacy policy: https://www.openhabfoundation.org/privacy</fdroid_privacy_policy>
     <fdroid_anti_features>Anti Features</fdroid_anti_features>
     <fdroid_anti_features_text>The app is flagged with the "NonFreeAsset" flag, because the openHAB icon is not under a free license.</fdroid_anti_features_text>


### PR DESCRIPTION
Links with F-Droid syntax don't work when the metadata is in the app repo. See https://gitlab.com/fdroid/fdroiddata/issues/1222

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>