### PR TITLE
Hide notification settings when running Oreo or higher

### DIFF
--- a/mobile/src/full/java/org/openhab/habdroid/core/GcmMessageListenerService.java
+++ b/mobile/src/full/java/org/openhab/habdroid/core/GcmMessageListenerService.java
@@ -73,6 +73,7 @@ public class GcmMessageListenerService extends GcmListenerService {
                     NotificationChannel channel = new NotificationChannel(
                             channelId, name, NotificationManager.IMPORTANCE_DEFAULT);
                     channel.setShowBadge(true);
+                    channel.enableVibration(true);
                     nm.createNotificationChannel(channel);
                 }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.java
@@ -314,7 +314,8 @@ public class PreferencesActivity extends AppCompatActivity {
                 getParent(fullscreenPreference).removePreference(fullscreenPreference);
             }
 
-            if (!CloudMessagingHelper.isSupported() || Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (!CloudMessagingHelper.isSupported()
+                    || Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 Log.d(TAG, "Removing notification prefs");
                 getParent(ringtonePref).removePreference(ringtonePref);
                 getParent(vibrationPref).removePreference(vibrationPref);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.java
@@ -314,8 +314,8 @@ public class PreferencesActivity extends AppCompatActivity {
                 getParent(fullscreenPreference).removePreference(fullscreenPreference);
             }
 
-            if (!CloudMessagingHelper.isSupported()) {
-                Log.d(TAG, "Removing full-only prefs");
+            if (!CloudMessagingHelper.isSupported() || Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                Log.d(TAG, "Removing notification prefs");
                 getParent(ringtonePref).removePreference(ringtonePref);
                 getParent(vibrationPref).removePreference(vibrationPref);
             }


### PR DESCRIPTION
In Oreo or higher Notification channels should be used to change the
notification sound and vibration.

@maniac103 Can you check the vibration setting as I don't have a physical device with O+?