### PR TITLE
Clean up public methods needed for SSE in HttpClient.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.java
@@ -505,11 +505,7 @@ public class PageConnectionHolderFragment extends Fragment {
                                     .addQueryParameter("sitemap", mSitemap)
                                     .addQueryParameter("pageid", mPageId)
                                     .build();
-                            Request request = mClient.makeAuthenticatedRequestBuilder()
-                                    .url(u)
-                                    .build();
-                            mEventStream = mClient.makeSseClient()
-                                    .newServerSentEvent(request, EventHelper.this);
+                            mEventStream = mClient.makeSse(u, EventHelper.this);
                         } catch (JSONException e) {
                             Log.w(TAG, "Failed parsing SSE subscription", e);
                             mFailureCb.handleFailure();

--- a/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.java
@@ -12,6 +12,8 @@ package org.openhab.habdroid.util;
 import androidx.annotation.VisibleForTesting;
 
 import com.here.oksse.OkSse;
+import com.here.oksse.ServerSentEvent;
+
 import okhttp3.CacheControl;
 import okhttp3.Call;
 import okhttp3.Credentials;
@@ -45,17 +47,11 @@ public abstract class HttpClient {
         mClient = client;
     }
 
-    public OkSse makeSseClient() {
-        return new OkSse(mClient);
-    }
-
-    public Request.Builder makeAuthenticatedRequestBuilder() {
-        Request.Builder builder = new Request.Builder()
-                .addHeader("User-Agent", "openHAB client for Android");
-        if (mAuthHeader != null) {
-            builder.addHeader("Authorization", mAuthHeader);
-        }
-        return builder;
+    public ServerSentEvent makeSse(HttpUrl url, ServerSentEvent.Listener listener) {
+        Request request = makeAuthenticatedRequestBuilder()
+                .url(url)
+                .build();
+        return new OkSse(mClient).newServerSentEvent(request, listener);
     }
 
     public HttpUrl buildUrl(String url) {
@@ -102,5 +98,14 @@ public abstract class HttpClient {
                 ? mClient.newBuilder().readTimeout(timeoutMillis, TimeUnit.MILLISECONDS).build()
                 : mClient;
         return client.newCall(request);
+    }
+
+    private Request.Builder makeAuthenticatedRequestBuilder() {
+        Request.Builder builder = new Request.Builder()
+                .addHeader("User-Agent", "openHAB client for Android");
+        if (mAuthHeader != null) {
+            builder.addHeader("Authorization", mAuthHeader);
+        }
+        return builder;
     }
 }


### PR DESCRIPTION
Previously, there were two public methods in HttpClient that were needed
only by the SSE code. Since they always were used together anyway, we
can as well combine them into one and keep HttpClient public API more
consise.
