### PR TITLE
Fix chart and image widget scaling.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.java
@@ -706,7 +706,7 @@ public class MainActivity extends AbstractBaseActivity implements
             return;
         }
         mConnection.getAsyncHttpClient().get(url,
-                new AsyncHttpClient.BitmapResponseHandler(defaultIcon.getIntrinsicWidth()) {
+                new AsyncHttpClient.BitmapResponseHandler(defaultIcon.getIntrinsicWidth(), true) {
             @Override
             public void onFailure(Request request, int statusCode, Throwable error) {
                 Log.w(TAG, "Could not fetch icon for sitemap " + sitemap.name());

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.java
@@ -311,7 +311,7 @@ public class WidgetListFragment extends Fragment
                      **/
                     int foregroundSize = (int) Util.convertDpToPixel(46, context);
                     Bitmap bitmap = connection.getSyncHttpClient().get(url)
-                            .asBitmap(foregroundSize).response;
+                            .asBitmap(foregroundSize, true).response;
                     if (bitmap != null) {
                         bitmap = addBackgroundAndBorder(bitmap,
                                 (int) Util.convertDpToPixel(31, context));

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.java
@@ -273,7 +273,7 @@ public class WidgetImageView extends AppCompatImageView {
         private Call mCall;
 
         public HttpImageRequest(int size, AsyncHttpClient client, HttpUrl url, long timeoutMillis) {
-            super(size);
+            super(size, false);
             mClient = client;
             mUrl = url;
             mTimeoutMillis = timeoutMillis;

--- a/mobile/src/main/java/org/openhab/habdroid/util/AsyncHttpClient.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/AsyncHttpClient.java
@@ -42,14 +42,16 @@ public class AsyncHttpClient extends HttpClient {
 
     public abstract static class BitmapResponseHandler implements ResponseHandler<Bitmap> {
         private final int mSize;
+        private final boolean mEnforceSize;
 
-        public BitmapResponseHandler(int sizePx) {
+        public BitmapResponseHandler(int sizePx, boolean enforceSize) {
             mSize = sizePx;
+            mEnforceSize = enforceSize;
         }
 
         @Override
         public Bitmap convertBodyInBackground(ResponseBody body) throws IOException {
-            return getBitmapFromResponseBody(body, mSize);
+            return getBitmapFromResponseBody(body, mSize, mEnforceSize);
         }
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.java
@@ -122,8 +122,8 @@ public abstract class HttpClient {
         return builder;
     }
 
-    protected static Bitmap getBitmapFromResponseBody(ResponseBody body, int size)
-            throws IOException {
+    protected static Bitmap getBitmapFromResponseBody(ResponseBody body,
+            int size, boolean enforceSize) throws IOException {
         MediaType contentType = body.contentType();
         boolean isSvg = contentType != null
                 && contentType.type().equals("image")
@@ -138,7 +138,9 @@ public abstract class HttpClient {
         } else {
             Bitmap bitmap = BitmapFactory.decodeStream(is);
             if (bitmap != null) {
-                return Bitmap.createScaledBitmap(bitmap, size, size, false);
+                return enforceSize
+                        ? Bitmap.createScaledBitmap(bitmap, size, size, false)
+                        : bitmap;
             }
             throw new IOException("Bitmap decoding failed");
         }

--- a/mobile/src/main/java/org/openhab/habdroid/util/SyncHttpClient.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/SyncHttpClient.java
@@ -63,8 +63,8 @@ public class SyncHttpClient extends HttpClient {
             return new HttpTextResult(this);
         }
 
-        public HttpBitmapResult asBitmap(int sizeInPixels) {
-            return new HttpBitmapResult(this, sizeInPixels);
+        public HttpBitmapResult asBitmap(int sizeInPixels, boolean enforceSize) {
+            return new HttpBitmapResult(this, sizeInPixels, enforceSize);
         }
 
         public HttpStatusResult asStatus() {
@@ -124,7 +124,7 @@ public class SyncHttpClient extends HttpClient {
         public final Throwable error;
         public final int statusCode;
 
-        HttpBitmapResult(HttpResult result, int size) {
+        HttpBitmapResult(HttpResult result, int size, boolean enforceSize) {
             this.request = result.request;
             this.statusCode = result.statusCode;
             if (result.response == null) {
@@ -134,7 +134,7 @@ public class SyncHttpClient extends HttpClient {
                 Bitmap response = null;
                 Throwable error = result.error;
                 try {
-                    response = getBitmapFromResponseBody(result.response, size);
+                    response = getBitmapFromResponseBody(result.response, size, enforceSize);
                 } catch (IOException e) {
                     error = e;
                 }


### PR DESCRIPTION
Only enforce passed desired size in HTTP bitmap loading if needed, and
for charts it certainly isn't needed.