### PR TITLE
Reduce verbosity when starting app

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -48,7 +48,6 @@ android {
             buildConfigField 'boolean', IS_DEVELOPER, 'true'
             buildConfigField "java.util.Date", "buildTime", "new java.util.Date(" + System.currentTimeMillis() + "L)"
             pseudoLocalesEnabled true
-            testCoverageEnabled true
         }
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/util/Util.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Util.java
@@ -72,7 +72,7 @@ public class Util {
                 normalizedUrl = normalizedUrl + "/";
             }
         } catch (MalformedURLException e) {
-            Log.e(TAG, "normalizeUrl: invalid URL");
+            Log.d(TAG, "normalizeUrl(): Invalid URL '" + sourceUrl + "'");
         }
         return normalizedUrl;
     }


### PR DESCRIPTION
* Make normalizeUrl() log as debug, not error and print the actual url
* Prevent this stacktrace:

````
05-11 09:29:01.288 org.openhab.habdroid.beta W/System.err: java.io.FileNotFoundException: /jacoco.exec: open failed: EROFS (Read-only file system)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at libcore.io.IoBridge.open(IoBridge.java:456)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at java.io.FileOutputStream.<init>(FileOutputStream.java:89)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at org.jacoco.agent.rt.internal_8ff85ea.output.FileOutput.openFile(FileOutput.java:67)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at org.jacoco.agent.rt.internal_8ff85ea.output.FileOutput.startup(FileOutput.java:49)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at org.jacoco.agent.rt.internal_8ff85ea.Agent.startup(Agent.java:122)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at org.jacoco.agent.rt.internal_8ff85ea.Agent.getInstance(Agent.java:50)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at org.jacoco.agent.rt.internal_8ff85ea.Offline.<clinit>(Offline.java:31)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at org.openhab.habdroid.core.OpenHabApplication.$jacocoInit(OpenHabApplication.java)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at org.openhab.habdroid.core.OpenHabApplication.<init>(OpenHabApplication.java)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at java.lang.reflect.Constructor.newInstance(Native Method)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at java.lang.Class.newInstance(Class.java:1603)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at android.app.Instrumentation.newApplication(Instrumentation.java:997)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at android.app.Instrumentation.newApplication(Instrumentation.java:981)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at android.app.LoadedApk.makeApplication(LoadedApk.java:590)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at android.app.ActivityThread.handleBindApplication(ActivityThread.java:4853)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at android.app.ActivityThread.access$1500(ActivityThread.java:160)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1382)
05-11 09:29:01.289 org.openhab.habdroid.beta W/System.err:     at android.os.Handler.dispatchMessage(Handler.java:102)
05-11 09:29:01.290 org.openhab.habdroid.beta W/System.err:     at android.os.Looper.loop(Looper.java:135)
05-11 09:29:01.290 org.openhab.habdroid.beta W/System.err:     at android.app.ActivityThread.main(ActivityThread.java:5597)
05-11 09:29:01.290 org.openhab.habdroid.beta W/System.err:     at java.lang.reflect.Method.invoke(Native Method)
05-11 09:29:01.290 org.openhab.habdroid.beta W/System.err:     at java.lang.reflect.Method.invoke(Method.java:372)
05-11 09:29:01.290 org.openhab.habdroid.beta W/System.err:     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:984)
05-11 09:29:01.290 org.openhab.habdroid.beta W/System.err:     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)
05-11 09:29:01.290 org.openhab.habdroid.beta W/System.err: Caused by: android.system.ErrnoException: open failed: EROFS (Read-only file system)
05-11 09:29:01.290 org.openhab.habdroid.beta W/System.err:     at libcore.io.Posix.open(Native Method)
05-11 09:29:01.290 org.openhab.habdroid.beta W/System.err:     at libcore.io.BlockGuardOs.open(BlockGuardOs.java:186)
05-11 09:29:01.290 org.openhab.habdroid.beta W/System.err:     at libcore.io.IoBridge.open(IoBridge.java:442)
05-11 09:29:01.290 org.openhab.habdroid.beta W/System.err: 	... 23 more
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>