### PR TITLE
Remove useless function overridePendingTransition()

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
@@ -85,12 +85,6 @@ public class AboutActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void finish() {
-        super.finish();
-        Util.overridePendingTransition(this, true);
-    }
-
-    @Override
     public void onBackStackChanged() {
         updateTitle();
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -769,7 +769,6 @@ public class MainActivity extends AppCompatActivity implements
         aboutIntent.putExtra("serverProperties", mServerProperties);
 
         startActivityForResult(aboutIntent, INFO_REQUEST_CODE);
-        Util.overridePendingTransition(this, false);
     }
 
     private Sitemap selectConfiguredSitemapFromList() {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.java
@@ -10,7 +10,6 @@
 package org.openhab.habdroid.ui;
 
 import android.app.FragmentManager;
-import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.drawable.Drawable;
@@ -106,12 +105,6 @@ public class PreferencesActivity extends AppCompatActivity {
             default:
                 return super.onOptionsItemSelected(item);
         }
-    }
-
-    @Override
-    public void finish() {
-        super.finish();
-        Util.overridePendingTransition(this, true);
     }
 
     public void handleThemeChange() {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
@@ -189,7 +189,6 @@ public class WidgetListFragment extends Fragment
                         writeTagIntent.putExtra("command", commands.get(which));
                     }
                     startActivityForResult(writeTagIntent, 0);
-                    Util.overridePendingTransition(getActivity(), false);
                 })
                 .show();
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.java
@@ -211,12 +211,6 @@ public class WriteTagActivity extends AppCompatActivity {
         watermark.setImageDrawable(getDrawable(R.drawable.ic_nfc_black_180dp));
     }
 
-    @Override
-    public void finish() {
-        super.finish();
-        Util.overridePendingTransition(this, true);
-    }
-
     private void autoCloseActivity() {
         new Handler().postDelayed(this::finish, 2000);
     }

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
@@ -20,7 +20,6 @@ public class Constants {
     public static final String PREFERENCE_REMOTE_URL            = "default_openhab_alturl";
     public static final String PREFERENCE_LOCAL_URL             = "default_openhab_url";
     public static final String PREFERENCE_THEME                 = "default_openhab_theme";
-    public static final String PREFERENCE_ANIMATION             = "default_openhab_animation";
     public static final String PREFERENCE_DEMOMODE              = "default_openhab_demomode";
     public static final String PREFERENCE_FULLSCREEN            = "default_openhab_fullscreen";
     public static final String PREFERENCE_TONE                  = "default_openhab_alertringtone";

--- a/mobile/src/main/java/org/openhab/habdroid/util/Util.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Util.java
@@ -22,7 +22,6 @@ import android.util.Log;
 import android.util.TypedValue;
 import android.webkit.WebView;
 import android.webkit.WebViewDatabase;
-import androidx.annotation.AnimRes;
 import androidx.annotation.AttrRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.StyleRes;
@@ -51,19 +50,6 @@ import java.util.Locale;
 
 public class Util {
     private static final String TAG = Util.class.getSimpleName();
-
-    public static void overridePendingTransition(Activity activity, boolean reverse) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activity);
-        if (!prefs.getString(Constants.PREFERENCE_ANIMATION, "android").equals("android")) {
-            if (prefs.getString(Constants.PREFERENCE_ANIMATION, "android").equals("ios")) {
-                @AnimRes int enterAnim = reverse ? R.anim.slide_in_left : R.anim.slide_in_right;
-                @AnimRes int exitAnim = reverse ? R.anim.slide_out_right : R.anim.slide_out_left;
-                activity.overridePendingTransition(enterAnim, exitAnim);
-            } else {
-                activity.overridePendingTransition(0, 0);
-            }
-        }
-    }
 
     public static String normalizeUrl(String sourceUrl) {
         String normalizedUrl = "";


### PR DESCRIPTION
It was possible to set fragment show/hide animations to be Android like,
iOS like or to disable them. The preference has been removed long ago,
so the code should be removed as well.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>