### PR TITLE
Wait up to 2 seconds for connection to become available

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/AbstractConnection.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/AbstractConnection.java
@@ -104,19 +104,19 @@ public abstract class AbstractConnection implements Connection {
         for (int retries = 0; retries < 10; retries++) {
             try {
                 s.connect(socketAddress, 1000);
+                Log.d(TAG, "Socket connected (attempt  " + retries + ")");
+                return s;
             } catch (SocketTimeoutException e) {
-                Log.d(TAG, "Socket timeout at the " + retries + ". try.", e);
+                Log.d(TAG, "Socket timeout after " + retries + " retries");
                 return null;
             } catch (IOException e) {
-                Log.d(TAG, "Socket connection failed at the " + retries + ". try.", e);
+                Log.d(TAG, "Socket creation failed (attempt  " + retries + ")");
                 try {
                     Thread.sleep(200);
                 } catch (InterruptedException ignored) {
                     // ignored
                 }
-                continue;
             }
-            return s;
         }
         return null;
     }

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/AbstractConnection.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/AbstractConnection.java
@@ -7,8 +7,10 @@ import okhttp3.OkHttpClient;
 import org.openhab.habdroid.util.AsyncHttpClient;
 import org.openhab.habdroid.util.SyncHttpClient;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.net.URL;
 
 public abstract class AbstractConnection implements Connection {
@@ -84,14 +86,38 @@ public abstract class AbstractConnection implements Connection {
             } else if (url.getProtocol().equals("https") && checkPort == -1) {
                 checkPort = 443;
             }
-            Socket s = new Socket();
-            s.connect(new InetSocketAddress(url.getHost(), checkPort), 1000);
+            Socket s = createConnectedSocket(new InetSocketAddress(url.getHost(), checkPort));
+            if (s == null) {
+                return false;
+            }
             Log.d(TAG, "Socket connected");
             s.close();
             return true;
         } catch (Exception e) {
-            Log.e(TAG, e.getMessage());
+            Log.d(TAG, e.getMessage());
             return false;
         }
+    }
+
+    private Socket createConnectedSocket(InetSocketAddress socketAddress) {
+        Socket s = new Socket();
+        for (int retries = 0; retries < 10; retries++) {
+            try {
+                s.connect(socketAddress, 1000);
+            } catch (SocketTimeoutException e) {
+                Log.d(TAG, "Socket timeout at the " + retries + ". try.", e);
+                return null;
+            } catch (IOException e) {
+                Log.d(TAG, "Socket connection failed at the " + retries + ". try.", e);
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException ignored) {
+                    // ignored
+                }
+                continue;
+            }
+            return s;
+        }
+        return null;
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/AbstractConnection.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/AbstractConnection.java
@@ -90,7 +90,6 @@ public abstract class AbstractConnection implements Connection {
             if (s == null) {
                 return false;
             }
-            Log.d(TAG, "Socket connected");
             s.close();
             return true;
         } catch (Exception e) {

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.java
@@ -346,7 +346,7 @@ public final class ConnectionFactory extends BroadcastReceiver implements
 
         // Else if we are on Wifi, Ethernet, WIMAX or VPN network
         if (LOCAL_CONNECTION_TYPES.contains(info.getType())) {
-            // If local URL is configured and rechable
+            // If local URL is configured and reachable
             if (local != null && local.checkReachabilityInBackground()) {
                 Log.d(TAG, "Connecting to local URL");
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -469,7 +469,7 @@ public class MainActivity extends AppCompatActivity implements
             if (failureReason instanceof NoUrlInformationException) {
                 NoUrlInformationException nuie = (NoUrlInformationException) failureReason;
                 // Attempt resolving only if we're connected locally and
-                // no local connection is configured yes
+                // no local connection is configured yet
                 if (nuie.wouldHaveUsedLocalConnection()
                         && ConnectionFactory.getConnection(Connection.TYPE_LOCAL) == null) {
                     if (mServiceResolver == null) {


### PR DESCRIPTION
Especially for local connections, like WiFi or maybe VPN, too, a
connection may not be "available" (~ connected to the internet) once it is
"connected". To allow a connection to do whatever is needed to do, wait up
to 2 seconds (in 10 200ms chunks) for the connection to become available.
If it is not available after this timeframe, the connection is returned as
"not reachable".

Fixes #755
Closes #780

Signed-off-by: Florian <florian.schmidt.welzow@t-online.de>
Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>