### PR TITLE
Improve HABPanel viewer

### DIFF
--- a/mobile/src/main/res/layout/fragment_fullscreenwebview.xml
+++ b/mobile/src/main/res/layout/fragment_fullscreenwebview.xml
@@ -38,7 +38,7 @@
             android:padding="16dp"
             android:textAppearance="?android:attr/textAppearanceMedium"
             android:textColor="@color/empty_list_text_color"
-            android:text="@string/habpanel_error" />
+            tools:text="Some error occured" />
 
         <TextView
             android:id="@+id/retry_button"


### PR DESCRIPTION
* Don't reset HABPanel on device rotation. Closes #1169
* Set the webview background to transparent. Avoids white flash when
opening HABPanel with a dark app theme.
* Make fragment reusable for other websites

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>