### PR TITLE
Improve NFC item updates

### DIFF
--- a/mobile/src/androidTest/java/org/openhab/habdroid/ui/NfcTest.java
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/ui/NfcTest.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import androidx.annotation.StringRes;
 import androidx.test.InstrumentationRegistry;
 import androidx.test.espresso.ViewInteraction;
-import androidx.test.espresso.contrib.RecyclerViewActions;
 import androidx.test.filters.LargeTest;
 import androidx.test.runner.AndroidJUnit4;
 
@@ -15,6 +14,7 @@ import org.openhab.habdroid.R;
 import org.openhab.habdroid.TestWithoutIntro;
 
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.longClick;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
@@ -32,7 +32,9 @@ public class NfcTest extends TestWithoutIntro {
         ViewInteraction recyclerView = onView(withId(R.id.recyclerview));
         Context context = InstrumentationRegistry.getTargetContext();
 
-        recyclerView.perform(RecyclerViewActions.actionOnItemAtPosition(10, click()));
+        recyclerView.perform(actionOnItemAtPosition(10, longClick()));
+        checkViewWithText(context, R.string.nfc_action_to_sitemap_page);
+        pressBack();
 
         recyclerView.perform(actionOnItemAtPosition(10, click()));
 
@@ -45,7 +47,6 @@ public class NfcTest extends TestWithoutIntro {
 
         checkViewWithText(context, R.string.nfc_action_off);
         checkViewWithText(context, R.string.nfc_action_toggle);
-        checkViewWithText(context, R.string.nfc_action_to_sitemap_page);
 
         ViewInteraction onButton = checkViewWithText(context, R.string.nfc_action_on);
         onButton.perform(click());

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -65,21 +65,6 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-
-                <data android:scheme="openhab" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:scheme="openhab" />
-            </intent-filter>
         </activity>
         <activity
             android:name=".ui.WriteTagActivity"
@@ -145,7 +130,7 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
 
-                <data android:scheme="openhabitem" />
+                <data android:scheme="openhab" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -153,7 +138,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="openhabitem" />
+                <data android:scheme="openhab" />
             </intent-filter>
         </activity>
     </application>

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -23,11 +23,11 @@
         android:allowBackup="false"
         android:icon="@mipmap/icon"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:resizeableActivity="true"
         android:supportsPictureInPicture="false"
         android:supportsRtl="true"
-        android:theme="@style/HABDroid.Light"
-        android:networkSecurityConfig="@xml/network_security_config">
+        android:theme="@style/HABDroid.Light">
         <activity
             android:name=".ui.PreferencesActivity"
             android:label="@string/app_preferences_name">
@@ -44,7 +44,8 @@
         <activity
             android:name=".ui.AboutActivity"
             android:label="@string/about_title" />
-        <activity android:name=".ui.LogActivity"
+        <activity
+            android:name=".ui.LogActivity"
             android:label="@string/log" />
         <activity
             android:name=".ui.MainActivity"
@@ -107,22 +108,21 @@
                 android:resource="@xml/voice_widget_info" />
         </receiver>
         <receiver
-                android:name=".ui.homescreenwidget.VoiceWidgetWithIcon"
-                android:label="@string/title_voice_widget_icon">
+            android:name=".ui.homescreenwidget.VoiceWidgetWithIcon"
+            android:label="@string/title_voice_widget_icon">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>
 
             <meta-data
-                    android:name="android.appwidget.provider"
-                    android:resource="@xml/voice_widget_with_icon_info" />
+                android:name="android.appwidget.provider"
+                android:resource="@xml/voice_widget_with_icon_info" />
         </receiver>
         <receiver android:name=".core.OnUpdateBroadcastReceiver">
             <intent-filter>
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
-
         <receiver
             android:name=".background.BackgroundTasksManager"
             android:enabled="true"
@@ -131,9 +131,31 @@
                 <action android:name="android.app.action.NEXT_ALARM_CLOCK_CHANGED" />
             </intent-filter>
             <intent-filter>
-                <action android:name="android.intent.action.LOCALE_CHANGED"/>
+                <action android:name="android.intent.action.LOCALE_CHANGED" />
             </intent-filter>
         </receiver>
+
+        <activity
+            android:name=".background.NfcReceiveActivity"
+            android:launchMode="singleInstance"
+            android:theme="@android:style/Theme.NoDisplay"
+            android:noHistory="true">
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:scheme="openhabitem" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="openhabitem" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.java
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.java
@@ -35,7 +35,7 @@ public class BackgroundTasksManager extends BroadcastReceiver {
     static final String EXTRA_RETRY_INFOS = "retryInfos";
 
     private static final String WORKER_TAG_ITEM_UPLOADS = "itemUploads";
-    public static final String WORKER_TAG_PREFIX_NFC = "nfc-";
+    static final String WORKER_TAG_PREFIX_NFC = "nfc-";
 
     static final List<String> KNOWN_KEYS = Arrays.asList(
         Constants.PREFERENCE_ALARM_CLOCK

--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.java
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.java
@@ -9,6 +9,7 @@ import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.preference.PreferenceManager;
+import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
 import androidx.annotation.Nullable;
@@ -19,9 +20,11 @@ import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkInfo;
 import androidx.work.WorkManager;
 
+import org.openhab.habdroid.R;
 import org.openhab.habdroid.model.NfcTag;
 import org.openhab.habdroid.ui.widget.ItemUpdatingPreference;
 import org.openhab.habdroid.util.Constants;
+import org.openhab.habdroid.util.Util;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -121,8 +124,15 @@ public class BackgroundTasksManager extends BroadcastReceiver {
         workManager.enqueue(workRequest);
     }
 
-    public static void enqueueNfcUpdateIfNeeded(@Nullable NfcTag tag) {
+    public static void enqueueNfcUpdateIfNeeded(Context context, @Nullable NfcTag tag) {
         if (tag != null && tag.sitemap() == null) {
+            String message;
+            if (TextUtils.isEmpty(tag.label())) {
+                message = context.getString(R.string.nfc_tag_recognized_item, tag.item());
+            } else {
+                message = context.getString(R.string.nfc_tag_recognized_label, tag.label());
+            }
+            Util.showToast(context, message);
             enqueueItemUpload(WORKER_TAG_PREFIX_NFC + tag.item(), tag.item(), tag.state());
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.java
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.java
@@ -36,6 +36,7 @@ public class BackgroundTasksManager extends BroadcastReceiver {
     static final String EXTRA_RETRY_INFOS = "retryInfos";
 
     private static final String WORKER_TAG_ITEM_UPLOADS = "itemUploads";
+    public static final String WORKER_TAG_PREFIX_NFC = "nfc-";
 
     static final List<String> KNOWN_KEYS = Arrays.asList(
         Constants.PREFERENCE_ALARM_CLOCK
@@ -108,7 +109,7 @@ public class BackgroundTasksManager extends BroadcastReceiver {
                 || NfcAdapter.ACTION_NDEF_DISCOVERED.equals(intent.getAction())) {
             Uri nfcData = intent.getData();
             String itemName = nfcData.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_ITEM_NAME);
-            enqueueItemUpload("nfc-" + itemName, itemName,
+            enqueueItemUpload(WORKER_TAG_PREFIX_NFC + itemName, itemName,
                     nfcData.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_STATE));
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.java
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.java
@@ -5,13 +5,14 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
+import android.nfc.NfcAdapter;
 import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.util.Pair;
-
 import androidx.lifecycle.LiveData;
 import androidx.work.Constraints;
 import androidx.work.NetworkType;
@@ -19,6 +20,7 @@ import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkInfo;
 import androidx.work.WorkManager;
 
+import org.openhab.habdroid.ui.WriteTagActivity;
 import org.openhab.habdroid.ui.widget.ItemUpdatingPreference;
 import org.openhab.habdroid.util.Constants;
 
@@ -99,6 +101,16 @@ public class BackgroundTasksManager extends BroadcastReceiver {
 
         String prefix = prefs.getString(Constants.PREFERENCE_SEND_DEVICE_INFO_PREFIX, "");
         enqueueItemUpload(key, prefix + setting.second, getter.getValue(context));
+    }
+
+    public static void enqueueNfcItemUpload(Intent intent) {
+        if (Intent.ACTION_VIEW.equals(intent.getAction())
+                || NfcAdapter.ACTION_NDEF_DISCOVERED.equals(intent.getAction())) {
+            Uri nfcData = intent.getData();
+            String itemName = nfcData.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_ITEM_NAME);
+            enqueueItemUpload("nfc-" + itemName, itemName,
+                    nfcData.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_STATE));
+        }
     }
 
     private static void enqueueItemUpload(String tag, String itemName, String value) {

--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.java
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.java
@@ -11,6 +11,7 @@ import android.os.Parcelable;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.util.Pair;
+import androidx.annotation.Nullable;
 import androidx.lifecycle.LiveData;
 import androidx.work.Constraints;
 import androidx.work.NetworkType;
@@ -18,6 +19,7 @@ import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkInfo;
 import androidx.work.WorkManager;
 
+import org.openhab.habdroid.model.NfcTag;
 import org.openhab.habdroid.ui.widget.ItemUpdatingPreference;
 import org.openhab.habdroid.util.Constants;
 
@@ -101,7 +103,7 @@ public class BackgroundTasksManager extends BroadcastReceiver {
         enqueueItemUpload(key, prefix + setting.second, getter.getValue(context));
     }
 
-    public static void enqueueItemUpload(String tag, String itemName, String value) {
+    private static void enqueueItemUpload(String tag, String itemName, String value) {
         final Constraints constraints = new Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)
                 .build();
@@ -117,6 +119,12 @@ public class BackgroundTasksManager extends BroadcastReceiver {
         Log.d(TAG, "Scheduling work for tag " + tag);
         workManager.cancelAllWorkByTag(tag);
         workManager.enqueue(workRequest);
+    }
+
+    public static void enqueueNfcUpdateIfNeeded(@Nullable NfcTag tag) {
+        if (tag != null && tag.sitemap() == null) {
+            enqueueItemUpload(WORKER_TAG_PREFIX_NFC + tag.item(), tag.item(), tag.state());
+        }
     }
 
     static class RetryInfo implements Parcelable {

--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.java
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
-import android.nfc.NfcAdapter;
 import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -104,14 +103,10 @@ public class BackgroundTasksManager extends BroadcastReceiver {
         enqueueItemUpload(key, prefix + setting.second, getter.getValue(context));
     }
 
-    public static void enqueueNfcItemUpload(Intent intent) {
-        if (Intent.ACTION_VIEW.equals(intent.getAction())
-                || NfcAdapter.ACTION_NDEF_DISCOVERED.equals(intent.getAction())) {
-            Uri nfcData = intent.getData();
-            String itemName = nfcData.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_ITEM_NAME);
-            enqueueItemUpload(WORKER_TAG_PREFIX_NFC + itemName, itemName,
-                    nfcData.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_STATE));
-        }
+    public static void enqueueNfcItemUpload(Uri nfcData) {
+        String itemName = nfcData.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_ITEM_NAME);
+        enqueueItemUpload(WORKER_TAG_PREFIX_NFC + itemName, itemName,
+                nfcData.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_STATE));
     }
 
     private static void enqueueItemUpload(String tag, String itemName, String value) {

--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.java
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.java
@@ -5,7 +5,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.net.Uri;
 import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -19,7 +18,6 @@ import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkInfo;
 import androidx.work.WorkManager;
 
-import org.openhab.habdroid.ui.WriteTagActivity;
 import org.openhab.habdroid.ui.widget.ItemUpdatingPreference;
 import org.openhab.habdroid.util.Constants;
 
@@ -103,13 +101,7 @@ public class BackgroundTasksManager extends BroadcastReceiver {
         enqueueItemUpload(key, prefix + setting.second, getter.getValue(context));
     }
 
-    public static void enqueueNfcItemUpload(Uri nfcData) {
-        String itemName = nfcData.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_ITEM_NAME);
-        enqueueItemUpload(WORKER_TAG_PREFIX_NFC + itemName, itemName,
-                nfcData.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_STATE));
-    }
-
-    private static void enqueueItemUpload(String tag, String itemName, String value) {
+    public static void enqueueItemUpload(String tag, String itemName, String value) {
         final Constraints constraints = new Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)
                 .build();

--- a/mobile/src/main/java/org/openhab/habdroid/background/NfcReceiveActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NfcReceiveActivity.java
@@ -1,0 +1,21 @@
+package org.openhab.habdroid.background;
+
+import android.app.Activity;
+import android.os.Build;
+import android.os.Bundle;
+
+public class NfcReceiveActivity extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        BackgroundTasksManager.enqueueNfcItemUpload(getIntent());
+
+        if (Build.VERSION.SDK_INT >= 21) {
+            finishAndRemoveTask();
+        } else {
+            finish();
+        }
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/background/NfcReceiveActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NfcReceiveActivity.java
@@ -6,6 +6,10 @@ import android.nfc.NfcAdapter;
 import android.os.Build;
 import android.os.Bundle;
 
+import org.openhab.habdroid.model.NfcTag;
+import org.openhab.habdroid.ui.MainActivity;
+
+
 public class NfcReceiveActivity extends Activity {
 
     @Override
@@ -13,10 +17,19 @@ public class NfcReceiveActivity extends Activity {
         super.onCreate(savedInstanceState);
 
         Intent intent = getIntent();
+        if (intent == null || intent.getData() == null) {
+            return;
+        }
 
         if (Intent.ACTION_VIEW.equals(intent.getAction())
                 || NfcAdapter.ACTION_NDEF_DISCOVERED.equals(intent.getAction())) {
-            BackgroundTasksManager.enqueueNfcItemUpload(intent.getData());
+            NfcTag tag = NfcTag.fromTagData(intent.getData());
+            if(tag.mustOpenSitemap()) {
+                Intent startMainIntent = new Intent(this, MainActivity.class);
+                startMainIntent.setAction(MainActivity.ACTION_SITEMAP_SELECTED);
+                startMainIntent.putExtra(MainActivity.EXTRA_SITEMAP_URL, tag.sitemap());
+                startActivity(startMainIntent);
+            }
         }
 
         if (Build.VERSION.SDK_INT >= 21) {

--- a/mobile/src/main/java/org/openhab/habdroid/background/NfcReceiveActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NfcReceiveActivity.java
@@ -25,7 +25,7 @@ public class NfcReceiveActivity extends Activity {
         if (Intent.ACTION_VIEW.equals(intent.getAction())
                 || NfcAdapter.ACTION_NDEF_DISCOVERED.equals(intent.getAction())) {
             NfcTag tag = NfcTag.fromTagData(intent.getData());
-            BackgroundTasksManager.enqueueNfcUpdateIfNeeded(tag);
+            BackgroundTasksManager.enqueueNfcUpdateIfNeeded(this, tag);
             if (tag != null && !TextUtils.isEmpty(tag.sitemap())) {
                 Intent startMainIntent = new Intent(this, MainActivity.class);
                 startMainIntent.setAction(MainActivity.ACTION_SITEMAP_SELECTED);

--- a/mobile/src/main/java/org/openhab/habdroid/background/NfcReceiveActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NfcReceiveActivity.java
@@ -1,6 +1,8 @@
 package org.openhab.habdroid.background;
 
 import android.app.Activity;
+import android.content.Intent;
+import android.nfc.NfcAdapter;
 import android.os.Build;
 import android.os.Bundle;
 
@@ -10,7 +12,12 @@ public class NfcReceiveActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        BackgroundTasksManager.enqueueNfcItemUpload(getIntent());
+        Intent intent = getIntent();
+
+        if (Intent.ACTION_VIEW.equals(intent.getAction())
+                || NfcAdapter.ACTION_NDEF_DISCOVERED.equals(intent.getAction())) {
+            BackgroundTasksManager.enqueueNfcItemUpload(intent.getData());
+        }
 
         if (Build.VERSION.SDK_INT >= 21) {
             finishAndRemoveTask();

--- a/mobile/src/main/java/org/openhab/habdroid/background/NfcReceiveActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NfcReceiveActivity.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.nfc.NfcAdapter;
 import android.os.Build;
 import android.os.Bundle;
+import android.text.TextUtils;
 
 import org.openhab.habdroid.model.NfcTag;
 import org.openhab.habdroid.ui.MainActivity;
@@ -17,13 +18,15 @@ public class NfcReceiveActivity extends Activity {
 
         Intent intent = getIntent();
         if (intent == null || intent.getData() == null) {
+            finish();
             return;
         }
 
         if (Intent.ACTION_VIEW.equals(intent.getAction())
                 || NfcAdapter.ACTION_NDEF_DISCOVERED.equals(intent.getAction())) {
             NfcTag tag = NfcTag.fromTagData(intent.getData());
-            if (tag.mustOpenSitemap()) {
+            BackgroundTasksManager.enqueueNfcUpdateIfNeeded(tag);
+            if (tag != null && !TextUtils.isEmpty(tag.sitemap())) {
                 Intent startMainIntent = new Intent(this, MainActivity.class);
                 startMainIntent.setAction(MainActivity.ACTION_SITEMAP_SELECTED);
                 startMainIntent.putExtra(MainActivity.EXTRA_SITEMAP_URL, tag.sitemap());

--- a/mobile/src/main/java/org/openhab/habdroid/background/NfcReceiveActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NfcReceiveActivity.java
@@ -9,7 +9,6 @@ import android.os.Bundle;
 import org.openhab.habdroid.model.NfcTag;
 import org.openhab.habdroid.ui.MainActivity;
 
-
 public class NfcReceiveActivity extends Activity {
 
     @Override
@@ -24,7 +23,7 @@ public class NfcReceiveActivity extends Activity {
         if (Intent.ACTION_VIEW.equals(intent.getAction())
                 || NfcAdapter.ACTION_NDEF_DISCOVERED.equals(intent.getAction())) {
             NfcTag tag = NfcTag.fromTagData(intent.getData());
-            if(tag.mustOpenSitemap()) {
+            if (tag.mustOpenSitemap()) {
                 Intent startMainIntent = new Intent(this, MainActivity.class);
                 startMainIntent.setAction(MainActivity.ACTION_SITEMAP_SELECTED);
                 startMainIntent.putExtra(MainActivity.EXTRA_SITEMAP_URL, tag.sitemap());

--- a/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.java
@@ -44,7 +44,8 @@ class NotificationUpdateObserver implements Observer<List<WorkInfo>> {
         HashMap<String, WorkInfo> latestInfoByTag = new HashMap<>();
         for (WorkInfo info : workInfos) {
             for (String tag : info.getTags()) {
-                if (BackgroundTasksManager.KNOWN_KEYS.contains(tag)) {
+                if (BackgroundTasksManager.KNOWN_KEYS.contains(tag)
+                        || tag.startsWith(BackgroundTasksManager.WORKER_TAG_PREFIX_NFC)) {
                     WorkInfo.State state = info.getState();
                     if (state == WorkInfo.State.ENQUEUED || state == WorkInfo.State.RUNNING) {
                         // Always treat a running job as the 'current' one

--- a/mobile/src/main/java/org/openhab/habdroid/core/VoiceService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/VoiceService.java
@@ -15,16 +15,14 @@ import android.os.Handler;
 import android.os.Looper;
 import android.speech.RecognizerIntent;
 import android.util.Log;
-import android.widget.Toast;
 import androidx.annotation.Nullable;
-import androidx.core.content.ContextCompat;
 
-import es.dmoral.toasty.Toasty;
 import org.openhab.habdroid.R;
 import org.openhab.habdroid.core.connection.Connection;
 import org.openhab.habdroid.core.connection.ConnectionFactory;
 import org.openhab.habdroid.core.connection.exception.ConnectionException;
 import org.openhab.habdroid.util.SyncHttpClient;
+import org.openhab.habdroid.util.Util;
 
 import java.util.HashMap;
 import java.util.List;
@@ -35,7 +33,6 @@ import java.util.Locale;
  */
 public class VoiceService extends IntentService {
     private static final String TAG = VoiceService.class.getSimpleName();
-    private Handler mHandler = new Handler(Looper.getMainLooper());
 
     public VoiceService() {
         super("VoiceService");
@@ -60,7 +57,7 @@ public class VoiceService extends IntentService {
         if (connection != null) {
             sendVoiceCommand(connection.getSyncHttpClient(), voiceCommand);
         } else {
-            showToast(getString(R.string.error_couldnt_determine_openhab_url));
+            Util.showToast(this, getString(R.string.error_couldnt_determine_openhab_url));
         }
     }
 
@@ -71,7 +68,7 @@ public class VoiceService extends IntentService {
             voiceCommand = textMatchList.get(0);
         }
         Log.i(TAG, "Recognized text: " + voiceCommand);
-        showToast(getString(R.string.info_voice_recognized_text, voiceCommand));
+        Util.showToast(this, getString(R.string.info_voice_recognized_text, voiceCommand));
         return voiceCommand;
     }
 
@@ -90,11 +87,5 @@ public class VoiceService extends IntentService {
         } else {
             Log.e(TAG, "Sending voice command failed", result.error);
         }
-    }
-
-    private void showToast(CharSequence text) {
-        mHandler.post(() -> Toasty.custom(this, text, R.drawable.ic_openhab_appicon_24dp,
-                ContextCompat.getColor(this, R.color.openhab_orange), Toast.LENGTH_SHORT,
-                true, true).show());
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.java
@@ -23,7 +23,6 @@ import de.duenndns.ssl.MemorizingTrustManager;
 import okhttp3.OkHttpClient;
 import okhttp3.internal.tls.OkHostnameVerifier;
 import okhttp3.logging.HttpLoggingInterceptor;
-
 import org.openhab.habdroid.core.CloudMessagingHelper;
 import org.openhab.habdroid.core.connection.exception.ConnectionException;
 import org.openhab.habdroid.core.connection.exception.NetworkNotAvailableException;

--- a/mobile/src/main/java/org/openhab/habdroid/model/Item.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Item.java
@@ -10,7 +10,6 @@
 package org.openhab.habdroid.model;
 
 import android.os.Parcelable;
-
 import androidx.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;

--- a/mobile/src/main/java/org/openhab/habdroid/model/NfcTag.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/NfcTag.java
@@ -1,0 +1,76 @@
+package org.openhab.habdroid.model;
+
+import android.net.Uri;
+import android.text.TextUtils;
+import androidx.annotation.Nullable;
+
+import com.google.auto.value.AutoValue;
+import org.openhab.habdroid.background.BackgroundTasksManager;
+import org.openhab.habdroid.ui.WriteTagActivity;
+
+import static org.openhab.habdroid.background.BackgroundTasksManager.WORKER_TAG_PREFIX_NFC;
+
+@AutoValue
+public abstract class NfcTag {
+    @Nullable
+    public abstract String sitemap();
+    @Nullable
+    public abstract String item();
+    @Nullable
+    public abstract String label();
+    @Nullable
+    public abstract String state();
+    @Nullable
+    public abstract String mappedState();
+    public abstract boolean isOpenHabTag();
+    public abstract boolean isSitemapTag();
+    public abstract boolean hasLabelAndMappedState();
+
+    @AutoValue.Builder
+    abstract static class Builder {
+        abstract Builder sitemap(String sitemap);
+        abstract Builder item(String item);
+        abstract Builder label(String label);
+        abstract Builder state(String state);
+        abstract Builder mappedState(String mappedState);
+        abstract Builder isOpenHabTag(boolean isOpenHabTag);
+        abstract Builder isSitemapTag(boolean isSitemapTag);
+        abstract Builder hasLabelAndMappedState(boolean hasLabelAndMappedState);
+
+        abstract NfcTag build();
+    }
+
+    public static NfcTag fromTagData(Uri uri) {
+        String sitemap = uri.getPath();
+        String item = TextUtils.isEmpty(uri.getQueryParameter("item")) ?
+                uri.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_ITEM_NAME)
+                : uri.getQueryParameter("item");
+        String label = uri.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_ITEM_LABEL);
+        String state = TextUtils.isEmpty(uri.getQueryParameter("command")) ?
+                uri.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_STATE)
+                : uri.getQueryParameter("command");
+        String mappedState = uri.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_MAPPED_STATE);
+
+        return new AutoValue_NfcTag.Builder()
+                .sitemap(sitemap)
+                .item(item)
+                .label(label)
+                .state(state)
+                .mappedState(mappedState)
+                .isOpenHabTag("openhab".equals(uri.getScheme()))
+                .isSitemapTag(!TextUtils.isEmpty(sitemap) && TextUtils.isEmpty(item))
+                .hasLabelAndMappedState(TextUtils.isEmpty(label) || TextUtils.isEmpty(mappedState))
+                .build();
+    }
+
+    public boolean mustOpenSitemap() {
+        if (!isOpenHabTag()) {
+            return false;
+        }
+        if (isSitemapTag()) {
+            return true;
+        }
+        BackgroundTasksManager.enqueueItemUpload(WORKER_TAG_PREFIX_NFC + item(), item(), state());
+        return false;
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/model/NfcTag.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/NfcTag.java
@@ -5,10 +5,7 @@ import android.text.TextUtils;
 import androidx.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
-import org.openhab.habdroid.background.BackgroundTasksManager;
 import org.openhab.habdroid.ui.WriteTagActivity;
-
-import static org.openhab.habdroid.background.BackgroundTasksManager.WORKER_TAG_PREFIX_NFC;
 
 @AutoValue
 public abstract class NfcTag {
@@ -22,9 +19,6 @@ public abstract class NfcTag {
     public abstract String state();
     @Nullable
     public abstract String mappedState();
-    public abstract boolean isOpenHabTag();
-    public abstract boolean isSitemapTag();
-    public abstract boolean hasLabelAndMappedState();
 
     @AutoValue.Builder
     abstract static class Builder {
@@ -33,44 +27,30 @@ public abstract class NfcTag {
         abstract Builder label(String label);
         abstract Builder state(String state);
         abstract Builder mappedState(String mappedState);
-        abstract Builder isOpenHabTag(boolean isOpenHabTag);
-        abstract Builder isSitemapTag(boolean isSitemapTag);
-        abstract Builder hasLabelAndMappedState(boolean hasLabelAndMappedState);
 
         abstract NfcTag build();
     }
 
-    public static NfcTag fromTagData(Uri uri) {
+    public static @Nullable NfcTag fromTagData(Uri uri) {
+        if (uri == null || !"openhab".equals(uri.getScheme())) {
+            return null;
+        }
         String sitemap = uri.getPath();
-        String item = TextUtils.isEmpty(uri.getQueryParameter("item")) ?
-                uri.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_ITEM_NAME)
+        String item = TextUtils.isEmpty(uri.getQueryParameter("item"))
+                ? uri.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_ITEM_NAME)
                 : uri.getQueryParameter("item");
         String label = uri.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_ITEM_LABEL);
-        String state = TextUtils.isEmpty(uri.getQueryParameter("command")) ?
-                uri.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_STATE)
+        String state = TextUtils.isEmpty(uri.getQueryParameter("command"))
+                ? uri.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_STATE)
                 : uri.getQueryParameter("command");
         String mappedState = uri.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_MAPPED_STATE);
 
         return new AutoValue_NfcTag.Builder()
-                .sitemap(sitemap)
+                .sitemap(!TextUtils.isEmpty(sitemap) && TextUtils.isEmpty(item) ? sitemap : null)
                 .item(item)
                 .label(label)
                 .state(state)
                 .mappedState(mappedState)
-                .isOpenHabTag("openhab".equals(uri.getScheme()))
-                .isSitemapTag(!TextUtils.isEmpty(sitemap) && TextUtils.isEmpty(item))
-                .hasLabelAndMappedState(TextUtils.isEmpty(label) || TextUtils.isEmpty(mappedState))
                 .build();
-    }
-
-    public boolean mustOpenSitemap() {
-        if (!isOpenHabTag()) {
-            return false;
-        }
-        if (isSitemapTag()) {
-            return true;
-        }
-        BackgroundTasksManager.enqueueItemUpload(WORKER_TAG_PREFIX_NFC + item(), item(), state());
-        return false;
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/model/NfcTag.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/NfcTag.java
@@ -5,10 +5,17 @@ import android.text.TextUtils;
 import androidx.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
-import org.openhab.habdroid.ui.WriteTagActivity;
 
 @AutoValue
 public abstract class NfcTag {
+    public static final String SCHEME = "openhab";
+    public static final String QUERY_PARAMETER_ITEM_NAME = "i";
+    public static final String DEPRECATED_QUERY_PARAMETER_ITEM_NAME = "item";
+    public static final String QUERY_PARAMETER_STATE = "s";
+    public static final String DEPRECATED_QUERY_PARAMETER_STATE = "command";
+    public static final String QUERY_PARAMETER_MAPPED_STATE = "m";
+    public static final String QUERY_PARAMETER_ITEM_LABEL = "l";
+
     @Nullable
     public abstract String sitemap();
     @Nullable
@@ -32,18 +39,18 @@ public abstract class NfcTag {
     }
 
     public static @Nullable NfcTag fromTagData(Uri uri) {
-        if (uri == null || !"openhab".equals(uri.getScheme())) {
+        if (uri == null || !SCHEME.equals(uri.getScheme())) {
             return null;
         }
         String sitemap = uri.getPath();
-        String item = TextUtils.isEmpty(uri.getQueryParameter("item"))
-                ? uri.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_ITEM_NAME)
-                : uri.getQueryParameter("item");
-        String label = uri.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_ITEM_LABEL);
-        String state = TextUtils.isEmpty(uri.getQueryParameter("command"))
-                ? uri.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_STATE)
-                : uri.getQueryParameter("command");
-        String mappedState = uri.getQueryParameter(WriteTagActivity.QUERY_PARAMETER_MAPPED_STATE);
+        String item = TextUtils.isEmpty(uri.getQueryParameter(DEPRECATED_QUERY_PARAMETER_ITEM_NAME))
+                ? uri.getQueryParameter(QUERY_PARAMETER_ITEM_NAME)
+                : uri.getQueryParameter(DEPRECATED_QUERY_PARAMETER_ITEM_NAME);
+        String label = uri.getQueryParameter(QUERY_PARAMETER_ITEM_LABEL);
+        String state = TextUtils.isEmpty(uri.getQueryParameter(DEPRECATED_QUERY_PARAMETER_STATE))
+                ? uri.getQueryParameter(QUERY_PARAMETER_STATE)
+                : uri.getQueryParameter(DEPRECATED_QUERY_PARAMETER_STATE);
+        String mappedState = uri.getQueryParameter(QUERY_PARAMETER_MAPPED_STATE);
 
         return new AutoValue_NfcTag.Builder()
                 .sitemap(!TextUtils.isEmpty(sitemap) && TextUtils.isEmpty(item) ? sitemap : null)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -40,6 +40,7 @@ import android.preference.PreferenceManager;
 import android.speech.RecognizerIntent;
 import android.speech.SpeechRecognizer;
 import android.text.SpannableStringBuilder;
+import android.text.TextUtils;
 import android.text.style.RelativeSizeSpan;
 import android.util.Base64;
 import android.util.Log;
@@ -70,6 +71,7 @@ import com.google.android.material.snackbar.Snackbar;
 import okhttp3.Headers;
 import okhttp3.Request;
 import org.openhab.habdroid.R;
+import org.openhab.habdroid.background.BackgroundTasksManager;
 import org.openhab.habdroid.core.CloudMessagingHelper;
 import org.openhab.habdroid.core.OnUpdateBroadcastReceiver;
 import org.openhab.habdroid.core.VoiceService;
@@ -370,8 +372,9 @@ public class MainActivity extends AbstractBaseActivity implements
             case NfcAdapter.ACTION_NDEF_DISCOVERED:
             case Intent.ACTION_VIEW:
                 NfcTag tag = NfcTag.fromTagData(intent.getData());
+                BackgroundTasksManager.enqueueNfcUpdateIfNeeded(tag);
 
-                if (tag.mustOpenSitemap()) {
+                if (tag != null && !TextUtils.isEmpty(tag.sitemap())) {
                     mPendingOpenSitemapUrl = tag.sitemap();
                     openPendingSitemapIfNeeded();
                 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -337,6 +337,7 @@ public class MainActivity extends AbstractBaseActivity implements
             }
             openHabpanelIfNeeded();
             launchVoiceRecognitionIfNeeded();
+            openPendingSitemapIfNeeded();
         };
         mPropsUpdateHandle = ServerProperties.fetch(mConnection,
                 successCb, this::handlePropertyFetchFailure);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -136,7 +136,7 @@ public class MainActivity extends AbstractBaseActivity implements
     private Snackbar mLastSnackbar;
     private Connection mConnection;
 
-    private Intent mPendingNfcIntent;
+    private Uri mPendingNfcData;
     private String mPendingOpenedNotificationId;
     private boolean mShouldOpenHabpanel;
     private boolean mShouldLaunchVoiceRecognition;
@@ -367,7 +367,7 @@ public class MainActivity extends AbstractBaseActivity implements
         switch (action) {
             case NfcAdapter.ACTION_NDEF_DISCOVERED:
             case Intent.ACTION_VIEW:
-                mPendingNfcIntent = intent;
+                mPendingNfcData = intent.getData();
                 openPendingNfcPageIfNeeded();
                 break;
             case ACTION_NOTIFICATION_SELECTED:
@@ -738,23 +738,20 @@ public class MainActivity extends AbstractBaseActivity implements
     }
 
     private void openPendingNfcPageIfNeeded() {
-        if (mPendingNfcIntent == null || mPendingNfcIntent.getData() == null
-                || mConnection == null || !mStarted) {
+        if (mPendingNfcData == null || mConnection == null || !mStarted) {
             return;
         }
 
-        Uri pendingNfcData = mPendingNfcIntent.getData();
+        Log.d(TAG, "NFC Scheme = " + mPendingNfcData.getScheme());
+        Log.d(TAG, "NFC Host = " + mPendingNfcData.getHost());
+        Log.d(TAG, "NFC Path = " + mPendingNfcData.getPath());
 
-        Log.d(TAG, "NFC Scheme = " + pendingNfcData.getScheme());
-        Log.d(TAG, "NFC Host = " + pendingNfcData.getHost());
-        Log.d(TAG, "NFC Path = " + pendingNfcData.getPath());
-
-        if ("openhabitem".equals(pendingNfcData.getScheme())) {
-            BackgroundTasksManager.enqueueNfcItemUpload(mPendingNfcIntent);
-        } else if ("openhab".equals(pendingNfcData.getScheme())) {
-            String nfcSitemap = pendingNfcData.getPath();
-            String nfcItem = pendingNfcData.getQueryParameter("item");
-            String nfcState = pendingNfcData.getQueryParameter("command");
+        if ("openhabitem".equals(mPendingNfcData.getScheme())) {
+            BackgroundTasksManager.enqueueNfcItemUpload(mPendingNfcData);
+        } else if ("openhab".equals(mPendingNfcData.getScheme())) {
+            String nfcSitemap = mPendingNfcData.getPath();
+            String nfcItem = mPendingNfcData.getQueryParameter("item");
+            String nfcState = mPendingNfcData.getQueryParameter("command");
 
             if (TextUtils.isEmpty(nfcItem)) {
                 Log.d(TAG, "This is a sitemap tag without parameters");
@@ -771,7 +768,7 @@ public class MainActivity extends AbstractBaseActivity implements
                         .show();
             }
         }
-        mPendingNfcIntent = null;
+        mPendingNfcData = null;
     }
 
     private void openAbout() {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -371,7 +371,7 @@ public class MainActivity extends AbstractBaseActivity implements
             case Intent.ACTION_VIEW:
                 NfcTag tag = NfcTag.fromTagData(intent.getData());
 
-                if(tag.mustOpenSitemap()) {
+                if (tag.mustOpenSitemap()) {
                     mPendingOpenSitemapUrl = tag.sitemap();
                     openPendingSitemapIfNeeded();
                 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -603,6 +603,7 @@ public class MainActivity extends AbstractBaseActivity implements
                             mConnection,
                             props -> {
                                 mServerProperties = props;
+                                openPendingSitemapIfNeeded();
                                 updateSitemapAndHabpanelDrawerItems();
                             },
                             MainActivity.this::handlePropertyFetchFailure);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -751,13 +751,10 @@ public class MainActivity extends AbstractBaseActivity implements
     }
 
     private void openPendingSitemapIfNeeded() {
-        if (mPendingOpenSitemapUrl == null || mConnection == null || !mStarted) {
-            return;
+        if (mStarted && mPendingOpenSitemapUrl != null && mServerProperties != null) {
+            buildUrlAndOpenSitemap(mPendingOpenSitemapUrl);
+            mPendingOpenSitemapUrl = null;
         }
-
-        buildUrlAndOpenSitemap(mPendingOpenSitemapUrl);
-
-        mPendingOpenSitemapUrl = null;
     }
 
     private void openAbout() {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -373,7 +373,7 @@ public class MainActivity extends AbstractBaseActivity implements
             case NfcAdapter.ACTION_NDEF_DISCOVERED:
             case Intent.ACTION_VIEW:
                 NfcTag tag = NfcTag.fromTagData(intent.getData());
-                BackgroundTasksManager.enqueueNfcUpdateIfNeeded(tag);
+                BackgroundTasksManager.enqueueNfcUpdateIfNeeded(this, tag);
 
                 if (tag != null && !TextUtils.isEmpty(tag.sitemap())) {
                     mPendingOpenSitemapUrl = tag.sitemap();

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
@@ -171,6 +171,13 @@ public class WidgetListFragment extends Fragment
                         labels.add(maxValue);
                         commands.add(maxValue);
                     }
+
+                    if (widget.switchSupport()) {
+                        labels.add(getString(R.string.nfc_action_on));
+                        commands.add("ON");
+                        labels.add(getString(R.string.nfc_action_off));
+                        commands.add("OFF");
+                    }
                 }
             }
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
@@ -27,7 +27,6 @@ import org.openhab.habdroid.R;
 import org.openhab.habdroid.model.Item;
 import org.openhab.habdroid.model.LabeledValue;
 import org.openhab.habdroid.model.LinkedPage;
-import org.openhab.habdroid.model.NfcTag;
 import org.openhab.habdroid.model.ParsedState;
 import org.openhab.habdroid.model.Widget;
 import org.openhab.habdroid.ui.widget.RecyclerViewSwipeRefreshLayout;
@@ -182,28 +181,29 @@ public class WidgetListFragment extends Fragment
                 }
             }
         }
-        labels.add(getString(R.string.nfc_action_to_sitemap_page));
 
-        final String[] labelArray = labels.toArray(new String[0]);
-        new AlertDialog.Builder(getActivity())
-                .setTitle(R.string.nfc_dialog_title)
-                .setItems(labelArray, (dialog, which) -> {
-                    Intent writeTagIntent = new Intent(getActivity(), WriteTagActivity.class);
-                    writeTagIntent.putExtra(WriteTagActivity.EXTRA_SITEMAP_PAGE, mPageUrl);
+        if (widget.linkedPage() != null) {
+            labels.add(getString(R.string.nfc_action_to_sitemap_page));
+        }
 
-                    if (which < labelArray.length - 1) {
-                        writeTagIntent.putExtra(NfcTag.QUERY_PARAMETER_ITEM_NAME,
-                                widget.item().name());
-                        writeTagIntent.putExtra(NfcTag.QUERY_PARAMETER_STATE,
-                                commands.get(which));
-                        writeTagIntent.putExtra(NfcTag.QUERY_PARAMETER_MAPPED_STATE,
-                                labels.get(which));
-                        writeTagIntent.putExtra(NfcTag.QUERY_PARAMETER_ITEM_LABEL,
-                                widget.item().label());
-                    }
-                    startActivityForResult(writeTagIntent, 0);
-                })
-                .show();
+        if (!labels.isEmpty()) {
+            final String[] labelArray = labels.toArray(new String[0]);
+            new AlertDialog.Builder(getActivity())
+                    .setTitle(R.string.nfc_dialog_title)
+                    .setItems(labelArray, (dialog, which) -> {
+                        final Intent writeTagIntent;
+                        if (which < commands.size()) {
+                            writeTagIntent = WriteTagActivity.createItemUpdateIntent(getActivity(),
+                                    mPageUrl, widget.item().name(), commands.get(which),
+                                    labels.get(which), widget.item().label());
+                        } else {
+                            writeTagIntent = WriteTagActivity.createSitemapNavigationIntent(
+                                    getActivity(), widget.linkedPage().link());
+                        }
+                        startActivityForResult(writeTagIntent, 0);
+                    })
+                    .show();
+        }
     }
 
     @Override

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
@@ -194,7 +194,7 @@ public class WidgetListFragment extends Fragment
                         final Intent writeTagIntent;
                         if (which < commands.size()) {
                             writeTagIntent = WriteTagActivity.createItemUpdateIntent(getActivity(),
-                                    mPageUrl, widget.item().name(), commands.get(which),
+                                    widget.item().name(), commands.get(which),
                                     labels.get(which), widget.item().label());
                         } else {
                             writeTagIntent = WriteTagActivity.createSitemapNavigationIntent(

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
@@ -184,9 +184,14 @@ public class WidgetListFragment extends Fragment
                     writeTagIntent.putExtra("sitemapPage", mPageUrl);
 
                     if (which < labelArray.length - 1) {
-                        writeTagIntent.putExtra("item", widget.item().name());
-                        writeTagIntent.putExtra("itemType", widget.item().type());
-                        writeTagIntent.putExtra("command", commands.get(which));
+                        writeTagIntent.putExtra(WriteTagActivity.QUERY_PARAMETER_ITEM_NAME,
+                                widget.item().name());
+                        writeTagIntent.putExtra(WriteTagActivity.QUERY_PARAMETER_STATE,
+                                commands.get(which));
+                        writeTagIntent.putExtra(WriteTagActivity.QUERY_PARAMETER_MAPPED_STATE,
+                                labels.get(which));
+                        writeTagIntent.putExtra(WriteTagActivity.QUERY_PARAMETER_ITEM_LABEL,
+                                widget.item().label());
                     }
                     startActivityForResult(writeTagIntent, 0);
                 })

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
@@ -27,6 +27,7 @@ import org.openhab.habdroid.R;
 import org.openhab.habdroid.model.Item;
 import org.openhab.habdroid.model.LabeledValue;
 import org.openhab.habdroid.model.LinkedPage;
+import org.openhab.habdroid.model.NfcTag;
 import org.openhab.habdroid.model.ParsedState;
 import org.openhab.habdroid.model.Widget;
 import org.openhab.habdroid.ui.widget.RecyclerViewSwipeRefreshLayout;
@@ -188,16 +189,16 @@ public class WidgetListFragment extends Fragment
                 .setTitle(R.string.nfc_dialog_title)
                 .setItems(labelArray, (dialog, which) -> {
                     Intent writeTagIntent = new Intent(getActivity(), WriteTagActivity.class);
-                    writeTagIntent.putExtra("sitemapPage", mPageUrl);
+                    writeTagIntent.putExtra(WriteTagActivity.EXTRA_SITEMAP_PAGE, mPageUrl);
 
                     if (which < labelArray.length - 1) {
-                        writeTagIntent.putExtra(WriteTagActivity.QUERY_PARAMETER_ITEM_NAME,
+                        writeTagIntent.putExtra(NfcTag.QUERY_PARAMETER_ITEM_NAME,
                                 widget.item().name());
-                        writeTagIntent.putExtra(WriteTagActivity.QUERY_PARAMETER_STATE,
+                        writeTagIntent.putExtra(NfcTag.QUERY_PARAMETER_STATE,
                                 commands.get(which));
-                        writeTagIntent.putExtra(WriteTagActivity.QUERY_PARAMETER_MAPPED_STATE,
+                        writeTagIntent.putExtra(NfcTag.QUERY_PARAMETER_MAPPED_STATE,
                                 labels.get(which));
-                        writeTagIntent.putExtra(WriteTagActivity.QUERY_PARAMETER_ITEM_LABEL,
+                        writeTagIntent.putExtra(NfcTag.QUERY_PARAMETER_ITEM_LABEL,
                                 widget.item().label());
                     }
                     startActivityForResult(writeTagIntent, 0);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
@@ -14,6 +14,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.nfc.FormatException;
 import android.nfc.NdefMessage;
 import android.nfc.NdefRecord;
@@ -167,16 +168,26 @@ public class WriteTagActivity extends AbstractBaseActivity {
                 try {
                     sitemapUri = new URI(mSitemapPage);
                     if (!TextUtils.isEmpty(mItem) && !TextUtils.isEmpty(mState)) {
-                        longUri = "openhabitem://?" + QUERY_PARAMETER_ITEM_NAME + "=" + mItem
-                                + "&" + QUERY_PARAMETER_STATE + "=" + mState
-                                + "&" + QUERY_PARAMETER_MAPPED_STATE + "=" + mMappedState
-                                + "&" + QUERY_PARAMETER_ITEM_LABEL + "=" + mLabel;
-                        shortUri = "openhabitem://?" + QUERY_PARAMETER_ITEM_NAME + "=" + mItem
-                                + "&" + QUERY_PARAMETER_STATE + "=" + mState;
+                        Uri.Builder uriBuilder = new Uri.Builder()
+                                .scheme("openhabitem")
+                                .authority("")
+                                .appendQueryParameter(QUERY_PARAMETER_ITEM_NAME, mItem)
+                                .appendQueryParameter(QUERY_PARAMETER_STATE, mState);
+
+                        shortUri = uriBuilder.toString();
+
+                        longUri = uriBuilder
+                                .appendQueryParameter(QUERY_PARAMETER_MAPPED_STATE, mMappedState)
+                                .appendQueryParameter(QUERY_PARAMETER_ITEM_LABEL, mLabel)
+                                .toString();
                     } else if (!sitemapUri.getPath().startsWith("/rest/sitemaps")) {
                         throw new URISyntaxException(mSitemapPage, "Expected a sitemap URL");
                     } else {
-                        longUri = "openhab://" + sitemapUri.getPath().substring(14);
+                        longUri = new Uri.Builder()
+                                .scheme("openhab")
+                                .authority("")
+                                .appendPath(sitemapUri.getPath().substring(15))
+                                .toString();
                     }
                 } catch (URISyntaxException e) {
                     Log.e(TAG, e.getMessage());

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
@@ -58,13 +58,13 @@ public class WriteTagActivity extends AbstractBaseActivity {
     private Uri mLongUri;
     private Uri mShortUri;
 
-    public static Intent createItemUpdateIntent(Context context, String parentSitemapUrl,
-            String itemName, String state, String mappedState, String label) {
+    public static Intent createItemUpdateIntent(Context context, String itemName, String state,
+            String mappedState, String label) {
         if (TextUtils.isEmpty(itemName) || TextUtils.isEmpty(state)) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Item name or state is empty");
         }
         Uri.Builder uriBuilder = new Uri.Builder()
-                .scheme("openhab")
+                .scheme(NfcTag.SCHEME)
                 .authority("")
                 .appendQueryParameter(NfcTag.QUERY_PARAMETER_ITEM_NAME, itemName)
                 .appendQueryParameter(NfcTag.QUERY_PARAMETER_STATE, state);
@@ -86,7 +86,7 @@ public class WriteTagActivity extends AbstractBaseActivity {
             throw new IllegalArgumentException("Expected a sitemap URL");
         }
         Uri longUri = new Uri.Builder()
-                .scheme("openhab")
+                .scheme(NfcTag.SCHEME)
                 .authority("")
                 .appendEncodedPath(sitemapUri.getPath().substring(15))
                 .build();

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
@@ -253,7 +253,8 @@ public class WriteTagActivity extends AbstractBaseActivity {
                     progressBar.setVisibility(View.INVISIBLE);
 
                     ImageView watermark = findViewById(R.id.nfc_watermark);
-                    watermark.setImageDrawable(ContextCompat.getDrawable(getBaseContext(), R.drawable.ic_nfc_black_180dp));
+                    watermark.setImageDrawable(ContextCompat.getDrawable(getBaseContext(),
+                            R.drawable.ic_nfc_black_180dp));
 
                     writeTagMessage.setText(R.string.info_write_tag_finished);
                     new Handler().postDelayed(WriteTagActivity.this::finish, 2000);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
@@ -45,6 +45,7 @@ import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 
 import org.openhab.habdroid.R;
+import org.openhab.habdroid.model.NfcTag;
 
 import java.io.IOException;
 import java.net.URI;
@@ -53,10 +54,8 @@ import java.util.Locale;
 
 public class WriteTagActivity extends AbstractBaseActivity {
     private static final String TAG = WriteTagActivity.class.getSimpleName();
-    public static final String QUERY_PARAMETER_ITEM_NAME = "i";
-    public static final String QUERY_PARAMETER_STATE = "s";
-    public static final String QUERY_PARAMETER_MAPPED_STATE = "m";
-    public static final String QUERY_PARAMETER_ITEM_LABEL = "l";
+
+    public static final String EXTRA_SITEMAP_PAGE = "sitemapPage";
 
     private NfcAdapter mNfcAdapter;
     private String mSitemapPage;
@@ -86,11 +85,11 @@ public class WriteTagActivity extends AbstractBaseActivity {
 
         setResult(RESULT_OK);
 
-        mSitemapPage = getIntent().getStringExtra("sitemapPage");
-        mItem = getIntent().getStringExtra(QUERY_PARAMETER_ITEM_NAME);
-        mState = getIntent().getStringExtra(QUERY_PARAMETER_STATE);
-        mMappedState = getIntent().getStringExtra(QUERY_PARAMETER_MAPPED_STATE);
-        mLabel = getIntent().getStringExtra(QUERY_PARAMETER_ITEM_LABEL);
+        mSitemapPage = getIntent().getStringExtra(EXTRA_SITEMAP_PAGE);
+        mItem = getIntent().getStringExtra(NfcTag.QUERY_PARAMETER_ITEM_NAME);
+        mState = getIntent().getStringExtra(NfcTag.QUERY_PARAMETER_STATE);
+        mMappedState = getIntent().getStringExtra(NfcTag.QUERY_PARAMETER_MAPPED_STATE);
+        mLabel = getIntent().getStringExtra(NfcTag.QUERY_PARAMETER_ITEM_LABEL);
         Log.d(TAG, String.format(Locale.US,
                 "Got sitemap '%s', item '%s', state '%s', mapped state '%s', label '%s'",
                 mSitemapPage, mItem, mState, mMappedState, mLabel));
@@ -169,22 +168,22 @@ public class WriteTagActivity extends AbstractBaseActivity {
                     sitemapUri = new URI(mSitemapPage);
                     if (!TextUtils.isEmpty(mItem) && !TextUtils.isEmpty(mState)) {
                         Uri.Builder uriBuilder = new Uri.Builder()
-                                .scheme("openhab")
+                                .scheme(NfcTag.SCHEME)
                                 .authority("")
-                                .appendQueryParameter(QUERY_PARAMETER_ITEM_NAME, mItem)
-                                .appendQueryParameter(QUERY_PARAMETER_STATE, mState);
+                                .appendQueryParameter(NfcTag.QUERY_PARAMETER_ITEM_NAME, mItem)
+                                .appendQueryParameter(NfcTag.QUERY_PARAMETER_STATE, mState);
 
                         shortUri = uriBuilder.toString();
 
                         longUri = uriBuilder
-                                .appendQueryParameter(QUERY_PARAMETER_MAPPED_STATE, mMappedState)
-                                .appendQueryParameter(QUERY_PARAMETER_ITEM_LABEL, mLabel)
+                                .appendQueryParameter(NfcTag.QUERY_PARAMETER_MAPPED_STATE, mMappedState)
+                                .appendQueryParameter(NfcTag.QUERY_PARAMETER_ITEM_LABEL, mLabel)
                                 .toString();
                     } else if (!sitemapUri.getPath().startsWith("/rest/sitemaps")) {
                         throw new URISyntaxException(mSitemapPage, "Expected a sitemap URL");
                     } else {
                         longUri = new Uri.Builder()
-                                .scheme("openhab")
+                                .scheme(NfcTag.SCHEME)
                                 .authority("")
                                 .appendEncodedPath(sitemapUri.getPath().substring(15))
                                 .toString();
@@ -268,7 +267,7 @@ public class WriteTagActivity extends AbstractBaseActivity {
                     progressBar.setVisibility(View.INVISIBLE);
 
                     ImageView watermark = findViewById(R.id.nfc_watermark);
-                    watermark.setImageDrawable(getDrawable(R.drawable.ic_nfc_black_180dp));
+                    watermark.setImageDrawable(ContextCompat.getDrawable(getBaseContext(), R.drawable.ic_nfc_black_180dp));
 
                     writeTagMessage.setText(R.string.info_write_tag_finished);
                     new Handler().postDelayed(WriteTagActivity.this::finish, 2000);
@@ -294,7 +293,7 @@ public class WriteTagActivity extends AbstractBaseActivity {
             final View view = inflater.inflate(R.layout.fragment_writenfc, container, false);
             final ImageView watermark = view.findViewById(R.id.nfc_watermark);
 
-            Drawable nfcIcon = getResources().getDrawable(getWatermarkIcon());
+            Drawable nfcIcon = ContextCompat.getDrawable(getContext(), getWatermarkIcon());
             nfcIcon.setColorFilter(
                     ContextCompat.getColor(getActivity(), R.color.empty_list_text_color),
                     PorterDuff.Mode.SRC_IN);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
@@ -247,7 +247,7 @@ public class WriteTagActivity extends AbstractBaseActivity {
                     watermark.setImageDrawable(getDrawable(R.drawable.ic_nfc_black_180dp));
 
                     writeTagMessage.setText(R.string.info_write_tag_finished);
-                    autoCloseActivity();
+                    new Handler().postDelayed(WriteTagActivity.this::finish, 2000);
                 } else {
                     writeTagMessage.setText(R.string.info_write_failed);
                 }
@@ -267,10 +267,6 @@ public class WriteTagActivity extends AbstractBaseActivity {
         }
         NdefRecord[] longNdefRecords = new NdefRecord[] { NdefRecord.createUri(uri) };
         return new NdefMessage(longNdefRecords);
-    }
-
-    private void autoCloseActivity() {
-        new Handler().postDelayed(this::finish, 2000);
     }
 
     public abstract static class AbstractNfcFragment extends Fragment {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
@@ -169,7 +169,7 @@ public class WriteTagActivity extends AbstractBaseActivity {
                     sitemapUri = new URI(mSitemapPage);
                     if (!TextUtils.isEmpty(mItem) && !TextUtils.isEmpty(mState)) {
                         Uri.Builder uriBuilder = new Uri.Builder()
-                                .scheme("openhabitem")
+                                .scheme("openhab")
                                 .authority("")
                                 .appendQueryParameter(QUERY_PARAMETER_ITEM_NAME, mItem)
                                 .appendQueryParameter(QUERY_PARAMETER_STATE, mState);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
@@ -202,10 +202,15 @@ public class WriteTagActivity extends AbstractBaseActivity {
                                 ndefFormatable.format(shortMessage);
                             }
                         }
-                        ndefFormatable.close();
                         return true;
                     } catch (IOException | FormatException e) {
                         Log.e(TAG, "Writing to unformatted tag failed: " + e);
+                    } finally {
+                        try {
+                            ndefFormatable.close();
+                        } catch (IOException e) {
+                            Log.e(TAG, "Closing ndefFormatable failed", e);
+                        }
                     }
                 } else {
                     Log.d(TAG, "Tag is initialized, writing");
@@ -225,11 +230,15 @@ public class WriteTagActivity extends AbstractBaseActivity {
                                     }
                                 }
                             }
-                            Log.d(TAG, "Closing");
-                            ndef.close();
                             return true;
                         } catch (IOException | FormatException e) {
                             Log.e(TAG, "Writing to formatted tag failed", e);
+                        } finally {
+                            try {
+                                ndef.close();
+                            } catch (IOException e) {
+                                Log.e(TAG, "Closing ndef failed", e);
+                            }
                         }
                     } else {
                         Log.e(TAG, "Ndef == null");

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
@@ -149,12 +149,16 @@ public class WriteTagActivity extends AbstractBaseActivity {
 
         new AsyncTask<Void, Integer, Boolean>() {
             @Override
+            protected void onPreExecute() {
+                TextView writeTagMessage = findViewById(R.id.write_tag_message);
+                writeTagMessage.setText(R.string.info_write_tag_progress);
+            }
+
+            @Override
             protected Boolean doInBackground(Void... voids) {
                 Tag tag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
                 Log.d(TAG, "NFC TAG = " + tag.toString());
                 Log.d(TAG, "Writing page " + mSitemapPage + " to tag");
-
-                publishProgress(R.string.info_write_tag_progress);
 
                 URI sitemapUri;
                 String longUri = "";
@@ -251,12 +255,6 @@ public class WriteTagActivity extends AbstractBaseActivity {
                 } else {
                     writeTagMessage.setText(R.string.info_write_failed);
                 }
-            }
-
-            @Override
-            protected void onProgressUpdate(Integer... values) {
-                TextView writeTagMessage = findViewById(R.id.write_tag_message);
-                writeTagMessage.setText(values[0]);
             }
         }.execute();
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
@@ -186,7 +186,7 @@ public class WriteTagActivity extends AbstractBaseActivity {
                         longUri = new Uri.Builder()
                                 .scheme("openhab")
                                 .authority("")
-                                .appendPath(sitemapUri.getPath().substring(15))
+                                .appendEncodedPath(sitemapUri.getPath().substring(15))
                                 .toString();
                     }
                 } catch (URISyntaxException e) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
@@ -49,6 +49,8 @@ import java.net.URISyntaxException;
 
 public class WriteTagActivity extends AbstractBaseActivity {
     private static final String TAG = WriteTagActivity.class.getSimpleName();
+    public static final String QUERY_PARAMETER_ITEM_NAME = "i";
+    public static final String QUERY_PARAMETER_STATE = "s";
 
     private NfcAdapter mNfcAdapter;
     private String mSitemapPage;
@@ -144,16 +146,18 @@ public class WriteTagActivity extends AbstractBaseActivity {
 
         try {
             URI sitemapUri = new URI(mSitemapPage);
-            if (!sitemapUri.getPath().startsWith("/rest/sitemaps")) {
-                throw new URISyntaxException(mSitemapPage, "Expected a sitemap URL");
-            }
-            StringBuilder uriToWrite = new StringBuilder("openhab://sitemaps");
-            uriToWrite.append(sitemapUri.getPath().substring(14));
+            String uriToWrite;
             if (!TextUtils.isEmpty(mItem) && !TextUtils.isEmpty(mCommand)) {
-                uriToWrite.append("?item=").append(mItem).append("&command=").append(mCommand);
+                uriToWrite = "openhabitem://?" + QUERY_PARAMETER_ITEM_NAME + "=" + mItem
+                        + "&" + QUERY_PARAMETER_STATE + "=" + mCommand;
+            } else if (!sitemapUri.getPath().startsWith("/rest/sitemaps")) {
+                throw new URISyntaxException(mSitemapPage, "Expected a sitemap URL");
+            } else {
+                uriToWrite = "openhab://" + sitemapUri.getPath().substring(14);
             }
+
             writeTagMessage.setText(R.string.info_write_tag_progress);
-            writeTag(tagFromIntent, uriToWrite.toString());
+            writeTag(tagFromIntent, uriToWrite);
         } catch (URISyntaxException e) {
             Log.e(TAG, e.getMessage());
             writeTagMessage.setText(R.string.info_write_failed);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/RecyclerViewSwipeRefreshLayout.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/RecyclerViewSwipeRefreshLayout.java
@@ -5,7 +5,6 @@ import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
-
 import androidx.core.view.NestedScrollingChildHelper;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/SegmentedControlButton.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/SegmentedControlButton.java
@@ -23,7 +23,6 @@ import android.graphics.Paint;
 import android.graphics.Paint.Style;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
-
 import androidx.annotation.ColorInt;
 import androidx.annotation.IdRes;
 import androidx.appcompat.content.res.AppCompatResources;

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/UrlInputPreference.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/UrlInputPreference.java
@@ -11,7 +11,6 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
-
 import androidx.annotation.StringRes;
 
 import org.openhab.habdroid.R;

--- a/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.java
@@ -13,7 +13,6 @@ import androidx.annotation.VisibleForTesting;
 
 import com.here.oksse.OkSse;
 import com.here.oksse.ServerSentEvent;
-
 import okhttp3.CacheControl;
 import okhttp3.Call;
 import okhttp3.Credentials;

--- a/mobile/src/main/java/org/openhab/habdroid/util/Util.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Util.java
@@ -15,16 +15,20 @@ import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.util.TypedValue;
 import android.webkit.WebView;
 import android.webkit.WebViewDatabase;
+import android.widget.Toast;
 import androidx.annotation.AttrRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.StyleRes;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
+import es.dmoral.toasty.Toasty;
 import okhttp3.Headers;
 import okhttp3.Request;
 import org.json.JSONArray;
@@ -351,5 +355,14 @@ public class Util {
             Log.e(TAG, "REST call to " + url + " failed", error);
             return error.getMessage();
         }
+    }
+
+    /**
+     * Shows an orange Toast with the openHAB icon. Can be called from the background.
+     */
+    public static void showToast(Context context, CharSequence message) {
+        new Handler(Looper.getMainLooper()).post(() -> Toasty.custom(context, message,
+                R.drawable.ic_openhab_appicon_24dp, R.color.openhab_orange, Toast.LENGTH_SHORT,
+                true, true).show());
     }
 }

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -138,6 +138,8 @@
     <string name="info_openhab_push_notification_label">Push notification status</string>
     <string name="action_settings">Settings</string>
     <string name="nfc_dialog_title">Write NFC tag action for this element</string>
+    <string name="nfc_tag_recognized_label">NFC tag for \"%s\" recognized</string>
+    <string name="nfc_tag_recognized_item">NFC tag for Item \"%s\" recognized</string>
     <string name="info_not_set">Not set</string>
     <string name="empty_page">This page doesn\'t contain any widgets that are set to be visible</string>
 

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -126,6 +126,7 @@
     <string name="install">Install</string>
     <string name="title_activity_openhabwritetag">Write NFC tag</string>
     <string name="title_activity_libraries">Used libraries</string>
+    <string name="info_write_tag_again">Please write this tag again for better user experience. Item %s has been set to %s.</string>
     <string name="info_write_tag">Touch the tag and keep it close until the confirmation message appear</string>
     <string name="info_write_tag_progress">Writing the tag</string>
     <string name="info_write_tag_finished">Successfully finished</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -126,7 +126,6 @@
     <string name="install">Install</string>
     <string name="title_activity_openhabwritetag">Write NFC tag</string>
     <string name="title_activity_libraries">Used libraries</string>
-    <string name="info_write_tag_again">Please write this tag again for better user experience. Item %s has been set to %s.</string>
     <string name="info_write_tag">Touch the tag and keep it close until the confirmation message appear</string>
     <string name="info_write_tag_progress">Writing the tag</string>
     <string name="info_write_tag_finished">Successfully finished</string>


### PR DESCRIPTION
Create a new scheme that is only used for item updates. This way we can
have a background responder for NFC item updates. It uses the framework
introduced in #1137.

If an old tag is used, we show a message to the user to renew his tag.

See https://github.com/openhab/openhab-android/issues/538#issuecomment-480483543
See #13 (Shorter parameter names and no sitemap require less bytes)

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>