### PR TITLE
Fix crash in svg parsing

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -107,7 +107,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:logging-interceptor:3.12.1'
     implementation 'com.github.heremaps:oksse:0.9.0'
     implementation 'com.larswerkman:HoloColorPicker:1.5'
-    implementation 'com.github.BigBadaboom:androidsvg:3511e136498da94018ef9fa438895984ea9b99db'
+    implementation 'com.caverock:androidsvg-aar:1.4'
     implementation('com.github.paolorotolo:appintro:v5.1.0') {
         transitive false
         exclude group: 'com.intellij', module: 'annotations'


### PR DESCRIPTION
Fixed in https://github.com/BigBadaboom/androidsvg/issues/170

````java
Fatal Exception: java.lang.IllegalArgumentException: bad base-64
       at android.util.Base64.decode(Base64.java:161)
       at android.util.Base64.decode(Base64.java:136)
       at android.util.Base64.decode(Base64.java:118)
       at com.caverock.androidsvg.SVGAndroidRenderer.checkForImageDataURL(SVGAndroidRenderer.java:1939)
       at com.caverock.androidsvg.SVGAndroidRenderer.render(SVGAndroidRenderer.java:1860)
       at com.caverock.androidsvg.SVGAndroidRenderer.render(SVGAndroidRenderer.java:300)
       at com.caverock.androidsvg.SVGAndroidRenderer.renderChildren(SVGAndroidRenderer.java:334)
       at com.caverock.androidsvg.SVGAndroidRenderer.render(SVGAndroidRenderer.java:623)
       at com.caverock.androidsvg.SVGAndroidRenderer.render(SVGAndroidRenderer.java:298)
       at com.caverock.androidsvg.SVGAndroidRenderer.renderChildren(SVGAndroidRenderer.java:334)
       at com.caverock.androidsvg.SVGAndroidRenderer.render(SVGAndroidRenderer.java:580)
       at com.caverock.androidsvg.SVGAndroidRenderer.renderDocument(SVGAndroidRenderer.java:268)
       at com.caverock.androidsvg.SVG.renderToCanvas(SVG.java:466)
       at com.caverock.androidsvg.SVG.renderToCanvas(SVG.java:443)
       at org.openhab.habdroid.util.AsyncHttpClient$BitmapResponseHandler.getBitmapFromSvgInputstream(AsyncHttpClient.java:126)
       at org.openhab.habdroid.util.AsyncHttpClient$BitmapResponseHandler.convertBodyInBackground(AsyncHttpClient.java:67)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>