### PR TITLE
Use %d instead of 1 in plurals strings

### DIFF
--- a/mobile/src/full/res/values/strings.xml
+++ b/mobile/src/full/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="notification_channel_severity_value">Severity \'%1$s\'</string>
 
     <plurals name="summary_notification_text">
-        <item quantity="one">1 new notification</item>
+        <item quantity="one">%d new notification</item>
         <item quantity="other">%d new notifications</item>
     </plurals>
 </resources>


### PR DESCRIPTION
> Always include %d in "one" because translators will need to use
> %d for languages where "one" doesn't mean 1 (as explained above)

from https://developer.android.com/guide/topics/resources/string-resource#Plurals

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>

I've tested this in English and it works like before, but I haven't tested it in a language where it makes a difference, e.g. Russian.