### PR TITLE
Disable backups

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -16,8 +16,7 @@
         android:required="false" />
 
     <application
-        android:allowBackup="true"
-        android:fullBackupContent="true"
+        android:allowBackup="false"
         android:icon="@mipmap/icon"
         android:label="@string/app_name"
         android:resizeableActivity="true"


### PR DESCRIPTION
Nothing is excluded from the backups, so the username and even the
password would be uploaded to Google Drive. Thus I'm disabling the
backups and we might want to enable it again when the url, user and
password settings are moved to a database.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>