### PR TITLE
Add failure reason to FCM status

### DIFF
--- a/mobile/src/foss/java/org/openhab/habdroid/core/CloudMessagingHelper.java
+++ b/mobile/src/foss/java/org/openhab/habdroid/core/CloudMessagingHelper.java
@@ -23,7 +23,7 @@ public class CloudMessagingHelper {
     public static void onNotificationSelected(Context context, Intent intent) {
     }
 
-    public static String getPushNotificationStatusResId(Context context) {
+    public static String getPushNotificationStatus(Context context) {
         return context.getString(R.string.info_openhab_notification_status_unavailable);
     }
 

--- a/mobile/src/foss/java/org/openhab/habdroid/core/CloudMessagingHelper.java
+++ b/mobile/src/foss/java/org/openhab/habdroid/core/CloudMessagingHelper.java
@@ -12,7 +12,6 @@ package org.openhab.habdroid.core;
 import android.content.Context;
 import android.content.Intent;
 import androidx.annotation.DrawableRes;
-import androidx.annotation.StringRes;
 
 import org.openhab.habdroid.R;
 import org.openhab.habdroid.core.connection.CloudConnection;
@@ -24,8 +23,8 @@ public class CloudMessagingHelper {
     public static void onNotificationSelected(Context context, Intent intent) {
     }
 
-    public static @StringRes int getPushNotificationStatusResId() {
-        return R.string.info_openhab_notification_status_unavailable;
+    public static String getPushNotificationStatusResId(Context context) {
+        return context.getString(R.string.info_openhab_notification_status_unavailable);
     }
 
     public static @DrawableRes int getPushNotificationIconResId() {

--- a/mobile/src/full/java/org/openhab/habdroid/core/CloudMessagingHelper.java
+++ b/mobile/src/full/java/org/openhab/habdroid/core/CloudMessagingHelper.java
@@ -12,14 +12,16 @@ package org.openhab.habdroid.core;
 import android.content.Context;
 import android.content.Intent;
 import androidx.annotation.DrawableRes;
-import androidx.annotation.StringRes;
 
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
 import org.openhab.habdroid.R;
 import org.openhab.habdroid.core.connection.CloudConnection;
 import org.openhab.habdroid.core.connection.Connection;
 import org.openhab.habdroid.core.connection.ConnectionFactory;
 
 public class CloudMessagingHelper {
+    private static final String TAG = CloudMessagingHelper.class.getSimpleName();
     static boolean sRegistrationDone;
     static Throwable sRegistrationFailureReason;
 
@@ -38,21 +40,27 @@ public class CloudMessagingHelper {
         }
     }
 
-    public static @StringRes int getPushNotificationStatusResId() {
+    public static String getPushNotificationStatusResId(Context context) {
         CloudConnection cloudConnection = (CloudConnection)
                 ConnectionFactory.getConnection(Connection.TYPE_CLOUD);
         if (cloudConnection == null) {
             if (ConnectionFactory.getConnection(Connection.TYPE_REMOTE) == null) {
-                return R.string.info_openhab_gcm_no_remote;
+                return context.getString(R.string.info_openhab_gcm_no_remote);
             } else {
-                return R.string.info_openhab_gcm_unsupported;
+                return context.getString(R.string.info_openhab_gcm_unsupported);
             }
         } else if (!sRegistrationDone) {
-            return R.string.info_openhab_gcm_in_progress;
+            return context.getString(R.string.info_openhab_gcm_in_progress);
         } else if (sRegistrationFailureReason != null) {
-            return R.string.info_openhab_gcm_failed;
+            GoogleApiAvailability gaa = GoogleApiAvailability.getInstance();
+            int errorCode = gaa.isGooglePlayServicesAvailable(context);
+            if (errorCode != ConnectionResult.SUCCESS) {
+                return context.getString(R.string.info_openhab_gcm_failed_with_reason,
+                        gaa.getErrorString(errorCode));
+            }
+            return context.getString(R.string.info_openhab_gcm_failed);
         } else {
-            return R.string.info_openhab_gcm_connected;
+            return context.getString(R.string.info_openhab_gcm_connected);
         }
     }
 

--- a/mobile/src/full/java/org/openhab/habdroid/core/CloudMessagingHelper.java
+++ b/mobile/src/full/java/org/openhab/habdroid/core/CloudMessagingHelper.java
@@ -21,7 +21,6 @@ import org.openhab.habdroid.core.connection.Connection;
 import org.openhab.habdroid.core.connection.ConnectionFactory;
 
 public class CloudMessagingHelper {
-    private static final String TAG = CloudMessagingHelper.class.getSimpleName();
     static boolean sRegistrationDone;
     static Throwable sRegistrationFailureReason;
 
@@ -40,7 +39,7 @@ public class CloudMessagingHelper {
         }
     }
 
-    public static String getPushNotificationStatusResId(Context context) {
+    public static String getPushNotificationStatus(Context context) {
         CloudConnection cloudConnection = (CloudConnection)
                 ConnectionFactory.getConnection(Connection.TYPE_CLOUD);
         if (cloudConnection == null) {

--- a/mobile/src/full/res/values/strings.xml
+++ b/mobile/src/full/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="info_openhab_gcm_unsupported">Unavailable, remote server isn\'t an openHAB cloud instance</string>
     <string name="info_openhab_gcm_in_progress">Device registration is in progress</string>
     <string name="info_openhab_gcm_failed">Device registration failed</string>
-    <string name="info_openhab_gcm_failed_with_reason">Device registration failed: %s</string>
+    <string name="info_openhab_gcm_failed_with_reason">Device registration failed due to a Google Play Services issue: %s</string>
     <string name="info_openhab_gcm_connected">Device successfully registered with Firebase Cloud Messaging</string>
     <string name="notification_channel_default">Default</string>
     <string name="notification_channel_severity_value">Severity \'%1$s\'</string>

--- a/mobile/src/full/res/values/strings.xml
+++ b/mobile/src/full/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="info_openhab_gcm_unsupported">Unavailable, remote server isn\'t an openHAB cloud instance</string>
     <string name="info_openhab_gcm_in_progress">Device registration is in progress</string>
     <string name="info_openhab_gcm_failed">Device registration failed</string>
+    <string name="info_openhab_gcm_failed_with_reason">Device registration failed: %s</string>
     <string name="info_openhab_gcm_connected">Device successfully registered with Firebase Cloud Messaging</string>
     <string name="notification_channel_default">Default</string>
     <string name="notification_channel_severity_value">Severity \'%1$s\'</string>

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
@@ -227,7 +227,7 @@ public class AboutActivity extends AppCompatActivity implements
 
             ohServerCard.addItem(new MaterialAboutActionItem.Builder()
                     .text(R.string.info_openhab_push_notification_label)
-                    .subText(CloudMessagingHelper.getPushNotificationStatusResId())
+                    .subText(CloudMessagingHelper.getPushNotificationStatusResId(context))
                     .icon(CloudMessagingHelper.getPushNotificationIconResId())
                     .build());
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
@@ -227,7 +227,7 @@ public class AboutActivity extends AppCompatActivity implements
 
             ohServerCard.addItem(new MaterialAboutActionItem.Builder()
                     .text(R.string.info_openhab_push_notification_label)
-                    .subText(CloudMessagingHelper.getPushNotificationStatusResId(context))
+                    .subText(CloudMessagingHelper.getPushNotificationStatus(context))
                     .icon(CloudMessagingHelper.getPushNotificationIconResId())
                     .build());
 


### PR DESCRIPTION
Fixes #560

On a device without Play Services it shows "Device registration failed: SERVICE_INVALID". No idea why SERVICE_MISSING isn't returned instead (https://developers.google.com/android/reference/com/google/android/gms/common/ConnectionResult).
I can add a mapping error code => human readable message, but I'm not sure if it's worth to do so.