### PR TITLE
[#1342] Improve web widget in BasicUI

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
@@ -1,6 +1,5 @@
 package org.openhab.habdroid.ui;
 
-import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -11,7 +10,6 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.widget.Toolbar;
@@ -25,7 +23,6 @@ import com.danielstone.materialaboutlibrary.items.MaterialAboutTitleItem;
 import com.danielstone.materialaboutlibrary.model.MaterialAboutCard;
 import com.danielstone.materialaboutlibrary.model.MaterialAboutList;
 import com.mikepenz.aboutlibraries.LibsBuilder;
-import es.dmoral.toasty.Toasty;
 import okhttp3.Headers;
 import okhttp3.Request;
 import org.json.JSONException;
@@ -329,14 +326,7 @@ public class AboutActivity extends AbstractBaseActivity implements
 
         private MaterialAboutItemOnClickAction clickRedirect(final String url) {
             return () -> {
-                Uri uri = Uri.parse(url);
-                Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-                try {
-                    startActivity(intent);
-                } catch (ActivityNotFoundException e) {
-                    Toasty.error(getContext(), R.string.error_no_browser_found,
-                            Toast.LENGTH_LONG, true).show();
-                }
+                Util.openInBrowser(url, getContext());
             };
         }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.java
@@ -1,8 +1,6 @@
 package org.openhab.habdroid.ui;
 
 import android.content.Context;
-import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
@@ -326,7 +324,7 @@ public class AboutActivity extends AbstractBaseActivity implements
 
         private MaterialAboutItemOnClickAction clickRedirect(final String url) {
             return () -> {
-                Util.openInBrowser(url, getContext());
+                Util.openInBrowser(getContext(), url);
             };
         }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -1009,12 +1009,7 @@ public class MainActivity extends AbstractBaseActivity implements
                     startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(
                             "market://details?id=com.google.android.googlequicksearchbox")));
                 } catch (ActivityNotFoundException appStoreNotFoundException) {
-                    try {
-                        startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(
-                                "http://play.google.com/store/apps/details?id=com.google.android.googlequicksearchbox")));
-                    } catch (ActivityNotFoundException browserNotFoundException) {
-                        showSnackbar(R.string.error_no_browser_found);
-                    }
+                    Util.openInBrowser(this, "http://play.google.com/store/apps/details?id=com.google.android.googlequicksearchbox");
                 }
             });
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.java
@@ -1089,11 +1089,9 @@ public class WidgetAdapter extends RecyclerView.Adapter<WidgetAdapter.ViewHolder
             }
 
             String url = mConnection.getAsyncHttpClient().buildUrl(widget.url()).toString();
-            Util.applyAuthentication(mWebView, mConnection, url);
+            Util.initWebView(mWebView, mConnection, url);
             mWebView.setWebViewClient(new AnchorWebViewClient(url,
                     mConnection.getUsername(), mConnection.getPassword()));
-            mWebView.getSettings().setDomStorageEnabled(true);
-            mWebView.getSettings().setJavaScriptEnabled(true);
             mWebView.loadUrl(url);
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/WebViewFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/WebViewFragment.java
@@ -7,7 +7,6 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.webkit.WebChromeClient;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
@@ -173,10 +172,7 @@ public class WebViewFragment extends Fragment implements ConnectionFactory.Updat
                 updateViewVisibility(true, false);
             }
         });
-        Util.applyAuthentication(mWebView, mConnection, url);
-        mWebView.setWebChromeClient(new WebChromeClient());
-        mWebView.getSettings().setDomStorageEnabled(true);
-        mWebView.getSettings().setJavaScriptEnabled(true);
+        Util.initWebView(mWebView, mConnection, url);
         mWebView.loadUrl(url);
         mWebView.setBackgroundColor(Color.TRANSPARENT);
     }

--- a/mobile/src/main/java/org/openhab/habdroid/util/Util.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Util.java
@@ -27,7 +27,6 @@ import android.util.TypedValue;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewDatabase;
-import android.widget.Toast;
 import androidx.annotation.AttrRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -303,21 +302,22 @@ public class Util {
                 Message href = view.getHandler().obtainMessage();
                 view.requestFocusNodeHref(href);
                 String url = href.getData().getString("url");
-                openInBrowser(url, view.getContext());
+                openInBrowser(view.getContext(), url);
                 return false;
             }
         });
     }
 
-    public static void openInBrowser(@Nullable String url, Context context) {
-        if (!TextUtils.isEmpty(url)) {
-            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-            try {
-                context.startActivity(intent);
-            } catch (ActivityNotFoundException e) {
-                Toasty.error(context, R.string.error_no_browser_found,
-                        Toast.LENGTH_LONG, true).show();
-            }
+    public static void openInBrowser(Context context, @Nullable String url) {
+        if (TextUtils.isEmpty(url)) {
+            Log.e(TAG, "Got empty url");
+            return;
+        }
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+        try {
+            context.startActivity(intent);
+        } catch (ActivityNotFoundException e) {
+            Toasty.error(context, R.string.error_no_browser_found, Toasty.LENGTH_LONG).show();
         }
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/util/Util.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Util.java
@@ -396,7 +396,7 @@ public class Util {
      */
     public static void showToast(Context context, CharSequence message) {
         new Handler(Looper.getMainLooper()).post(() -> Toasty.custom(context, message,
-                R.drawable.ic_openhab_appicon_24dp, R.color.openhab_orange, Toast.LENGTH_SHORT,
+                R.drawable.ic_openhab_appicon_24dp, R.color.openhab_orange, Toasty.LENGTH_SHORT,
                 true, true).show());
     }
 }


### PR DESCRIPTION
Set supportsMultipleWindows for the WebView. This prevents the WebView from
following links with target="_blank", which previously were opened in the same
WebView, corrupting the UI. The same adjustment is also made for HABPanel, can
be good there too.

Also set WebWidget background to transparent; this enables to use transparent
HTML background. Useful for e.g. weather informers.

Signed-off-by: Pavel Fedin <pavel_fedin@mail.ru>