### PR TITLE
Remove jacoco-android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     repositories {
         mavenCentral()
@@ -8,8 +6,5 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.3'
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
     }
 }

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -18,7 +18,6 @@ buildscript {
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'jacoco-android'
 if(!isFoss) {
     apply plugin: 'io.fabric'
 }


### PR DESCRIPTION
We don't need it, because we don't use CodeCov anymore.
Fixes #1070

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>