### PR TITLE
Make sure buttons aren't cut on Android 4

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/SegmentedControlButton.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/SegmentedControlButton.java
@@ -22,7 +22,9 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Paint.Style;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.util.AttributeSet;
+import androidx.annotation.ColorInt;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.appcompat.widget.AppCompatRadioButton;
 
@@ -54,11 +56,15 @@ public class SegmentedControlButton extends AppCompatRadioButton {
             TypedArray a = context.obtainStyledAttributes(attrs,
                     R.styleable.SegmentedControlButton);
 
-            int lineColor = a.getColor(R.styleable.SegmentedControlButton_lineColor, 0);
+            @ColorInt int lineColor = a.getColor(R.styleable.SegmentedControlButton_lineColor, 0);
             mLineHeight = a.getDimensionPixelSize(
                     R.styleable.SegmentedControlButton_lineHeight, 0);
             mTextDistanceFromLine = a.getDimensionPixelSize(
                     R.styleable.SegmentedControlButton_textDistanceFromLine, 0);
+
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                setHeight((int) ((mLineHeight + mTextDistanceFromLine + (int) getTextSize()) * 1.3));
+            }
 
             mTextPaint = new Paint();
             mTextPaint.setAntiAlias(true);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/SegmentedControlButton.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/SegmentedControlButton.java
@@ -56,20 +56,22 @@ public class SegmentedControlButton extends AppCompatRadioButton {
             TypedArray a = context.obtainStyledAttributes(attrs,
                     R.styleable.SegmentedControlButton);
 
-            @ColorInt int lineColor = a.getColor(R.styleable.SegmentedControlButton_lineColor, 0);
             mLineHeight = a.getDimensionPixelSize(
                     R.styleable.SegmentedControlButton_lineHeight, 0);
             mTextDistanceFromLine = a.getDimensionPixelSize(
                     R.styleable.SegmentedControlButton_textDistanceFromLine, 0);
 
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-                setHeight((int) ((mLineHeight + mTextDistanceFromLine + (int) getTextSize()) * 1.3));
+                setHeight((int) ((mLineHeight + mTextDistanceFromLine + (int) getTextSize())
+                        * 1.3));
             }
 
             mTextPaint = new Paint();
             mTextPaint.setAntiAlias(true);
             mTextPaint.setTextSize(getTextSize());
             mTextPaint.setTextAlign(Paint.Align.CENTER);
+
+            @ColorInt int lineColor = a.getColor(R.styleable.SegmentedControlButton_lineColor, 0);
 
             mLinePaint = new Paint();
             mLinePaint.setColor(lineColor);


### PR DESCRIPTION
Closes #1121

I didn't find the reason why the heights are cut, so I added this workaround for Android 4 and lower.