### PR TITLE
Fix NPE in color picker

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.java
@@ -1095,7 +1095,8 @@ public class WidgetAdapter extends RecyclerView.Adapter<WidgetAdapter.ViewHolder
             colorPicker.setOnColorChangedListener(this);
             colorPicker.setShowOldCenterColor(false);
 
-            float[] initialColor = mBoundItem.state() != null ? mBoundItem.state().asHsv() : null;
+            float[] initialColor = mBoundItem != null && mBoundItem.state() != null
+                    ? mBoundItem.state().asHsv() : null;
             if (initialColor != null) {
                 colorPicker.setColor(Color.HSVToColor(initialColor));
             }


### PR DESCRIPTION
````
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'org.openhab.habdroid.model.ParsedState org.openhab.habdroid.model.Item.state()' on a null object reference
       at org.openhab.habdroid.ui.WidgetAdapter$ColorViewHolder.showColorPickerDialog(WidgetAdapter.java:1106)
       at org.openhab.habdroid.ui.WidgetAdapter$ColorViewHolder.onTouch(WidgetAdapter.java:1072)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>