### PR TITLE
Fix NullPointerException in Setpoint

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.java
@@ -793,6 +793,10 @@ public class WidgetAdapter extends RecyclerView.Adapter<WidgetAdapter.ViewHolder
 
         @Override
         public void onClick(final View view) {
+            if (mBoundWidget.item() == null) {
+                Log.e(TAG, "mBoundWidget.item() is null");
+                return;
+            }
             float minValue = mBoundWidget.minValue();
             float maxValue = mBoundWidget.maxValue();
             // This prevents an exception below, but could lead to


### PR DESCRIPTION
Fixes

````
java.lang.NullPointerException:
  at org.openhab.habdroid.ui.WidgetAdapter$SetpointViewHolder.onClick (WidgetAdapter.java:819)
  at android.view.View.performClick (View.java:6897)
  at android.view.View$PerformClick.run (View.java:26101)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>