### PR TITLE
Revert "Remove unneeded try catch in voice command funtionality (#899)"

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -60,6 +60,7 @@ import android.view.View;
 import android.view.ViewStub;
 import android.view.WindowManager;
 import android.widget.ProgressBar;
+import android.widget.Toast;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -1007,14 +1008,13 @@ public class OpenHABMainActivity extends AppCompatActivity implements
 
         try {
             startActivity(speechIntent);
-        } catch (ActivityNotFoundException e) {
-            final String googleAppPackageName = "com.google.android.googlequicksearchbox";
+        } catch (ActivityNotFoundException speechRecognizerNotFoundException) {
             try {
-                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id="
-                        + googleAppPackageName)));
-            } catch (android.content.ActivityNotFoundException anfe) {
-                startActivity(new Intent(Intent.ACTION_VIEW,Uri.parse(
-                        "https://play.google.com/store/apps/details?id=" + googleAppPackageName)));
+                startActivity(new Intent(Intent.ACTION_VIEW,
+                        Uri.parse("market://details?id=com.google.android.googlequicksearchbox")));
+            } catch (ActivityNotFoundException appStoreNotFoundException) {
+                Toast.makeText(this, R.string.error_no_app_store_found,
+                        Toast.LENGTH_LONG).show();
             }
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -12,6 +12,7 @@ package org.openhab.habdroid.ui;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.PendingIntent;
+import android.content.ActivityNotFoundException;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -1004,7 +1005,18 @@ public class OpenHABMainActivity extends AppCompatActivity implements
         speechIntent.putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1);
         speechIntent.putExtra(RecognizerIntent.EXTRA_RESULTS_PENDINGINTENT, openhabPendingIntent);
 
-        startActivity(speechIntent);
+        try {
+            startActivity(speechIntent);
+        } catch (ActivityNotFoundException e) {
+            final String googleAppPackageName = "com.google.android.googlequicksearchbox";
+            try {
+                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id="
+                        + googleAppPackageName)));
+            } catch (android.content.ActivityNotFoundException anfe) {
+                startActivity(new Intent(Intent.ACTION_VIEW,Uri.parse(
+                        "https://play.google.com/store/apps/details?id=" + googleAppPackageName)));
+            }
+        }
     }
 
     public void showRefreshHintSnackbarIfNeeded() {

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -103,6 +103,7 @@
     <string name="error_http_code_511">Network authentication is required (HTTP response code 511)</string>
     <string name="error_about_no_conn">Error while fetching openHAB server information</string>
     <string name="error_openhab_offline">Your openHAB server is offline while the cloud instance is running</string>
+    <string name="error_no_app_store_found">No app store found to install voice recognizer app</string>
     <string name="title_activity_openhabwritetag">Write NFC tag</string>
     <string name="title_activity_libraries">Used libraries</string>
     <string name="info_write_tag">Touch the tag and keep it close until the confirmation message appear</string>


### PR DESCRIPTION
In some case the try catch is needed. See
https://console.firebase.google.com/project/openhab-mobile/crashlytics/app/android:org.openhab.habdroid/issues/5b755c156007d59fcdf12bc8
(only visible to the openHAB staff).
I updated the code to open the Google app in any app store. Some users
might use YALP store or any other custom Play Store (or Amazon app
store). For users without any additional app store the Play Store is opened.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>