### PR TITLE
Don't update sitemap drawer items in activity's onCreate().

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -250,7 +250,6 @@ public class OpenHABMainActivity extends AppCompatActivity implements
                 // via the fragment state restoration.
                 mController.recreateFragmentState();
             }
-            updateSitemapDrawerItems();
             if (savedInstanceState.getBoolean("isSitemapSelectionDialogShown")) {
                 showSitemapSelectionDialog();
             }


### PR DESCRIPTION
They're already correctly handled via onStart() ->
onAvailableConnectionChanged(). As that path also correctly clears the
sitemap list if there's no available connection, there's no reason to
also do the update via onCreate().

Fixes #986 