### PR TITLE
Use primitive types if possible

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/util/AsyncHttpClient.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/AsyncHttpClient.java
@@ -110,8 +110,8 @@ public class AsyncHttpClient extends HttpClient {
             }
 
             if (docWidth != size || docHeight != size) {
-                Float scaleWidth = (float) size / docWidth;
-                Float scaleHeigth = (float) size / docHeight;
+                float scaleWidth = (float) size / docWidth;
+                float scaleHeigth = (float) size / docHeight;
                 density = (scaleWidth + scaleHeigth) / 2;
 
                 docWidth = size;


### PR DESCRIPTION
Fixes two LGTM alerts.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>