### PR TITLE
Add "installLocation" to Manifest

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.openhab.habdroid">
+    package="org.openhab.habdroid"
+    android:installLocation="internalOnly">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -94,8 +95,5 @@
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
-        <!--    This is temp disabled because of a bug in GMS 6.5
-                <meta-data android:name="com.google.android.gms.analytics.globalConfigResource"
-                    android:resource="@xml/global_tracker" /> -->
     </application>
 </manifest>


### PR DESCRIPTION
> Though this does not change the default behavior, it explicitly states that your application should only be installed on the internal storage and serves as a reminder to you and other developers that this decision has been made.

from https://developer.android.com/guide/topics/data/install-location

The removed code has been disabled four years ago and we don't use
Analytics anymore.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>