### PR TITLE
Relax per-host connection limit.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.java
@@ -121,6 +121,10 @@ public final class ConnectionFactory extends BroadcastReceiver implements
                 .build();
         updateHttpClientForClientCert(true);
 
+        // Relax per-host connection limit, as the default limit (max 5 connections per host) is
+        // too low considering SSE connections count against that limit.
+        mHttpClient.dispatcher().setMaxRequestsPerHost(mHttpClient.dispatcher().getMaxRequests());
+
         IntentFilter filter = new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION);
         // Make sure to ignore the initial sticky broadcast, as we're only interested in changes
         mIgnoreNextConnectivityChange = context.registerReceiver(null, filter) != null;


### PR DESCRIPTION
Given SSE connections count against that limit, the default per-host
connection limit (5) is too low, as with that limit no further
connections can be made when reaching a sitemap nesting level of 5
pages. The OH HTTP server should be able to handle more connections, so
generally use the max concurrent request count (64).

Fixes #1329