### PR TITLE
Reload widgets when encountering events for unknown ones.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.java
@@ -410,6 +410,13 @@ public class PageConnectionHolderFragment extends Fragment {
                         return;
                     }
                 }
+
+                // We didn't find the widget, so the widget in question probably
+                // just became visible. Reload the page in that case.
+                if (object.optBoolean("visibility")) {
+                    cancel();
+                    load();
+                }
             } catch (JSONException e) {
                 Log.w(TAG, "Could not parse SSE event ('" + payload + "')", e);
             }


### PR DESCRIPTION
The server doesn't return invisible widgets in its REST API response, so
if we're seeing an event for an unknown widget chances are high it's for
a widget that previously was invisible.

Closes #1094
