### PR TITLE
Revert "Bump okhttp from 3.12.1 to 3.13.1"

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'org.jmdns:jmdns:3.5.5'
-    implementation 'com.squareup.okhttp3:okhttp:3.13.1'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.1'
     implementation 'com.github.heremaps:oksse:0.9.0'
     implementation 'com.larswerkman:HoloColorPicker:1.5'
     implementation 'com.github.BigBadaboom:androidsvg:3511e136498da94018ef9fa438895984ea9b99db'


### PR DESCRIPTION
Reverts openhab/openhab-android#1199
Fixes crash at startup on Kitkat.