### PR TITLE
Revert "Use networkSecurityConfig to disallow http to myopenhab.org" (#908)

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -23,8 +23,7 @@
         android:supportsPictureInPicture="false"
         android:theme="@style/HABDroid.Light"
         android:supportsRtl="true"
-        android:name=".core.OpenHABApplication"
-        android:networkSecurityConfig="@xml/network_security_config">
+        android:name=".core.OpenHABApplication">
         <activity
             android:name="org.openhab.habdroid.ui.OpenHABPreferencesActivity"
             android:label="@string/app_preferences_name">

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -90,7 +90,6 @@ import java.lang.reflect.Constructor;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
-import java.net.UnknownServiceException;
 import java.nio.charset.Charset;
 import java.security.cert.CertPathValidatorException;
 import java.security.cert.CertificateExpiredException;
@@ -1078,8 +1077,6 @@ public class OpenHABMainActivity extends AppCompatActivity implements
             }
         } else if (error instanceof ConnectException || error instanceof SocketTimeoutException) {
             message = getString(R.string.error_connection_failed);
-        } else if (error instanceof UnknownServiceException) {
-            message = getString(R.string.error_cleartext_not_permitted);
         } else {
             Log.e(TAG, "REST call to " + request.url() + " failed", error);
             message = error.getMessage();

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -100,7 +100,6 @@
     <string name="error_http_code_507">The openHAB server hasn\'t enough free space (HTTP response code 507)</string>
     <string name="error_http_code_511">Network authentication is required (HTTP response code 511)</string>
     <string name="error_about_no_conn">Error while fetching openHAB server information</string>
-    <string name="error_cleartext_not_permitted">HTTP is not allowed for this server</string>
     <string name="error_openhab_offline">Your openHAB server is offline while the cloud instance is running</string>
     <string name="title_activity_openhabwritetag">Write NFC tag</string>
     <string name="title_activity_libraries">Used libraries</string>

--- a/mobile/src/main/res/xml/network_security_config.xml
+++ b/mobile/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-    <domain-config cleartextTrafficPermitted="false">
-        <domain includeSubdomains="true">myopenhab.org</domain>
-    </domain-config>
-</network-security-config>


### PR DESCRIPTION
Adding a security config requires our trust manager implementation to
implement the variant of checkServerTrusted() that accepts a host name,
but we can't provide that hostname from within MTM.

This reverts commit ac986b18f8c94336f333611b95021cefdc035fa2.

Fixes #937