### PR TITLE
Fix NullPointerException in ServerProperties.fetch()

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -297,6 +297,10 @@ public class MainActivity extends AppCompatActivity implements
                 }
             }
         };
+        if (getConnection() == null) {
+            mController.indicateNoNetwork(getString(R.string.error_network_not_available));
+            return;
+        }
         mPropsUpdateHandle = ServerProperties.fetch(mConnection,
                 successCb, this::handlePropertyFetchFailure);
     }


### PR DESCRIPTION
Fixes:

````
java.lang.NullPointerException:

  at org.openhab.habdroid.model.ServerProperties.fetch (ServerProperties.java:94)

  at org.openhab.habdroid.ui.MainActivity.queryServerProperties (MainActivity.java:300)

  at org.openhab.habdroid.ui.MainActivity.retryServerPropertyQuery (MainActivity.java:277)

  at org.openhab.habdroid.ui.activity.ContentController$CommunicationFailureFragment.onClick (ContentController.java:553)

  at android.view.View.performClick (View.java:6291)

  at android.view.View$PerformClick.run (View.java:24931)

  at android.os.Handler.handleCallback (Handler.java:808)

  at android.os.Handler.dispatchMessage (Handler.java:101)

  at android.os.Looper.loop (Looper.java:166)

  at android.app.ActivityThread.main (ActivityThread.java:7425)

  at java.lang.reflect.Method.invoke (Native Method)

  at com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:245)

  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:921)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>