### PR TITLE
Improve error message when oh is offline, but cloud is running

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -1047,12 +1047,16 @@ public class OpenHABMainActivity extends AppCompatActivity implements
         Log.e(TAG, "HTTP status code: " + statusCode);
         CharSequence message;
         if (statusCode >= 400){
-            int resourceID;
-            try {
-                resourceID = getResources().getIdentifier("error_http_code_" + statusCode, "string", getPackageName());
-                message = getString(resourceID);
-            } catch (android.content.res.Resources.NotFoundException e) {
-                message = String.format(getString(R.string.error_http_connection_failed), statusCode);
+            if (error.getMessage().equals("openHAB is offline")) {
+                message = getString(R.string.error_openhab_offline);
+            } else {
+                int resourceID;
+                try {
+                    resourceID = getResources().getIdentifier("error_http_code_" + statusCode, "string", getPackageName());
+                    message = getString(resourceID);
+                } catch (android.content.res.Resources.NotFoundException e) {
+                    message = String.format(getString(R.string.error_http_connection_failed), statusCode);
+                }
             }
         } else if (error instanceof UnknownHostException) {
             Log.e(TAG, "Unable to resolve hostname");

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="error_http_code_511">Network authentication is required (HTTP response code 511)</string>
     <string name="error_about_no_conn">Error while fetching openHAB server information</string>
     <string name="error_cleartext_not_permitted">HTTP is not allowed for this server</string>
+    <string name="error_openhab_offline">Your openHAB server is offline while the cloud instance is running</string>
     <string name="title_activity_openhabwritetag">Write NFC tag</string>
     <string name="title_activity_libraries">Used libraries</string>
     <string name="info_write_tag">Touch the tag and keep it close until the confirmation message appear</string>


### PR DESCRIPTION
See #935

I've checked the openhab cloud sources and couldn't find any similar code where the error is created by openhab cloud: https://github.com/openhab/openhab-cloud/blob/master/routes/index.js#L347