### PR TITLE
Save server properties for later use

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/ServerProperties.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ServerProperties.java
@@ -1,8 +1,6 @@
 package org.openhab.habdroid.model;
 
-import android.content.Context;
 import android.os.Parcelable;
-import android.preference.PreferenceManager;
 import android.util.Log;
 
 import com.google.auto.value.AutoValue;
@@ -13,7 +11,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.openhab.habdroid.core.connection.Connection;
-import org.openhab.habdroid.core.connection.DemoConnection;
 import org.openhab.habdroid.util.AsyncHttpClient;
 import org.openhab.habdroid.util.Util;
 import org.w3c.dom.Document;
@@ -28,8 +25,6 @@ import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-
-import static org.openhab.habdroid.util.Constants.PREV_SERVER_FLAGS;
 
 @AutoValue
 public abstract class ServerProperties implements Parcelable {
@@ -93,16 +88,15 @@ public abstract class ServerProperties implements Parcelable {
     }
 
     public static UpdateHandle fetch(Connection connection,
-            UpdateSuccessCallback successCb, UpdateFailureCallback failureCb, Context context) {
+            UpdateSuccessCallback successCb, UpdateFailureCallback failureCb) {
         final UpdateHandle handle = new UpdateHandle();
         handle.builder = new AutoValue_ServerProperties.Builder();
-        fetchFlags(connection, handle, successCb, failureCb, context);
+        fetchFlags(connection.getAsyncHttpClient(), handle, successCb, failureCb);
         return handle;
     }
 
-    private static void fetchFlags(Connection connection, UpdateHandle handle,
-            UpdateSuccessCallback successCb, UpdateFailureCallback failureCb, Context context) {
-        AsyncHttpClient client = connection.getAsyncHttpClient();
+    private static void fetchFlags(AsyncHttpClient client, UpdateHandle handle,
+            UpdateSuccessCallback successCb, UpdateFailureCallback failureCb) {
         handle.call = client.get("rest", new AsyncHttpClient.StringResponseHandler() {
             @Override
             public void onFailure(Request request, int statusCode, Throwable error) {
@@ -127,19 +121,11 @@ public abstract class ServerProperties implements Parcelable {
                     }
                     handle.builder.flags(flags);
                     fetchSitemaps(client, handle, successCb, failureCb);
-                    if (!(connection instanceof DemoConnection)) {
-                        PreferenceManager.getDefaultSharedPreferences(context).edit()
-                                .putInt(PREV_SERVER_FLAGS, flags).apply();
-                    }
                 } catch (JSONException e) {
                     if (response.startsWith("<?xml")) {
                         // We're talking to an OH1 instance
                         handle.builder.flags(0);
                         fetchSitemaps(client, handle, successCb, failureCb);
-                        if (!(connection instanceof DemoConnection)) {
-                            PreferenceManager.getDefaultSharedPreferences(context).edit()
-                                    .putInt(PREV_SERVER_FLAGS, 0).apply();
-                        }
                     } else {
                         failureCb.handleUpdateFailure(handle.call.request(), 200, e);
                     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -298,8 +298,10 @@ public class MainActivity extends AppCompatActivity implements
                 }
             }
             if (!(getConnection() instanceof DemoConnection)) {
-                PreferenceManager.getDefaultSharedPreferences(this).edit()
-                        .putInt(PREV_SERVER_FLAGS, props.flags()).apply();
+                PreferenceManager.getDefaultSharedPreferences(this)
+                        .edit()
+                        .putInt(PREV_SERVER_FLAGS, props.flags())
+                        .apply();
             }
         };
         mPropsUpdateHandle = ServerProperties.fetch(mConnection,
@@ -314,8 +316,10 @@ public class MainActivity extends AppCompatActivity implements
         String serverUrl = "https://" + serviceInfo.getHostAddresses()[0] + ":"
                 + String.valueOf(serviceInfo.getPort()) + "/";
 
-        PreferenceManager.getDefaultSharedPreferences(this).edit()
-                .putString(Constants.PREFERENCE_LOCAL_URL, serverUrl).apply();
+        PreferenceManager.getDefaultSharedPreferences(this)
+                .edit()
+                .putString(Constants.PREFERENCE_LOCAL_URL, serverUrl)
+                .apply();
         // We'll get a connection update later
         mServiceResolver = null;
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -101,6 +101,7 @@ import javax.jmdns.ServiceInfo;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
+import static org.openhab.habdroid.util.Constants.PREV_SERVER_FLAGS;
 import static org.openhab.habdroid.util.Util.exceptionHasCause;
 import static org.openhab.habdroid.util.Util.getHostFromUrl;
 
@@ -296,9 +297,13 @@ public class MainActivity extends AppCompatActivity implements
                     showSitemapSelectionDialog();
                 }
             }
+            if (!(getConnection() instanceof DemoConnection)) {
+                PreferenceManager.getDefaultSharedPreferences(this).edit()
+                        .putInt(PREV_SERVER_FLAGS, props.flags()).apply();
+            }
         };
         mPropsUpdateHandle = ServerProperties.fetch(mConnection,
-                successCb, this::handlePropertyFetchFailure, this);
+                successCb, this::handlePropertyFetchFailure);
     }
 
     @Override

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -298,7 +298,7 @@ public class MainActivity extends AppCompatActivity implements
             }
         };
         mPropsUpdateHandle = ServerProperties.fetch(mConnection,
-                successCb, this::handlePropertyFetchFailure);
+                successCb, this::handlePropertyFetchFailure, this);
     }
 
     @Override

--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.java
@@ -44,6 +44,7 @@ import org.openhab.habdroid.util.Util;
 
 import java.util.BitSet;
 
+import static org.openhab.habdroid.util.Constants.PREV_SERVER_FLAGS;
 import static org.openhab.habdroid.util.Util.getHostFromUrl;
 
 /**
@@ -323,7 +324,8 @@ public class PreferencesActivity extends AppCompatActivity {
 
             final ServerProperties props =
                     getActivity().getIntent().getParcelableExtra(START_EXTRA_SERVER_PROPERTIES);
-            final int flags = props != null ? props.flags() : 0;
+            final int flags = props != null ? props.flags() :
+                    getPreferenceScreen().getSharedPreferences().getInt(PREV_SERVER_FLAGS, 0);
 
             if ((flags & ServerProperties.SERVER_FLAG_ICON_FORMAT_SUPPORT) == 0) {
                 Preference iconFormatPreference =

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
@@ -38,6 +38,8 @@ public class Constants {
     public static final String PREFERENCE_CHART_HQ            = "default_openhab_chart_hq";
     public static final String PREFERENCE_ICON_FORMAT         = "iconFormatType";
 
+    public static final String PREV_SERVER_FLAGS              = "prevServerFlags";
+
     public static final String SUBSCREEN_LOCAL_CONNECTION     = "default_openhab_local_connection";
     public static final String SUBSCREEN_REMOTE_CONNECTION    = "default_openhab_remote_connection";
 }


### PR DESCRIPTION
When the app is offline and the user opens the settings, some settings
like chart scaling are missing and it might be confusing to have that
settings "just sometimes". Since we don't support multiple servers
(except demo server, which is excluded), saving the flags to prefs
seems save to me.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>