### PR TITLE
Keep authentication header an implementation detail of HttpClient.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.java
@@ -489,14 +489,11 @@ public class PageConnectionHolderFragment extends Fragment {
                                     .addQueryParameter("sitemap", mSitemap)
                                     .addQueryParameter("pageid", mPageId)
                                     .build();
-                            Request.Builder requestBuilder = new Request.Builder()
-                                    .addHeader("User-Agent", "openHAB client for Android")
-                                    .url(u);
-                            if (mClient.mAuthHeader != null) {
-                                requestBuilder.addHeader("Authorization", mClient.mAuthHeader);
-                            }
+                            Request request = mClient.makeAuthenticatedRequestBuilder()
+                                    .url(u)
+                                    .build();
                             mEventStream = mClient.makeSseClient()
-                                    .newServerSentEvent(requestBuilder.build(), EventHelper.this);
+                                    .newServerSentEvent(request, EventHelper.this);
                         } catch (JSONException e) {
                             Log.w(TAG, "Failed parsing SSE subscription", e);
                             mFailureCb.handleFailure();

--- a/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.java
@@ -49,6 +49,15 @@ public abstract class HttpClient {
         return new OkSse(mClient);
     }
 
+    public Request.Builder makeAuthenticatedRequestBuilder() {
+        Request.Builder builder = new Request.Builder()
+                .addHeader("User-Agent", "openHAB client for Android");
+        if (mAuthHeader != null) {
+            builder.addHeader("Authorization", mAuthHeader);
+        }
+        return builder;
+    }
+
     public HttpUrl buildUrl(String url) {
         HttpUrl absoluteUrl = HttpUrl.parse(url);
         if (absoluteUrl == null && mBaseUrl != null) {
@@ -66,12 +75,8 @@ public abstract class HttpClient {
     protected Call prepareCall(String url, String method, Map<String, String> additionalHeaders,
             String requestBody, String mediaType,
             long timeoutMillis, CachingMode caching) {
-        Request.Builder requestBuilder = new Request.Builder();
-        requestBuilder.url(buildUrl(url));
-        requestBuilder.addHeader("User-Agent", "openHAB client for Android");
-        if (mAuthHeader != null) {
-            requestBuilder.addHeader("Authorization", mAuthHeader);
-        }
+        Request.Builder requestBuilder = makeAuthenticatedRequestBuilder()
+                .url(buildUrl(url));
         if (additionalHeaders != null) {
             for (Map.Entry<String, String> entry : additionalHeaders.entrySet()) {
                 requestBuilder.addHeader(entry.getKey(), entry.getValue());


### PR DESCRIPTION
mAuthHeader is only public for unit testing (marked by the
VisibleForTesting annotation), so keep the usage of the member variable
private to the HttpClient class. Doing so also avoids code duplication.
