### PR TITLE
Fix wrong icons being loaded if views are re-used

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.java
@@ -115,6 +115,9 @@ public class WidgetImageView extends AppCompatImageView {
         }
 
         cancelCurrentLoad();
+        // Make sure to discard last request (which was for a different URL) to ensure
+        // it's not re-triggered later, e.g. when being attached to the window
+        mLastRequest = null;
 
         if (actualUrl == null) {
             applyFallbackDrawable();


### PR DESCRIPTION
There's a condition where widget icons are loaded incorrectly:
- Have a WidgetImageView which just loaded an icon
- Go to another page (previous views are detached)
- Go back to initial page (previous views are reattached, but not
  necessarily in the same spot)
In step 3 of that scenario, views are likely to use a cached bitmap
instead of loading them again, in which case mLastRequest isn't properly
cleared out and re-triggered later when onAttachedToWindow() is called.
As the request points to the URL of the last spot, the wrong icon is
loaded in that case. Fix this by properly clearing out the last request
when assigning a new URL.

Fixes #955 