### PR TITLE
Clear webviews before being re-used

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
@@ -970,6 +970,7 @@ public class OpenHABWidgetAdapter extends RecyclerView.Adapter<OpenHABWidgetAdap
         @SuppressLint("SetJavaScriptEnabled")
         @Override
         public void bind(OpenHABWidget widget) {
+            mWebView.loadUrl("about:blank");
             ViewGroup.LayoutParams lp = mWebView.getLayoutParams();
             int desiredHeightPixels = widget.height() > 0
                     ? widget.height() * mRowHeightPixels : ViewGroup.LayoutParams.WRAP_CONTENT;


### PR DESCRIPTION
Webviews are recycled and need to be cleared before being re-used.
Otherwise the old webview content is shown until the new one is loaded.

Closes #948

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>