### PR TITLE
Use consistent versions of OkHttp components.

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -104,7 +104,7 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'org.jmdns:jmdns:3.5.5'
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.13.1'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.12.1'
     implementation 'com.github.heremaps:oksse:0.9.0'
     implementation 'com.larswerkman:HoloColorPicker:1.5'
     implementation 'com.github.BigBadaboom:androidsvg:3511e136498da94018ef9fa438895984ea9b99db'
@@ -140,7 +140,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.25.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.json:json:20180813'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:3.13.1'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:3.12.1'
 
     // PowerMock
     testImplementation 'org.powermock:powermock-core:2.0.0'


### PR DESCRIPTION
We need to stick to 3.12.x versions, as newer versions don't support API
level < 21 anymore.

Closes #1253
