### PR TITLE
Prevent swipe-to-refresh if swipe isn't started at top of page.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
@@ -29,6 +29,7 @@ import org.openhab.habdroid.model.Item;
 import org.openhab.habdroid.model.LabeledValue;
 import org.openhab.habdroid.model.LinkedPage;
 import org.openhab.habdroid.model.Widget;
+import org.openhab.habdroid.ui.widget.RecyclerViewSwipeRefreshLayout;
 import org.openhab.habdroid.util.CacheManager;
 import org.openhab.habdroid.util.Util;
 
@@ -55,7 +56,7 @@ public class WidgetListFragment extends Fragment
     // parent activity
     private MainActivity mActivity;
     private String mTitle;
-    private SwipeRefreshLayout mRefreshLayout;
+    private RecyclerViewSwipeRefreshLayout mRefreshLayout;
     private String mHighlightedPageLink;
 
     @Override
@@ -182,6 +183,7 @@ public class WidgetListFragment extends Fragment
         mRefreshLayout = view.findViewById(R.id.swiperefresh);
 
         Util.applySwipeLayoutColors(mRefreshLayout, R.attr.colorPrimary, R.attr.colorAccent);
+        mRefreshLayout.setRecyclerView(mRecyclerView);
         mRefreshLayout.setOnRefreshListener(() -> {
             mActivity.showRefreshHintSnackbarIfNeeded();
             CacheManager.getInstance(getActivity()).clearCache();

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/RecyclerViewSwipeRefreshLayout.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/RecyclerViewSwipeRefreshLayout.java
@@ -1,0 +1,143 @@
+package org.openhab.habdroid.ui.widget;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewConfiguration;
+
+import androidx.core.view.NestedScrollingChildHelper;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
+public class RecyclerViewSwipeRefreshLayout extends SwipeRefreshLayout {
+    private final int mTouchSlop;
+    private float mDownX;
+    private float mDownY;
+    private boolean mChildScrollableOnDown;
+    private final int[] mParentOffsetInWindow = new int[2];
+    private final NestedScrollingChildHelper mNestedScrollingChildHelper;
+    private boolean mHorizontalSwipe;
+    private boolean mIsOrWasUpSwipe;
+    private RecyclerView mRecyclerView;
+
+
+    public RecyclerViewSwipeRefreshLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        mTouchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
+        mNestedScrollingChildHelper = new NestedScrollingChildHelper(this);
+        setNestedScrollingEnabled(true);
+    }
+
+    public void setRecyclerView(RecyclerView view) {
+        mRecyclerView = view;
+    }
+
+    @Override
+    public boolean canChildScrollUp() {
+        if (mRecyclerView != null) {
+            return mRecyclerView.canScrollVertically(-1);
+        }
+        return super.canChildScrollUp();
+    }
+
+    @Override
+    public boolean onStartNestedScroll(View child, View target, int nestedScrollAxes) {
+        return false;
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent event) {
+        if (event.getAction() != MotionEvent.ACTION_DOWN && shouldPreventRefresh()) {
+            return false;
+        }
+
+        switch (event.getAction()) {
+            case MotionEvent.ACTION_DOWN:
+                mDownX = event.getX();
+                mDownY = event.getY();
+                mHorizontalSwipe = false;
+                mIsOrWasUpSwipe = false;
+                mChildScrollableOnDown = canChildScrollUp();
+                break;
+            case MotionEvent.ACTION_MOVE:
+                final float xDiff = Math.abs(event.getX() - mDownX);
+                final float yDiff = event.getY() - mDownY;
+
+                if (yDiff < -mTouchSlop) {
+                    mIsOrWasUpSwipe = true;
+                }
+                if (mHorizontalSwipe || xDiff > mTouchSlop) {
+                    mHorizontalSwipe = true;
+                    return false;
+                }
+                break;
+        }
+
+        return super.onInterceptTouchEvent(event);
+    }
+
+    @Override
+    public void setNestedScrollingEnabled(boolean enabled) {
+        if (mNestedScrollingChildHelper != null) {
+            mNestedScrollingChildHelper.setNestedScrollingEnabled(enabled);
+        }
+    }
+
+    @Override
+    public boolean isNestedScrollingEnabled() {
+        return mNestedScrollingChildHelper.isNestedScrollingEnabled();
+    }
+
+    @Override
+    public boolean startNestedScroll(int axes) {
+        return mNestedScrollingChildHelper.startNestedScroll(axes);
+    }
+
+    @Override
+    public void stopNestedScroll() {
+        mNestedScrollingChildHelper.stopNestedScroll();
+    }
+
+    @Override
+    public boolean hasNestedScrollingParent() {
+        return mNestedScrollingChildHelper.hasNestedScrollingParent();
+    }
+
+    @Override
+    public boolean dispatchNestedScroll(int dxConsumed, int dyConsumed, int dxUnconsumed,
+                                        int dyUnconsumed, int[] offsetInWindow) {
+        return mNestedScrollingChildHelper.dispatchNestedScroll(dxConsumed, dyConsumed,
+                dxUnconsumed, dyUnconsumed, offsetInWindow);
+    }
+
+    @Override
+    public boolean dispatchNestedPreScroll(int dx, int dy, int[] consumed, int[] offsetInWindow) {
+        return mNestedScrollingChildHelper.dispatchNestedPreScroll(dx, dy, consumed, offsetInWindow);
+    }
+
+    @Override
+    public boolean dispatchNestedFling(float velocityX, float velocityY, boolean consumed) {
+        return mNestedScrollingChildHelper.dispatchNestedFling(velocityX, velocityY, consumed);
+    }
+
+    @Override
+    public boolean dispatchNestedPreFling(float velocityX, float velocityY) {
+        return mNestedScrollingChildHelper.dispatchNestedPreFling(velocityX, velocityY);
+    }
+
+    @Override
+    public void onNestedScroll(final View target, final int dxConsumed, final int dyConsumed,
+                               final int dxUnconsumed, final int dyUnconsumed) {
+        if (shouldPreventRefresh()) {
+            dispatchNestedScroll(dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed,
+                    mParentOffsetInWindow);
+        } else {
+            super.onNestedScroll(target, dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed);
+        }
+    }
+
+    private boolean shouldPreventRefresh() {
+        return mChildScrollableOnDown || mIsOrWasUpSwipe;
+    }
+}

--- a/mobile/src/main/res/layout/fragment_widgetlist.xml
+++ b/mobile/src/main/res/layout/fragment_widgetlist.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<org.openhab.habdroid.ui.widget.RecyclerViewSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/swiperefresh"
@@ -48,4 +48,4 @@
 
     </FrameLayout>
 
-</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+</org.openhab.habdroid.ui.widget.RecyclerViewSwipeRefreshLayout>


### PR DESCRIPTION
Current it's too easy to accidentally trigger swipe-to-refresh when
swiping to scroll the widget list upwards. Prevent that by only allowing
swipe-to-refresh if the widget list is already at the top when starting
the swipe gesture. This means if one wants to refresh while in the
middle of the list, one needs two swipe gestures.

See #1230
