### PR TITLE
Fix IllegalStateException in PreferencesActivity

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.java
@@ -10,7 +10,6 @@
 package org.openhab.habdroid.ui;
 
 import android.app.FragmentManager;
-import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.drawable.Drawable;
@@ -94,6 +93,9 @@ public class PreferencesActivity extends AppCompatActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+        if (isFinishing() || isDestroyed()) {
+            return true;
+        }
         switch (item.getItemId()) {
             case android.R.id.home:
                 FragmentManager fm = getFragmentManager();


### PR DESCRIPTION
````
Fatal Exception: java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
       at android.app.FragmentManagerImpl.checkStateLoss(FragmentManager.java:1870)
       at android.app.FragmentManagerImpl.enqueueAction(FragmentManager.java:1893)
       at android.app.FragmentManagerImpl.popBackStack(FragmentManager.java:805)
       at org.openhab.habdroid.ui.PreferencesActivity.onOptionsItemSelected(PreferencesActivity.java:98)
       at android.app.Activity.onMenuItemSelected(Activity.java:3527)
       at androidx.fragment.app.FragmentActivity.onMenuItemSelected(FragmentActivity.java:436)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>