### PR TITLE
Fix slow chart loading issue

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.java
@@ -74,6 +74,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 
+import static org.openhab.habdroid.util.Constants.PREFERENCE_CHART_HQ;
+
 /**
  * This class provides openHAB widgets adapter for list view.
  */
@@ -870,7 +872,9 @@ public class WidgetAdapter extends RecyclerView.Adapter<WidgetAdapter.ViewHolder
             Item item = widget.item();
 
             if (item != null) {
-                float scalingFactor = mPrefs.getFloat(Constants.PREFERENCE_CHART_SCALING, 1.0f);
+                float scalingFactor = mPrefs.getFloat(Constants.PREFERENCE_CHART_SCALING,
+                        1.0f);
+                boolean requestHighResChart = mPrefs.getBoolean(PREFERENCE_CHART_HQ, true);
                 float actualDensity = (float) mDensity / scalingFactor;
 
                 StringBuilder chartUrl = new StringBuilder("chart?")
@@ -878,7 +882,8 @@ public class WidgetAdapter extends RecyclerView.Adapter<WidgetAdapter.ViewHolder
                         .append(item.name())
                         .append("&period=").append(widget.period())
                         .append("&random=").append(mRandom.nextInt())
-                        .append("&dpi=").append((int) actualDensity);
+                        .append("&dpi=").append(requestHighResChart ? (int) actualDensity :
+                                (int) actualDensity / 2);
                 if (!TextUtils.isEmpty(widget.service())) {
                     chartUrl.append("&service=").append(widget.service());
                 }
@@ -891,8 +896,10 @@ public class WidgetAdapter extends RecyclerView.Adapter<WidgetAdapter.ViewHolder
 
                 int parentWidth = mParentView.getWidth();
                 if (parentWidth > 0) {
-                    chartUrl.append("&w=").append(parentWidth);
-                    chartUrl.append("&h=").append(parentWidth / 2);
+                    chartUrl.append("&w=").append(requestHighResChart ? parentWidth :
+                            parentWidth / 2);
+                    chartUrl.append("&h=").append(requestHighResChart ? parentWidth / 2 :
+                            parentWidth / 4);
                 }
 
                 Log.d(TAG, "Chart url = " + chartUrl);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.java
@@ -883,7 +883,7 @@ public class WidgetAdapter extends RecyclerView.Adapter<WidgetAdapter.ViewHolder
                         .append("&period=").append(widget.period())
                         .append("&random=").append(mRandom.nextInt())
                         .append("&dpi=").append(requestHighResChart ? (int) actualDensity :
-                                (int) actualDensity / 2);
+                        (int) actualDensity / 2);
                 if (!TextUtils.isEmpty(widget.service())) {
                     chartUrl.append("&service=").append(widget.service());
                 }

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
@@ -35,6 +35,7 @@ public class Constants {
     public static final String PREFERENCE_FIRST_START           = "firstStart";
     public static final String PREFERENCE_SWIPE_REFRESH_EXPLAINED = "swipToRefreshExplained";
     public static final String PREFERENCE_CHART_SCALING       = "chartScalingFactor";
+    public static final String PREFERENCE_CHART_HQ            = "default_openhab_chart_hq";
     public static final String PREFERENCE_ICON_FORMAT         = "iconFormatType";
 
     public static final String SUBSCREEN_LOCAL_CONNECTION     = "default_openhab_local_connection";

--- a/mobile/src/main/res/drawable/ic_high_quality_grey_24dp.xml
+++ b/mobile/src/main/res/drawable/ic_high_quality_grey_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#757575"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M19,4L5,4c-1.11,0 -2,0.9 -2,2v12c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,6c0,-1.1 -0.9,-2 -2,-2zM11,15L9.5,15v-2h-2v2L6,15L6,9h1.5v2.5h2L9.5,9L11,9v6zM18,14c0,0.55 -0.45,1 -1,1h-0.75v1.5h-1.5L14.75,15L14,15c-0.55,0 -1,-0.45 -1,-1v-4c0,-0.55 0.45,-1 1,-1h3c0.55,0 1,0.45 1,1v4zM14.5,13.5h2v-3h-2v3z"/>
+</vector>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -48,6 +48,8 @@
     <string name="settings_chart_scaling_value_s">Small</string>
     <string name="settings_chart_scaling_value_m">Default</string>
     <string name="settings_chart_scaling_value_l">Large</string>
+    <string name="settings_openhab_chart_hq">High resolution charts</string>
+    <string name="settings_openhab_chart_hq_summary">Generating charts can be taxing to the server. If you experience slow chart loading times and your server isn\'t powerful, disable this option to improve loading times.</string>
     <string name="settings_ringtone">Notification ringtone</string>
     <string name="settings_ringtone_none">None</string>
     <string name="settings_clear_default_sitemap">Clear default Sitemap</string>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -56,6 +56,12 @@
             android:key="chartScalingFactor"
             android:defaultValue="1.5"
             android:icon="@drawable/ic_forum_grey_24dp" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="default_openhab_chart_hq"
+            android:summary="@string/settings_openhab_chart_hq_summary"
+            android:title="@string/settings_openhab_chart_hq"
+            android:icon="@drawable/ic_high_quality_grey_24dp" />
         <Preference
             android:clickable="true"
             android:key="default_openhab_cleacache"


### PR DESCRIPTION
Fixes #440

This issue can already solved server-side by setting a max width for
charts in Paper UI, but it's not easy to find for the user.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>

@lolodomo Do you want to test this?

Low res. Please note, that my device has a quite low resolution.
![screenshot_2018-10-24-09-13-16](https://user-images.githubusercontent.com/22525368/47413198-efd63480-d76d-11e8-9f26-b5bc4f95fff3.png)

High res:
![screenshot_2018-10-24-09-13-31](https://user-images.githubusercontent.com/22525368/47413199-efd63480-d76d-11e8-8180-9b2d3bde3660.png)

