### PR TITLE
Convert GcmRegistrationService to a JobIntentService.

### DIFF
--- a/mobile/src/full/AndroidManifest.xml
+++ b/mobile/src/full/AndroidManifest.xml
@@ -32,7 +32,7 @@
 
         <service
             android:name="org.openhab.habdroid.core.GcmRegistrationService"
-            android:exported="false" />
+            android:permission="android.permission.BIND_JOB_SERVICE" />
 
         <meta-data
             android:name="com.google.android.gms.version"

--- a/mobile/src/full/AndroidManifest.xml
+++ b/mobile/src/full/AndroidManifest.xml
@@ -14,6 +14,13 @@
             </intent-filter>
         </receiver>
 
+        <receiver
+            android:name="org.openhab.habdroid.core.GcmRegistrationService$ProxyReceiver">
+            <intent-filter>
+                <action android:name="org.openhab.habdroid.action.HIDE_NOTIFICATION" />
+            </intent-filter>
+        </receiver>
+
         <service
             android:name="org.openhab.habdroid.core.GcmMessageListenerService"
             android:exported="false">

--- a/mobile/src/full/java/org/openhab/habdroid/core/CloudMessagingHelper.java
+++ b/mobile/src/full/java/org/openhab/habdroid/core/CloudMessagingHelper.java
@@ -12,6 +12,7 @@ package org.openhab.habdroid.core;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.StringRes;
+import android.support.v4.app.JobIntentService;
 
 import org.openhab.habdroid.R;
 import org.openhab.habdroid.core.connection.CloudConnection;
@@ -27,7 +28,7 @@ public class CloudMessagingHelper {
         if (connection != null) {
             Intent intent = new Intent(context, GcmRegistrationService.class)
                     .setAction(GcmRegistrationService.ACTION_REGISTER);
-            context.startService(intent);
+            JobIntentService.enqueueWork(context, GcmRegistrationService.class, 1, intent);
         }
     }
 

--- a/mobile/src/full/java/org/openhab/habdroid/core/CloudMessagingHelper.java
+++ b/mobile/src/full/java/org/openhab/habdroid/core/CloudMessagingHelper.java
@@ -12,7 +12,6 @@ package org.openhab.habdroid.core;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.StringRes;
-import android.support.v4.app.JobIntentService;
 
 import org.openhab.habdroid.R;
 import org.openhab.habdroid.core.connection.CloudConnection;
@@ -26,19 +25,14 @@ public class CloudMessagingHelper {
     public static void onConnectionUpdated(Context context, CloudConnection connection) {
         sRegistrationDone = false;
         if (connection != null) {
-            Intent intent = new Intent(context, GcmRegistrationService.class)
-                    .setAction(GcmRegistrationService.ACTION_REGISTER);
-            JobIntentService.enqueueWork(context, GcmRegistrationService.class, 1, intent);
+            GcmRegistrationService.scheduleRegistration(context);
         }
     }
 
     public static void onNotificationSelected(Context context, Intent intent) {
         int notificationId = intent.getIntExtra(GcmMessageListenerService.EXTRA_NOTIFICATION_ID, -1);
         if (notificationId >= 0) {
-            Intent serviceIntent = new Intent(context, GcmRegistrationService.class)
-                    .setAction(GcmRegistrationService.ACTION_HIDE_NOTIFICATION)
-                    .putExtra(GcmRegistrationService.EXTRA_NOTIFICATION_ID, notificationId);
-            context.startService(serviceIntent);
+            GcmRegistrationService.scheduleHideNotification(context, notificationId);
         }
     }
 

--- a/mobile/src/full/java/org/openhab/habdroid/core/GcmInstanceIDListenerService.java
+++ b/mobile/src/full/java/org/openhab/habdroid/core/GcmInstanceIDListenerService.java
@@ -9,15 +9,11 @@
 
 package org.openhab.habdroid.core;
 
-import android.content.Intent;
-
 import com.google.android.gms.iid.InstanceIDListenerService;
 
 public class GcmInstanceIDListenerService extends InstanceIDListenerService {
     @Override
     public void onTokenRefresh() {
-        Intent intent = new Intent(this, GcmRegistrationService.class)
-                .setAction(GcmRegistrationService.ACTION_REGISTER);
-        startService(intent);
+        GcmRegistrationService.scheduleRegistration(this);
     }
 }

--- a/mobile/src/full/java/org/openhab/habdroid/core/GcmMessageListenerService.java
+++ b/mobile/src/full/java/org/openhab/habdroid/core/GcmMessageListenerService.java
@@ -116,12 +116,6 @@ public class GcmMessageListenerService extends GcmListenerService {
                 contentIntent, PendingIntent.FLAG_UPDATE_CURRENT);
     }
 
-    private PendingIntent makeDeleteIntent(int notificationId) {
-        return PendingIntent.getService(this, notificationId,
-                GcmRegistrationService.createHideNotificationIntent(this, notificationId),
-                PendingIntent.FLAG_UPDATE_CURRENT);
-    }
-
     private Notification makeNotification(String msg, String channelId, String icon,
                 long timestamp, String persistedId, int notificationId) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
@@ -155,7 +149,7 @@ public class GcmMessageListenerService extends GcmListenerService {
                 .setSound(Uri.parse(toneSetting))
                 .setContentText(msg)
                 .setContentIntent(contentIntent)
-                .setDeleteIntent(makeDeleteIntent(notificationId))
+                .setDeleteIntent(GcmRegistrationService.createHideNotificationIntent(this, notificationId))
                 .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
                 .setPublicVersion(publicVersion)
                 .build();
@@ -178,7 +172,7 @@ public class GcmMessageListenerService extends GcmListenerService {
                 .setContentText(text)
                 .setPublicVersion(publicVersion)
                 .setContentIntent(clickIntent)
-                .setDeleteIntent(makeDeleteIntent(SUMMARY_NOTIFICATION_ID))
+                .setDeleteIntent(GcmRegistrationService.createHideNotificationIntent(this, SUMMARY_NOTIFICATION_ID))
                 .build();
     }
 

--- a/mobile/src/full/java/org/openhab/habdroid/core/GcmMessageListenerService.java
+++ b/mobile/src/full/java/org/openhab/habdroid/core/GcmMessageListenerService.java
@@ -117,12 +117,9 @@ public class GcmMessageListenerService extends GcmListenerService {
     }
 
     private PendingIntent makeDeleteIntent(int notificationId) {
-        Intent deleteIntent = new Intent(this, GcmRegistrationService.class)
-                .setAction(GcmRegistrationService.ACTION_HIDE_NOTIFICATION)
-                .putExtra(GcmRegistrationService.EXTRA_NOTIFICATION_ID, notificationId);
-
         return PendingIntent.getService(this, notificationId,
-                deleteIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                GcmRegistrationService.createHideNotificationIntent(this, notificationId),
+                PendingIntent.FLAG_UPDATE_CURRENT);
     }
 
     private Notification makeNotification(String msg, String channelId, String icon,

--- a/mobile/src/full/java/org/openhab/habdroid/core/GcmRegistrationService.java
+++ b/mobile/src/full/java/org/openhab/habdroid/core/GcmRegistrationService.java
@@ -9,12 +9,12 @@
 
 package org.openhab.habdroid.core;
 
-import android.app.IntentService;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
-import android.support.annotation.Nullable;
+import android.support.annotation.NonNull;
+import android.support.v4.app.JobIntentService;
 import android.util.Log;
 
 import com.google.android.gms.gcm.GoogleCloudMessaging;
@@ -29,19 +29,15 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.util.Locale;
 
-public class GcmRegistrationService extends IntentService {
+public class GcmRegistrationService extends JobIntentService {
     private static final String TAG = GcmRegistrationService.class.getSimpleName();
 
     static final String ACTION_REGISTER = "org.openhab.habdroid.action.REGISTER_GCM";
     static final String ACTION_HIDE_NOTIFICATION = "org.openhab.habdroid.action.HIDE_NOTIFICATION";
     static final String EXTRA_NOTIFICATION_ID = "notificationId";
 
-    public GcmRegistrationService() {
-        super("GcmRegistrationService");
-    }
-
     @Override
-    protected void onHandleIntent(@Nullable Intent intent) {
+    protected void onHandleWork(@NonNull Intent intent) {
         ConnectionFactory.waitForInitialization();
         CloudConnection connection =
                 (CloudConnection) ConnectionFactory.getConnection(Connection.TYPE_CLOUD);

--- a/mobile/src/full/java/org/openhab/habdroid/core/GcmRegistrationService.java
+++ b/mobile/src/full/java/org/openhab/habdroid/core/GcmRegistrationService.java
@@ -9,6 +9,7 @@
 
 package org.openhab.habdroid.core;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
@@ -32,9 +33,28 @@ import java.util.Locale;
 public class GcmRegistrationService extends JobIntentService {
     private static final String TAG = GcmRegistrationService.class.getSimpleName();
 
-    static final String ACTION_REGISTER = "org.openhab.habdroid.action.REGISTER_GCM";
-    static final String ACTION_HIDE_NOTIFICATION = "org.openhab.habdroid.action.HIDE_NOTIFICATION";
-    static final String EXTRA_NOTIFICATION_ID = "notificationId";
+    private static final int JOB_ID = 1000;
+
+    private static final String ACTION_REGISTER = "org.openhab.habdroid.action.REGISTER_GCM";
+    private static final String ACTION_HIDE_NOTIFICATION = "org.openhab.habdroid.action.HIDE_NOTIFICATION";
+    private static final String EXTRA_NOTIFICATION_ID = "notificationId";
+
+    static void scheduleRegistration(Context context) {
+        Intent intent = new Intent(context, GcmRegistrationService.class)
+                .setAction(GcmRegistrationService.ACTION_REGISTER);
+        JobIntentService.enqueueWork(context, GcmRegistrationService.class, JOB_ID, intent);
+    }
+
+    static void scheduleHideNotification(Context context, int notificationId) {
+        JobIntentService.enqueueWork(context, GcmRegistrationService.class, JOB_ID,
+                createHideNotificationIntent(context, notificationId));
+    }
+
+    static Intent createHideNotificationIntent(Context context, int notificationId) {
+        return new Intent(context, GcmRegistrationService.class)
+                .setAction(GcmRegistrationService.ACTION_HIDE_NOTIFICATION)
+                .putExtra(GcmRegistrationService.EXTRA_NOTIFICATION_ID, notificationId);
+    }
 
     @Override
     protected void onHandleWork(@NonNull Intent intent) {

--- a/mobile/src/test/java/org/openhab/habdroid/core/CloudMessagingHelper.java
+++ b/mobile/src/test/java/org/openhab/habdroid/core/CloudMessagingHelper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2010-2018, openHAB.org and others.
+ *
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.openhab.habdroid.core;
+
+import android.content.Context;
+import android.content.Intent;
+import android.support.annotation.StringRes;
+
+import org.openhab.habdroid.core.connection.CloudConnection;
+
+public class CloudMessagingHelper {
+    public static void onConnectionUpdated(Context context, CloudConnection connection) {
+    }
+
+    public static void onNotificationSelected(Context context, Intent intent) {
+    }
+
+    public static @StringRes int getPushNotificationStatusResId() {
+        return 0;
+    }
+
+    public static boolean isSupported() {
+        return false;
+    }
+}


### PR DESCRIPTION
Otherwise crashes might occur when app is in the background and
connectivity changes on Android 8+.

Fixes #953

Signed-off-by: Danny Baumann <dannybaumann@web.de>