### PR TITLE
Improve location parsing

### DIFF
--- a/mobile/src/full/java/org/openhab/habdroid/ui/MapViewHelper.java
+++ b/mobile/src/full/java/org/openhab/habdroid/ui/MapViewHelper.java
@@ -189,7 +189,7 @@ public class MapViewHelper {
 
         private static LatLng toLatLng(ParsedState state) {
             Location location = state != null ? state.asLocation() : null;
-            return state != null
+            return location != null
                     ? new LatLng(location.getLatitude(), location.getLongitude())
                     : null;
         }

--- a/mobile/src/full/java/org/openhab/habdroid/ui/MapViewHelper.java
+++ b/mobile/src/full/java/org/openhab/habdroid/ui/MapViewHelper.java
@@ -2,6 +2,7 @@ package org.openhab.habdroid.ui;
 
 import android.app.AlertDialog;
 import android.content.res.Resources;
+import android.location.Location;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
@@ -151,7 +152,7 @@ public class MapViewHelper {
             if (!mBoundItem.members().isEmpty()) {
                 ArrayList<LatLng> positions = new ArrayList<>();
                 for (Item item : mBoundItem.members()) {
-                    LatLng position = parseLocation(item.state());
+                    LatLng position = toLatLng(item.state());
                     if (position != null) {
                         setMarker(map, position, item, item.label(), canDragMarker);
                         positions.add(position);
@@ -169,7 +170,7 @@ public class MapViewHelper {
                     }
                 }
             } else {
-                LatLng position = parseLocation(mBoundItem.state());
+                LatLng position = toLatLng(mBoundItem.state());
                 if (position != null) {
                     setMarker(map, position, mBoundItem, mLabelView.getText(), canDragMarker);
                     map.moveCamera(CameraUpdateFactory.newLatLngZoom(position, zoomLevel));
@@ -186,17 +187,11 @@ public class MapViewHelper {
             map.addMarker(marker).setTag(item);
         }
 
-        private static LatLng parseLocation(ParsedState state) {
-            String location = state != null ? state.asString() : null;
-            String[] splitState = location != null ? location.split(",") : null;
-            if (splitState != null && splitState.length == 2) {
-                try {
-                    return new LatLng(Float.valueOf(splitState[0]), Float.valueOf(splitState[1]));
-                } catch (NumberFormatException e) {
-                    // ignored
-                }
-            }
-            return null;
+        private static LatLng toLatLng(ParsedState state) {
+            Location location = state != null ? state.asLocation() : null;
+            return state != null
+                    ? new LatLng(location.getLatitude(), location.getLongitude())
+                    : null;
         }
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.java
@@ -1,5 +1,6 @@
 package org.openhab.habdroid.model;
 
+import android.location.Location;
 import android.os.Parcel;
 import android.os.Parcelable;
 import androidx.annotation.NonNull;
@@ -122,6 +123,7 @@ public abstract class ParsedState implements Parcelable {
         abstract Builder asNumber(@Nullable NumberState number);
         abstract Builder asHsv(@Nullable float[] hsv);
         abstract Builder asBrightness(@Nullable Integer brightness);
+        abstract Builder asLocation(@Nullable Location location);
         abstract ParsedState build();
     }
 
@@ -142,6 +144,7 @@ public abstract class ParsedState implements Parcelable {
                 .asNumber(parseAsNumber(state, numberPattern))
                 .asHsv(parseAsHsv(state))
                 .asBrightness(parseAsBrightness(state))
+                .asLocation(parseAsLocation(state))
                 .build();
     }
 
@@ -154,6 +157,8 @@ public abstract class ParsedState implements Parcelable {
     public abstract float[] asHsv();
     @Nullable
     public abstract Integer asBrightness();
+    @Nullable
+    public abstract Location asLocation();
 
     private static boolean parseAsBoolean(String state) {
         // If state is ON for switches return True
@@ -207,6 +212,21 @@ public abstract class ParsedState implements Parcelable {
                 };
             } catch (NumberFormatException e) {
                 // fall through
+            }
+        }
+        return null;
+    }
+
+    private static Location parseAsLocation(String state) {
+        String[] splitState = state.split(",");
+        if (splitState.length == 2) {
+            try {
+                Location l = new Location((String) null);
+                l.setLatitude(Float.valueOf(splitState[0]));
+                l.setLongitude(Float.valueOf(splitState[1]));
+                return l;
+            } catch (NumberFormatException e) {
+                // ignored
             }
         }
         return null;

--- a/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.java
@@ -3,6 +3,7 @@ package org.openhab.habdroid.model;
 import android.location.Location;
 import android.os.Parcel;
 import android.os.Parcelable;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -219,12 +220,19 @@ public abstract class ParsedState implements Parcelable {
 
     private static Location parseAsLocation(String state) {
         String[] splitState = state.split(",");
-        if (splitState.length == 2) {
+        // Valid states are either "latitude,longitude" or "latitude,longitude,elevation",
+        // (we ignore elevation in the latter case)
+        if (splitState.length == 2 || splitState.length == 3) {
             try {
-                Location l = new Location((String) null);
+                Location l = new Location("openhab");
                 l.setLatitude(Float.valueOf(splitState[0]));
                 l.setLongitude(Float.valueOf(splitState[1]));
-                return l;
+                l.setTime(System.currentTimeMillis());
+                // Do our best to avoid parsing e.g. HSV values into location by
+                // sanity checking the values
+                if (Math.abs(l.getLatitude()) <= 90 && Math.abs(l.getLongitude()) <= 90) {
+                    return l;
+                }
             } catch (NumberFormatException e) {
                 // ignored
             }

--- a/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.java
@@ -221,13 +221,15 @@ public abstract class ParsedState implements Parcelable {
     private static Location parseAsLocation(String state) {
         String[] splitState = state.split(",");
         // Valid states are either "latitude,longitude" or "latitude,longitude,elevation",
-        // (we ignore elevation in the latter case)
         if (splitState.length == 2 || splitState.length == 3) {
             try {
                 Location l = new Location("openhab");
-                l.setLatitude(Float.valueOf(splitState[0]));
-                l.setLongitude(Float.valueOf(splitState[1]));
+                l.setLatitude(Double.valueOf(splitState[0]));
+                l.setLongitude(Double.valueOf(splitState[1]));
                 l.setTime(System.currentTimeMillis());
+                if (splitState.length == 3) {
+                    l.setAltitude(Double.valueOf(splitState[2]));
+                }
                 // Do our best to avoid parsing e.g. HSV values into location by
                 // sanity checking the values
                 if (Math.abs(l.getLatitude()) <= 90 && Math.abs(l.getLongitude()) <= 90) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.java
@@ -353,12 +353,12 @@ public class PageConnectionHolderFragment extends Fragment {
                     widgetList.add(w);
                 }
 
+                Log.d(TAG, "Updated page data for URL " + mUrl
+                        + " (" + widgetList.size() + " widgets)");
                 if (mCallback.isDetailedLoggingEnabled()) {
-                    Log.d(TAG, "Updated page data for URL " + mUrl
-                            + ": widget list " + widgetList);
-                } else {
-                    Log.d(TAG, "Updated page data for URL " + mUrl
-                            + " (" + widgetList.size() + " widgets)");
+                    for (int i = 0; i < widgetList.size(); i++) {
+                        Log.d(TAG, "Widget " + (i + 1) + ": " + widgetList.get(i));
+                    }
                 }
                 mLastPageTitle = dataSource.getTitle();
                 mLastWidgetList = widgetList;


### PR DESCRIPTION
Move it to the correct place, and make it more lenient to also cover the 'latitude,longitude,elevation' case.

Fixes issue reported in https://community.openhab.org/t/mapview-in-android-app-does-not-show-the-location/73379