### PR TITLE
Fix NegativeArraySizeException in MjpegInputStream

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/util/MjpegInputStream.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MjpegInputStream.java
@@ -63,6 +63,10 @@ public class MjpegInputStream extends DataInputStream {
         int headerLen = getStartOfSequence(this, SOI_MARKER);
         reset();
 
+        if (headerLen < 0) {
+            return null;
+        }
+
         byte[] header = new byte[headerLen];
         readFully(header);
 
@@ -75,6 +79,10 @@ public class MjpegInputStream extends DataInputStream {
 
         reset();
         skipBytes(headerLen);
+
+        if (contentLength < 0) {
+            return null;
+        }
 
         byte[] frameData = new byte[contentLength];
         readFully(frameData);


### PR DESCRIPTION
`getEndOfSeqeunce()` may return -1 which is an illegal value for array
size.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>