### PR TITLE
Enhance status fragments

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     android:installLocation="internalOnly">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.NFC" />

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -138,7 +138,7 @@ public class MainActivity extends AppCompatActivity implements
     private Uri mPendingNfcData;
     private String mPendingOpenedNotificationId;
     private Sitemap mSelectedSitemap;
-    public ContentController mController;
+    private ContentController mController;
     private ServerProperties mServerProperties;
     private ServerProperties.UpdateHandle mPropsUpdateHandle;
     private boolean mStarted;
@@ -273,6 +273,14 @@ public class MainActivity extends AppCompatActivity implements
             }
         }
         queryServerProperties();
+    }
+
+    public void enableWifiAndIndicateStartup() {
+        WifiManager wifiManager =
+                (WifiManager) getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+        wifiManager.setWifiEnabled(true);
+        mController.updateConnection(null, getString(R.string.waiting_for_wifi),
+                R.drawable.ic_signal_wifi_0_bar_black_24dp);
     }
 
     public void retryServerPropertyQuery() {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -445,7 +445,8 @@ public class MainActivity extends AppCompatActivity implements
                     mController.indicateMissingConfiguration(false);
                 }
             } else if (failureReason != null) {
-                WifiManager wifiManager = (WifiManager) getSystemService(Context.WIFI_SERVICE);
+                WifiManager wifiManager = (WifiManager)
+                        getApplicationContext().getSystemService(Context.WIFI_SERVICE);
                 if (failureReason instanceof NetworkNotSupportedException) {
                     NetworkInfo info =
                             ((NetworkNotSupportedException) failureReason).getNetworkInfo();

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -445,18 +445,19 @@ public class MainActivity extends AppCompatActivity implements
                     mController.indicateMissingConfiguration(false);
                 }
             } else if (failureReason != null) {
+                WifiManager wifiManager = (WifiManager) getSystemService(Context.WIFI_SERVICE);
                 if (failureReason instanceof NetworkNotSupportedException) {
                     NetworkInfo info =
                             ((NetworkNotSupportedException) failureReason).getNetworkInfo();
                     mController.indicateNoNetwork(
-                            getString(R.string.error_network_type_unsupported, info.getTypeName()));
+                            getString(R.string.error_network_type_unsupported, info.getTypeName()), false);
                 } else if (failureReason instanceof NetworkNotAvailableException
-                        && !((WifiManager) getSystemService(Context.WIFI_SERVICE))
-                        .isWifiEnabled()) {
-                    mController.indicateEnableWifiNetwork(
-                            getString(R.string.error_wifi_not_available));
+                        && !wifiManager.isWifiEnabled()) {
+                    mController.indicateNoNetwork(
+                            getString(R.string.error_wifi_not_available), true);
                 } else {
-                    mController.indicateNoNetwork(getString(R.string.error_network_not_available));
+                    mController.indicateNoNetwork(getString(R.string.error_network_not_available),
+                            false);
                 }
             } else {
                 mController.updateConnection(null, null);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -451,7 +451,8 @@ public class MainActivity extends AppCompatActivity implements
                     mController.indicateNoNetwork(
                             getString(R.string.error_network_type_unsupported, info.getTypeName()));
                 } else if (failureReason instanceof NetworkNotAvailableException
-                        && !((WifiManager) getSystemService(Context.WIFI_SERVICE)).isWifiEnabled()) {
+                        && !((WifiManager) getSystemService(Context.WIFI_SERVICE))
+                        .isWifiEnabled()) {
                     mController.indicateEnableWifiNetwork(
                             getString(R.string.error_wifi_not_available));
                 } else {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -450,7 +450,8 @@ public class MainActivity extends AppCompatActivity implements
                     NetworkInfo info =
                             ((NetworkNotSupportedException) failureReason).getNetworkInfo();
                     mController.indicateNoNetwork(
-                            getString(R.string.error_network_type_unsupported, info.getTypeName()), false);
+                            getString(R.string.error_network_type_unsupported, info.getTypeName()),
+                            false);
                 } else if (failureReason instanceof NetworkNotAvailableException
                         && !wifiManager.isWifiEnabled()) {
                     mController.indicateNoNetwork(

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -138,7 +138,7 @@ public class MainActivity extends AppCompatActivity implements
     private Uri mPendingNfcData;
     private String mPendingOpenedNotificationId;
     private Sitemap mSelectedSitemap;
-    private ContentController mController;
+    public ContentController mController;
     private ServerProperties mServerProperties;
     private ServerProperties.UpdateHandle mPropsUpdateHandle;
     private boolean mStarted;
@@ -427,7 +427,7 @@ public class MainActivity extends AppCompatActivity implements
 
         if (newConnection != null) {
             handleConnectionChange();
-            mController.updateConnection(newConnection, null);
+            mController.updateConnection(newConnection, null, 0);
         } else {
             if (failureReason instanceof NoUrlInformationException) {
                 NoUrlInformationException nuie = (NoUrlInformationException) failureReason;
@@ -439,7 +439,9 @@ public class MainActivity extends AppCompatActivity implements
                         mServiceResolver = new AsyncServiceResolver(this, this,
                                 getString(R.string.openhab_service_type));
                         mServiceResolver.start();
-                        mController.updateConnection(null, getString(R.string.resolving_openhab));
+                        mController.updateConnection(null,
+                                getString(R.string.resolving_openhab),
+                                R.drawable.ic_openhab_appicon_340dp /*FIXME?*/);
                     }
                 } else {
                     mController.indicateMissingConfiguration(false);
@@ -462,7 +464,7 @@ public class MainActivity extends AppCompatActivity implements
                             false);
                 }
             } else {
-                mController.updateConnection(null, null);
+                mController.updateConnection(null, null, 0);
             }
         }
         mViewPool.clear();

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -27,6 +27,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.NetworkInfo;
 import android.net.Uri;
+import android.net.wifi.WifiManager;
 import android.nfc.NfcAdapter;
 import android.os.Build;
 import android.os.Bundle;
@@ -74,6 +75,7 @@ import org.openhab.habdroid.core.connection.Connection;
 import org.openhab.habdroid.core.connection.ConnectionFactory;
 import org.openhab.habdroid.core.connection.DemoConnection;
 import org.openhab.habdroid.core.connection.exception.ConnectionException;
+import org.openhab.habdroid.core.connection.exception.NetworkNotAvailableException;
 import org.openhab.habdroid.core.connection.exception.NetworkNotSupportedException;
 import org.openhab.habdroid.core.connection.exception.NoUrlInformationException;
 import org.openhab.habdroid.model.LinkedPage;
@@ -443,16 +445,18 @@ public class MainActivity extends AppCompatActivity implements
                     mController.indicateMissingConfiguration(false);
                 }
             } else if (failureReason != null) {
-                final String message;
                 if (failureReason instanceof NetworkNotSupportedException) {
                     NetworkInfo info =
                             ((NetworkNotSupportedException) failureReason).getNetworkInfo();
-                    message = getString(R.string.error_network_type_unsupported,
-                            info.getTypeName());
+                    mController.indicateNoNetwork(
+                            getString(R.string.error_network_type_unsupported, info.getTypeName()));
+                } else if (failureReason instanceof NetworkNotAvailableException
+                        && !((WifiManager) getSystemService(Context.WIFI_SERVICE)).isWifiEnabled()) {
+                    mController.indicateEnableWifiNetwork(
+                            getString(R.string.error_wifi_not_available));
                 } else {
-                    message = getString(R.string.error_network_not_available);
+                    mController.indicateNoNetwork(getString(R.string.error_network_not_available));
                 }
-                mController.indicateNoNetwork(message);
             } else {
                 mController.updateConnection(null, null);
             }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
@@ -223,7 +223,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
     }
 
     /**
-     * Indicate to the user that no network connectivity is present
+     * Indicate to the user that no network connectivity is present.
      *
      * @param message Error message to show
      */
@@ -236,7 +236,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
     }
 
     /**
-     * Indicate to the user that no network connectivity is present and Wi-Fi is disabled
+     * Indicate to the user that no network connectivity is present and Wi-Fi is disabled.
      *
      * @param message Error message to show
      */
@@ -727,7 +727,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
         }
 
         /**
-         * Set description text or hide TextView
+         * Set description text or hide TextView.
          *
          * @return true if button is shown, false if not.
          */
@@ -744,7 +744,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
         }
 
         /**
-         * Set button text and tag or hide button
+         * Set button text and tag or hide button.
          *
          * @return true if button is shown, false if not.
          */

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
@@ -288,7 +288,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
      * @param progressMessage Message to show to the user if no connection is available
      */
     public void updateConnection(Connection connection, CharSequence progressMessage,
-                                 @DrawableRes int icon) {
+            @DrawableRes int icon) {
         Log.d(TAG, "Update to connection " + connection + " (message " + progressMessage + ")");
         if (connection == null) {
             mNoConnectionFragment = ProgressFragment.newInstance(progressMessage, icon);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
@@ -656,7 +656,14 @@ public abstract class ContentController implements PageConnectionHolderFragment.
             Bundle arguments = getArguments();
 
             View view = inflater.inflate(R.layout.fragment_status, container, false);
-            setDescription(arguments, view, R.id.description, KEY_MESSAGE);
+
+            TextView descriptionText = view.findViewById(R.id.description);
+            CharSequence message = arguments.getCharSequence(KEY_MESSAGE);
+            if (!TextUtils.isEmpty(message)) {
+                descriptionText.setText(message);
+            } else {
+                descriptionText.setVisibility(View.GONE);
+            }
 
             view.findViewById(R.id.progress).setVisibility(
                     arguments.getBoolean(KEY_PROGRESS) ? View.VISIBLE : View.GONE);
@@ -703,23 +710,6 @@ public abstract class ContentController implements PageConnectionHolderFragment.
                 getActivity().recreate();
             } else if (view.getTag().equals(BUTTON_TAG_RETRY_SERVER_PROP_FETCH)) {
                 ((MainActivity) getActivity()).retryServerPropertyQuery();
-            }
-        }
-
-        /**
-         * Set description text or hide TextView.
-         *
-         * @return true if button is shown, false if not.
-         */
-        private boolean setDescription(Bundle arguments, View view, @IdRes int id, String key) {
-            TextView descriptionText = view.findViewById(id);
-            CharSequence message = arguments.getCharSequence(key);
-            if (!TextUtils.isEmpty(message)) {
-                descriptionText.setText(message);
-                return true;
-            } else {
-                descriptionText.setVisibility(View.GONE);
-                return false;
             }
         }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
@@ -249,7 +249,8 @@ public abstract class ContentController implements PageConnectionHolderFragment.
         Log.d(TAG, "Indicate missing configuration (resolveAttempted "
                 + resolveAttempted + ")");
         resetState();
-        WifiManager wifiManager = (WifiManager) mActivity.getSystemService(Context.WIFI_SERVICE);
+        WifiManager wifiManager = (WifiManager)
+                mActivity.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
         mNoConnectionFragment = MissingConfigurationFragment
                 .newInstance(mActivity, resolveAttempted, wifiManager.isWifiEnabled());
         updateFragmentState(FragmentUpdateReason.PAGE_UPDATE);
@@ -692,8 +693,10 @@ public abstract class ContentController implements PageConnectionHolderFragment.
                         .putBoolean(Constants.PREFERENCE_DEMOMODE, true)
                         .apply();
             } else if (view.getTag().equals(BUTTON_TAG_ENABLE_WIFI)) {
-                WifiManager wifiManager = (WifiManager) getContext().getSystemService(Context.WIFI_SERVICE);
+                WifiManager wifiManager = (WifiManager)
+                        getContext().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
                 wifiManager.setWifiEnabled(true);
+                // todo make progress indicator visible
             } else if (view.getTag().equals(BUTTON_TAG_RETRY_NETWORK)) {
                 ConnectionFactory.restartNetworkCheck();
                 getActivity().recreate();

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
@@ -569,7 +569,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
     public static class ProgressFragment extends StatusFragment {
         public static ProgressFragment newInstance(CharSequence message, @DrawableRes int image) {
             ProgressFragment f = new ProgressFragment();
-            f.setArguments(buildArgs(message, 0, image,true));
+            f.setArguments(buildArgs(message, 0, image, true));
             return f;
         }
 
@@ -626,8 +626,8 @@ public abstract class ContentController implements PageConnectionHolderFragment.
                         R.string.go_to_settings_button, R.string.enable_wifi_button,
                         R.drawable.ic_signal_wifi_off_black_24dp, false);
             }
-            args.putBoolean("resolveAttempted", resolveAttempted);
-            args.putBoolean("wifiEnabled", hasWifiEnabled);
+            args.putBoolean(KEY_RESOLVE_ATTEMPTED, resolveAttempted);
+            args.putBoolean(KEY_WIFI_ENABLED, hasWifiEnabled);
             f.setArguments(args);
 
             return f;
@@ -641,13 +641,13 @@ public abstract class ContentController implements PageConnectionHolderFragment.
                 TaskStackBuilder.create(getActivity())
                         .addNextIntentWithParentStack(preferencesIntent)
                         .startActivities();
-            } else if (getArguments().getBoolean("resolveAttempted")) {
+            } else if (getArguments().getBoolean(KEY_RESOLVE_ATTEMPTED)) {
                 // If we attempted resolving, secondary button enables demo mode
                 PreferenceManager.getDefaultSharedPreferences(getContext())
                         .edit()
                         .putBoolean(Constants.PREFERENCE_DEMOMODE, true)
                         .apply();
-            } else if (!getArguments().getBoolean("wifiEnabled")) {
+            } else if (!getArguments().getBoolean(KEY_WIFI_ENABLED)) {
                 // If Wifi is disabled, secondary button suggests enabling Wifi
                 ((MainActivity) getActivity()).enableWifiAndIndicateStartup();
             }
@@ -660,6 +660,8 @@ public abstract class ContentController implements PageConnectionHolderFragment.
         protected static final String KEY_BUTTON_1_TEXT = "button1text";
         protected static final String KEY_BUTTON_2_TEXT = "button2text";
         protected static final String KEY_PROGRESS = "progress";
+        protected static final String KEY_RESOLVE_ATTEMPTED = "resolveAttempted";
+        protected static final String KEY_WIFI_ENABLED = "wifiEnabled";
 
         protected static Bundle buildArgs(CharSequence message, @StringRes int buttonTextResId,
                 @DrawableRes int drawableResId, boolean showProgress) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
@@ -235,6 +235,11 @@ public abstract class ContentController implements PageConnectionHolderFragment.
         mActivity.updateTitle();
     }
 
+    /**
+     * Indicate to the user that no network connectivity is present and Wi-Fi is disabled
+     *
+     * @param message Error message to show
+     */
     public void indicateEnableWifiNetwork(CharSequence message) {
         Log.d(TAG, "Indicate enable wifi (message " + message + ")");
         resetState();
@@ -621,20 +626,20 @@ public abstract class ContentController implements PageConnectionHolderFragment.
     }
 
     private abstract static class StatusFragment extends Fragment implements View.OnClickListener {
-        protected final static String KEY_MESSAGE_1 = "message1";
-        protected final static String KEY_MESSAGE_2 = "message2";
-        protected final static String KEY_DRAWABLE = "drawable";
-        protected final static String KEY_BUTTON_1_TEXT = "button1text";
-        protected final static String KEY_BUTTON_1_TAG = "button1tag";
-        protected final static String KEY_BUTTON_2_TEXT = "button2text";
-        protected final static String KEY_BUTTON_2_TAG = "button2tag";
-        protected final static String KEY_PROGRESS = "progress";
-        protected final static int BUTTON_TAG_NONE = 0;
-        protected final static int BUTTON_TAG_OPEN_SETTINGS = 1;
-        protected final static int BUTTON_TAG_ENABLE_WIFI = 2;
-        protected final static int BUTTON_TAG_ENABLE_DEMO_MODE = 3;
-        protected final static int BUTTON_TAG_RETRY_NETWORK = 4;
-        protected final static int BUTTON_TAG_RETRY_SERVER_PROP_FETCH = 5;
+        protected static final String KEY_MESSAGE_1 = "message1";
+        protected static final String KEY_MESSAGE_2 = "message2";
+        protected static final String KEY_DRAWABLE = "drawable";
+        protected static final String KEY_BUTTON_1_TEXT = "button1text";
+        protected static final String KEY_BUTTON_1_TAG = "button1tag";
+        protected static final String KEY_BUTTON_2_TEXT = "button2text";
+        protected static final String KEY_BUTTON_2_TAG = "button2tag";
+        protected static final String KEY_PROGRESS = "progress";
+        protected static final int BUTTON_TAG_NONE = 0;
+        protected static final int BUTTON_TAG_OPEN_SETTINGS = 1;
+        protected static final int BUTTON_TAG_ENABLE_WIFI = 2;
+        protected static final int BUTTON_TAG_ENABLE_DEMO_MODE = 3;
+        protected static final int BUTTON_TAG_RETRY_NETWORK = 4;
+        protected static final int BUTTON_TAG_RETRY_SERVER_PROP_FETCH = 5;
 
         protected static Bundle buildArgs(CharSequence message, @StringRes int buttonTextResId,
                 int buttonTag, @DrawableRes int drawableResId, boolean showProgress) {
@@ -722,6 +727,8 @@ public abstract class ContentController implements PageConnectionHolderFragment.
         }
 
         /**
+         * Set description text or hide TextView
+         *
          * @return true if button is shown, false if not.
          */
         private boolean setDescription(Bundle arguments, View view, @LayoutRes int id, String key) {
@@ -737,6 +744,8 @@ public abstract class ContentController implements PageConnectionHolderFragment.
         }
 
         /**
+         * Set button text and tag or hide button
+         *
          * @return true if button is shown, false if not.
          */
         private boolean initButton(Bundle arguments, View view, @LayoutRes int buttonId,

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
@@ -90,7 +90,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
             mConnectionFragment = new PageConnectionHolderFragment();
             mFm.beginTransaction().add(mConnectionFragment, "connections").commit();
         }
-        mDefaultProgressFragment = ProgressFragment.newInstance(null, false);
+        mDefaultProgressFragment = ProgressFragment.newInstance(null, 0);
         mConnectionFragment.setCallback(this);
     }
 
@@ -287,11 +287,11 @@ public abstract class ContentController implements PageConnectionHolderFragment.
      * @param connection New connection to use; might be null if none is currently available
      * @param progressMessage Message to show to the user if no connection is available
      */
-    public void updateConnection(Connection connection, CharSequence progressMessage) {
+    public void updateConnection(Connection connection, CharSequence progressMessage,
+                                 @DrawableRes int icon) {
         Log.d(TAG, "Update to connection " + connection + " (message " + progressMessage + ")");
         if (connection == null) {
-            mNoConnectionFragment = ProgressFragment.newInstance(progressMessage,
-                    progressMessage != null);
+            mNoConnectionFragment = ProgressFragment.newInstance(progressMessage, icon);
         } else {
             mNoConnectionFragment = null;
         }
@@ -562,10 +562,9 @@ public abstract class ContentController implements PageConnectionHolderFragment.
     }
 
     public static class ProgressFragment extends StatusFragment {
-        public static ProgressFragment newInstance(CharSequence message, boolean showImage) {
+        public static ProgressFragment newInstance(CharSequence message, @DrawableRes int image) {
             ProgressFragment f = new ProgressFragment();
-            f.setArguments(buildArgs(message, 0, BUTTON_TAG_NONE,
-                    showImage ? R.drawable.ic_openhab_appicon_340dp : 0, true));
+            f.setArguments(buildArgs(message, 0, BUTTON_TAG_NONE, image,true));
             return f;
         }
     }
@@ -696,7 +695,9 @@ public abstract class ContentController implements PageConnectionHolderFragment.
                 WifiManager wifiManager = (WifiManager)
                         getContext().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
                 wifiManager.setWifiEnabled(true);
-                // todo make progress indicator visible
+                ((MainActivity) getActivity()).mController.updateConnection(null,
+                        getContext().getString(R.string.waiting_for_wifi),
+                        R.drawable.ic_signal_wifi_0_bar_black_24dp);
             } else if (view.getTag().equals(BUTTON_TAG_RETRY_NETWORK)) {
                 ConnectionFactory.restartNetworkCheck();
                 getActivity().recreate();

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
@@ -557,7 +557,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
         public static CommunicationFailureFragment newInstance(CharSequence message) {
             CommunicationFailureFragment f = new CommunicationFailureFragment();
             f.setArguments(buildArgs(message, R.string.try_again_button,
-                    BUTTON_TAG_RETRY_SERVER_PROP_FETCH, R.drawable.ic_openhab_appicon_24dp /* FIXME */,
+                    BUTTON_TAG_RETRY_SERVER_PROP_FETCH, R.drawable.ic_openhab_appicon_340dp /* FIXME */,
                     false));
             return f;
         }
@@ -567,7 +567,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
         public static ProgressFragment newInstance(CharSequence message, boolean showImage) {
             ProgressFragment f = new ProgressFragment();
             f.setArguments(buildArgs(message, 0, BUTTON_TAG_NONE,
-                    showImage ? R.drawable.ic_openhab_appicon_24dp : 0, true));
+                    showImage ? R.drawable.ic_openhab_appicon_340dp : 0, true));
             return f;
         }
     }
@@ -601,7 +601,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
                         context.getString(R.string.settings_openhab_demomode_summary),
                         R.string.enable_demo_mode_button,
                         BUTTON_TAG_ENABLE_DEMO_MODE,
-                        R.drawable.ic_openhab_appicon_24dp /* FIXME */, false));
+                        R.drawable.ic_openhab_appicon_340dp /* FIXME */, false));
             } else if (hasWifiEnabled) {
                 f.setArguments(buildArgs(context.getString(R.string.no_remote_server),
                         R.string.go_to_settings_button,

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
@@ -29,7 +29,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.annotation.AnimRes;
 import androidx.annotation.DrawableRes;
-import androidx.annotation.LayoutRes;
+import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
@@ -595,7 +595,6 @@ public abstract class ContentController implements PageConnectionHolderFragment.
                 f.setArguments(buildArgs(context.getString(R.string.configuration_missing),
                         R.string.go_to_settings_button,
                         BUTTON_TAG_OPEN_SETTINGS,
-                        context.getString(R.string.settings_openhab_demomode_summary),
                         R.string.enable_demo_mode_button,
                         BUTTON_TAG_ENABLE_DEMO_MODE,
                         R.drawable.ic_openhab_appicon_340dp /* FIXME */, false));
@@ -608,7 +607,6 @@ public abstract class ContentController implements PageConnectionHolderFragment.
                 f.setArguments(buildArgs(context.getString(R.string.no_remote_server),
                         R.string.go_to_settings_button,
                         BUTTON_TAG_OPEN_SETTINGS,
-                        null,
                         R.string.enable_wifi_button,
                         BUTTON_TAG_ENABLE_WIFI,
                         R.drawable.ic_signal_wifi_off_black_24dp, false));
@@ -618,8 +616,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
     }
 
     private abstract static class StatusFragment extends Fragment implements View.OnClickListener {
-        protected static final String KEY_MESSAGE_1 = "message1";
-        protected static final String KEY_MESSAGE_2 = "message2";
+        protected static final String KEY_MESSAGE = "message";
         protected static final String KEY_DRAWABLE = "drawable";
         protected static final String KEY_BUTTON_1_TEXT = "button1text";
         protected static final String KEY_BUTTON_1_TAG = "button1tag";
@@ -635,16 +632,15 @@ public abstract class ContentController implements PageConnectionHolderFragment.
 
         protected static Bundle buildArgs(CharSequence message, @StringRes int buttonTextResId,
                 int buttonTag, @DrawableRes int drawableResId, boolean showProgress) {
-            return buildArgs(message, buttonTextResId, buttonTag, null,
-                    0, 0, drawableResId, showProgress);
+            return buildArgs(message, buttonTextResId, buttonTag, 0,
+                    0, drawableResId, showProgress);
         }
 
-        protected static Bundle buildArgs(CharSequence message1, @StringRes int button1TextResId,
-                int button1Tag, CharSequence message2, @StringRes int button2TextResId,
+        protected static Bundle buildArgs(CharSequence message, @StringRes int button1TextResId,
+                int button1Tag, @StringRes int button2TextResId,
                 int button2Tag, @DrawableRes int drawableResId, boolean showProgress) {
             Bundle args = new Bundle();
-            args.putCharSequence(KEY_MESSAGE_1, message1);
-            args.putCharSequence(KEY_MESSAGE_2, message2);
+            args.putCharSequence(KEY_MESSAGE, message);
             args.putInt(KEY_DRAWABLE, drawableResId);
             args.putInt(KEY_BUTTON_1_TEXT, button1TextResId);
             args.putInt(KEY_BUTTON_2_TEXT, button2TextResId);
@@ -660,9 +656,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
             Bundle arguments = getArguments();
 
             View view = inflater.inflate(R.layout.fragment_status, container, false);
-
-            boolean needsOr = setDescription(arguments, view, R.id.description1, KEY_MESSAGE_1)
-                    && setDescription(arguments, view, R.id.description2, KEY_MESSAGE_2);
+            setDescription(arguments, view, R.id.description, KEY_MESSAGE);
 
             view.findViewById(R.id.progress).setVisibility(
                     arguments.getBoolean(KEY_PROGRESS) ? View.VISIBLE : View.GONE);
@@ -679,12 +673,8 @@ public abstract class ContentController implements PageConnectionHolderFragment.
                 watermark.setVisibility(View.GONE);
             }
 
-            needsOr = initButton(arguments, view, R.id.button1, KEY_BUTTON_1_TEXT, KEY_BUTTON_1_TAG)
-                    && initButton(arguments, view, R.id.button2, KEY_BUTTON_2_TEXT,
-                    KEY_BUTTON_2_TAG);
-
-            TextView or = view.findViewById(R.id.or);
-            or.setVisibility(needsOr ? View.VISIBLE : View.GONE);
+            initButton(arguments, view, R.id.button1, KEY_BUTTON_1_TEXT, KEY_BUTTON_1_TAG);
+            initButton(arguments, view, R.id.button2, KEY_BUTTON_2_TEXT, KEY_BUTTON_2_TAG);
 
             return view;
         }
@@ -702,8 +692,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
                         .putBoolean(Constants.PREFERENCE_DEMOMODE, true)
                         .apply();
             } else if (view.getTag().equals(BUTTON_TAG_ENABLE_WIFI)) {
-                WifiManager wifiManager =
-                        (WifiManager) getContext().getSystemService(Context.WIFI_SERVICE);
+                WifiManager wifiManager = (WifiManager) getContext().getSystemService(Context.WIFI_SERVICE);
                 wifiManager.setWifiEnabled(true);
             } else if (view.getTag().equals(BUTTON_TAG_RETRY_NETWORK)) {
                 ConnectionFactory.restartNetworkCheck();
@@ -718,7 +707,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
          *
          * @return true if button is shown, false if not.
          */
-        private boolean setDescription(Bundle arguments, View view, @LayoutRes int id, String key) {
+        private boolean setDescription(Bundle arguments, View view, @IdRes int id, String key) {
             TextView descriptionText = view.findViewById(id);
             CharSequence message = arguments.getCharSequence(key);
             if (!TextUtils.isEmpty(message)) {
@@ -735,7 +724,7 @@ public abstract class ContentController implements PageConnectionHolderFragment.
          *
          * @return true if button is shown, false if not.
          */
-        private boolean initButton(Bundle arguments, View view, @LayoutRes int buttonId,
+        private boolean initButton(Bundle arguments, View view, @IdRes int buttonId,
                 String titleKey, String tagRes) {
             final Button button = view.findViewById(buttonId);
             int buttonTextResId = arguments.getInt(titleKey);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.java
@@ -226,24 +226,16 @@ public abstract class ContentController implements PageConnectionHolderFragment.
      * Indicate to the user that no network connectivity is present.
      *
      * @param message Error message to show
+     * @param shouldSuggestEnablingWifi
      */
-    public void indicateNoNetwork(CharSequence message) {
+    public void indicateNoNetwork(CharSequence message, boolean shouldSuggestEnablingWifi) {
         Log.d(TAG, "Indicate no network (message " + message + ")");
         resetState();
-        mNoConnectionFragment = NoNetworkFragment.newInstance(message);
-        updateFragmentState(FragmentUpdateReason.PAGE_UPDATE);
-        mActivity.updateTitle();
-    }
-
-    /**
-     * Indicate to the user that no network connectivity is present and Wi-Fi is disabled.
-     *
-     * @param message Error message to show
-     */
-    public void indicateEnableWifiNetwork(CharSequence message) {
-        Log.d(TAG, "Indicate enable wifi (message " + message + ")");
-        resetState();
-        mNoConnectionFragment = EnableWifiNetworkFragment.newInstance(message);
+        if (shouldSuggestEnablingWifi) {
+            mNoConnectionFragment = EnableWifiNetworkFragment.newInstance(message);
+        } else {
+            mNoConnectionFragment = NoNetworkFragment.newInstance(message);
+        }
         updateFragmentState(FragmentUpdateReason.PAGE_UPDATE);
         mActivity.updateTitle();
     }
@@ -669,11 +661,8 @@ public abstract class ContentController implements PageConnectionHolderFragment.
 
             View view = inflater.inflate(R.layout.fragment_status, container, false);
 
-            boolean needsOr = false;
-            if (setDescription(arguments, view, R.id.description1, KEY_MESSAGE_1)
-                    & setDescription(arguments, view, R.id.description2, KEY_MESSAGE_2)) {
-                needsOr = true;
-            }
+            boolean needsOr = setDescription(arguments, view, R.id.description1, KEY_MESSAGE_1)
+                    && setDescription(arguments, view, R.id.description2, KEY_MESSAGE_2);
 
             view.findViewById(R.id.progress).setVisibility(
                     arguments.getBoolean(KEY_PROGRESS) ? View.VISIBLE : View.GONE);
@@ -690,11 +679,9 @@ public abstract class ContentController implements PageConnectionHolderFragment.
                 watermark.setVisibility(View.GONE);
             }
 
-            if (initButton(arguments, view, R.id.button1, KEY_BUTTON_1_TEXT, KEY_BUTTON_1_TAG)
-                    & initButton(arguments, view, R.id.button2, KEY_BUTTON_2_TEXT,
-                    KEY_BUTTON_2_TAG)) {
-                needsOr = true;
-            }
+            needsOr = initButton(arguments, view, R.id.button1, KEY_BUTTON_1_TEXT, KEY_BUTTON_1_TAG)
+                    && initButton(arguments, view, R.id.button2, KEY_BUTTON_2_TEXT,
+                    KEY_BUTTON_2_TAG);
 
             TextView or = view.findViewById(R.id.or);
             or.setVisibility(needsOr ? View.VISIBLE : View.GONE);

--- a/mobile/src/main/res/drawable/ic_signal_wifi_0_bar_black_24dp.xml
+++ b/mobile/src/main/res/drawable/ic_signal_wifi_0_bar_black_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12.01,21.49L23.64,7c-0.45,-0.34 -4.93,-4 -11.64,-4C5.28,3 0.81,6.66 0.36,7l11.63,14.49 0.01,0.01 0.01,-0.01z"
+        android:fillAlpha=".3"/>
+</vector>

--- a/mobile/src/main/res/drawable/ic_signal_wifi_off_black_24dp.xml
+++ b/mobile/src/main/res/drawable/ic_signal_wifi_off_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M23.64,7c-0.45,-0.34 -4.93,-4 -11.64,-4 -1.5,0 -2.89,0.19 -4.15,0.48L18.18,13.8 23.64,7zM17.04,15.22L3.27,1.44 2,2.72l2.05,2.06C1.91,5.76 0.59,6.82 0.36,7l11.63,14.49 0.01,0.01 0.01,-0.01 3.9,-4.86 3.32,3.32 1.27,-1.27 -3.46,-3.46z"/>
+</vector>

--- a/mobile/src/main/res/layout/fragment_status.xml
+++ b/mobile/src/main/res/layout/fragment_status.xml
@@ -1,81 +1,88 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:gravity="center_horizontal|center_vertical"
-              android:orientation="vertical">
-    <ImageView
-        android:id="@+id/image"
-        android:layout_width="100dp"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:adjustViewBounds="true"
-        android:gravity="center"
-        android:scaleType="fitXY"
-        android:src="@drawable/ic_signal_cellular_off_black_24dp"
-        tools:ignore="contentDescription"/>
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:fillViewport="true"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" >
+    <LinearLayout
+        android:gravity="center_horizontal|center_vertical"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <ImageView
+            android:id="@+id/image"
+            android:paddingTop="4dp"
+            android:layout_width="100dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:adjustViewBounds="true"
+            android:gravity="center"
+            android:scaleType="fitXY"
+            android:src="@drawable/ic_signal_cellular_off_black_24dp"
+            tools:ignore="contentDescription"/>
 
-    <TextView
-        android:id="@+id/description1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:gravity="center"
-        android:padding="16dp"
-        android:textAppearance="?android:attr/textAppearanceMedium"
-        android:textColor="@color/empty_list_text_color"
-        tools:text="Some status message" />
+        <TextView
+            android:id="@+id/description1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:padding="16dp"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textColor="@color/empty_list_text_color"
+            tools:text="Some status message" />
 
-    <ProgressBar
-        android:id="@+id/progress"
-        style="?attr/indeterminateProgressStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:layout_gravity="center_horizontal" />
+        <ProgressBar
+            android:id="@+id/progress"
+            style="?attr/indeterminateProgressStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:layout_gravity="center_horizontal" />
 
-    <Button
-        android:id="@+id/button1"
-        style="?attr/buttonBarButtonStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:clickable="true"
-        android:focusable="true"
-        android:gravity="center"
-        tools:text="Some action" />
+        <Button
+            android:id="@+id/button1"
+            style="?attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="center"
+            tools:text="Some action" />
 
-    <TextView
-        android:id="@+id/or"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:gravity="center"
-        android:padding="8dp"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="@color/empty_list_text_color"
-        android:text="@string/or" />
+        <TextView
+            android:id="@+id/or"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:padding="8dp"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="@color/empty_list_text_color"
+            android:text="@string/or" />
 
-    <TextView
-        android:id="@+id/description2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:gravity="center"
-        android:padding="16dp"
-        android:textAppearance="?android:attr/textAppearanceMedium"
-        android:textColor="@color/empty_list_text_color"
-        tools:text="Some status message" />
+        <TextView
+            android:id="@+id/description2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:padding="16dp"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textColor="@color/empty_list_text_color"
+            tools:text="Some status message" />
 
-    <Button
-        android:id="@+id/button2"
-        style="?attr/buttonBarButtonStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:clickable="true"
-        android:focusable="true"
-        android:gravity="center"
-        tools:text="Some other action" />
+        <Button
+            android:id="@+id/button2"
+            style="?attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="center"
+            tools:text="Some other action" />
 
-</LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/mobile/src/main/res/layout/fragment_status.xml
+++ b/mobile/src/main/res/layout/fragment_status.xml
@@ -22,7 +22,7 @@
             tools:ignore="contentDescription"/>
 
         <TextView
-            android:id="@+id/description1"
+            android:id="@+id/description"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -50,28 +50,6 @@
             android:focusable="true"
             android:gravity="center"
             tools:text="Some action" />
-
-        <TextView
-            android:id="@+id/or"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:gravity="center"
-            android:padding="8dp"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:textColor="@color/empty_list_text_color"
-            android:text="@string/or" />
-
-        <TextView
-            android:id="@+id/description2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:gravity="center"
-            android:padding="16dp"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:textColor="@color/empty_list_text_color"
-            tools:text="Some status message" />
 
         <Button
             android:id="@+id/button2"

--- a/mobile/src/main/res/layout/fragment_status.xml
+++ b/mobile/src/main/res/layout/fragment_status.xml
@@ -16,7 +16,7 @@
         tools:ignore="contentDescription"/>
 
     <TextView
-        android:id="@+id/description"
+        android:id="@+id/description1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
@@ -35,7 +35,7 @@
         android:layout_gravity="center_horizontal" />
 
     <Button
-        android:id="@+id/button"
+        android:id="@+id/button1"
         style="?attr/buttonBarButtonStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -44,5 +44,38 @@
         android:focusable="true"
         android:gravity="center"
         tools:text="Some action" />
+
+    <TextView
+        android:id="@+id/or"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:padding="8dp"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:textColor="@color/empty_list_text_color"
+        android:text="@string/or" />
+
+    <TextView
+        android:id="@+id/description2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:padding="16dp"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textColor="@color/empty_list_text_color"
+        tools:text="Some status message" />
+
+    <Button
+        android:id="@+id/button2"
+        style="?attr/buttonBarButtonStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center"
+        tools:text="Some other action" />
 
 </LinearLayout>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -199,10 +199,9 @@
     <string name="enable_wifi_button">Turn on Wi-Fi</string>
     <string name="go_to_settings_button">Go to settings</string>
     <string name="enable_demo_mode_button">Turn on demo mode</string>
-    <string name="configuration_missing">Your openHAB server couldn\'t be discovered automatically. Please configure its IP address or host name in the server settings.</string>
+    <string name="configuration_missing">We didn\'t find an openHAB server in your network. If you already have a server, please configure its IP address or host name in the server settings. If you don\'t yet have a server, you can enable demo mode to see what openHAB is capable of.</string>
     <string name="no_remote_server">Connection to local server failed and you haven\'t configured a remote server</string>
     <string name="resolving_openhab">Trying to discover openHAB server instance\u2026</string>
-    <string name="or">or</string>
 
     <!-- Content description for images -->
     <string name="content_description_open_roller_shutter">Open roller shutter</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -80,6 +80,7 @@
     <!-- Error messages -->
     <string name="error_empty_sitemap_list">openHAB returned empty Sitemap list</string>
     <string name="error_network_not_available">Network is not available</string>
+    <string name="error_wifi_not_available">Wi-Fi is turned off</string>
     <string name="error_http_connection_failed">Connection unsuccessful. An unexpected response was received while trying to connect to the configured openHAB server (Received HTTP response code: %d).</string>
     <string name="error_invalid_url">Please enter a valid URL in a \'http(s)://host(:port)/\' form</string>
     <string name="error_connection_failed">Connection to host failed</string>
@@ -195,10 +196,13 @@
     <string name="cancel">Cancel</string>
     <string name="close">Close</string>
     <string name="try_again_button">Try again</string>
+    <string name="enable_wifi_button">Turn on Wi-Fi</string>
     <string name="go_to_settings_button">Go to settings</string>
+    <string name="enable_demo_mode_button">Turn on demo mode</string>
     <string name="configuration_missing">Your openHAB server couldn\'t be discovered automatically. Please configure its IP address or host name in the server settings.</string>
-    <string name="no_remote_server">Local network is unavailable and you haven\'t configured a remote server</string>
+    <string name="no_remote_server">Connection to local server failed and you haven\'t configured a remote server</string>
     <string name="resolving_openhab">Trying to discover openHAB server instance\u2026</string>
+    <string name="or">or</string>
 
     <!-- Content description for images -->
     <string name="content_description_open_roller_shutter">Open roller shutter</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -202,6 +202,7 @@
     <string name="configuration_missing">We didn\'t find an openHAB server in your network. If you already have a server, please configure its IP address or host name in the server settings. If you don\'t yet have a server, you can enable demo mode to see what openHAB is capable of.</string>
     <string name="no_remote_server">Connection to local server failed and you haven\'t configured a remote server</string>
     <string name="resolving_openhab">Trying to discover openHAB server instance\u2026</string>
+    <string name="waiting_for_wifi">Waiting for Wi-Fi to establish connection\u2026</string>
 
     <!-- Content description for images -->
     <string name="content_description_open_roller_shutter">Open roller shutter</string>


### PR DESCRIPTION
* Add ability to show a second hint and/or button.

Discorvery failed:
* Discorvery failed hint and open settings button (old)
* Demo mode hint and enable demo mode button (added)

No network available:
* Enable wifi button (added)

No remote server:
If wifi is enabled:
* "No remote server configured" hint and open settings button (old)

If wifi is disabled:
* "No remote server configured" hint and open settings button (old)
* Enable wifi button (added)

Fixes #1115

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>