### PR TITLE
Only send unit in Setpoint/Slider updates if needed.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/Item.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Item.java
@@ -39,6 +39,7 @@ public abstract class Item implements Parcelable {
         Image,
         Location,
         Number,
+        NumberWithDimension,
         Player,
         Rollershutter,
         StringItem,
@@ -92,6 +93,9 @@ public abstract class Item implements Parcelable {
         }
         if ("String".equals(type)) {
             return Type.StringItem;
+        }
+        if ("Number".equals(type) && colonPos > 0) {
+            return Type.NumberWithDimension;
         }
         try {
             return Type.valueOf(type);

--- a/mobile/src/main/java/org/openhab/habdroid/util/Util.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Util.java
@@ -198,7 +198,7 @@ public class Util {
         if (item == null || state == null) {
             return;
         }
-        if (item.isOfTypeOrGroupType(Item.Type.Number)) {
+        if (item.isOfTypeOrGroupType(Item.Type.NumberWithDimension)) {
             // For number items, include unit (if present) in command
             sendItemCommand(client, item, state.toString(Locale.US));
         } else {


### PR DESCRIPTION
In particular, only send them for Number:<dimension> items, not for
plain Number ones.