### PR TITLE
Fix Setpoint widget

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.kt
@@ -22,6 +22,7 @@ import kotlinx.android.parcel.Parcelize
 import java.util.IllegalFormatException
 import java.util.Locale
 import java.util.regex.Pattern
+import kotlin.math.roundToInt
 
 @Parcelize
 data class HsvState internal constructor(val hue: Float, val saturation: Float, val value: Float) : Parcelable {
@@ -166,18 +167,20 @@ data class ParsedState internal constructor(
              * Returns a new NumberState instance, basing its contents on the passed-in previous state.
              * In particular, unit, format and number type (float/integer) will be taken from the
              * previous state. If previous state is integer, the new value will be rounded accordingly.
+             * The value can be forced to Float by setting forceFloat to true.
              * @param state Previous state to base on
              * @param value New numeric value
+             * @param forceFloat Force value to be Float
              * @return new NumberState instance
              */
-            fun withValue(state: NumberState?, value: Float): NumberState {
+            fun withValue(state: NumberState?, value: Float, forceFloat: Boolean = false): NumberState {
                 if (state == null) {
                     return NumberState(value)
                 }
-                if (state.value is Int) {
-                    return NumberState(Math.round(value), state.unit, state.format)
+                if (state.value is Float || forceFloat) {
+                    return NumberState(value, state.unit, state.format)
                 }
-                return NumberState(value, state.unit, state.format)
+                return NumberState(value.roundToInt(), state.unit, state.format)
             }
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -43,10 +43,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import org.openhab.habdroid.R
 import org.openhab.habdroid.core.connection.Connection
-import org.openhab.habdroid.model.Item
-import org.openhab.habdroid.model.LabeledValue
-import org.openhab.habdroid.model.ParsedState
-import org.openhab.habdroid.model.Widget
+import org.openhab.habdroid.model.*
 import org.openhab.habdroid.ui.widget.DividerItemDecoration
 import org.openhab.habdroid.ui.widget.ExtendedSpinner
 import org.openhab.habdroid.ui.widget.SegmentedControlButton
@@ -464,8 +461,7 @@ class WidgetAdapter(
             val widget = boundWidget
             val item = widget?.item ?: return
             val newValue = widget.minValue + widget.step * progress
-            connection.httpClient.sendItemUpdate(item,
-                ParsedState.NumberState.withValue(item.state?.asNumber, newValue))
+            connection.httpClient.sendItemUpdate(item, item.state?.asNumber.withValue(newValue))
         }
     }
 
@@ -699,7 +695,7 @@ class WidgetAdapter(
                     closestIndex = index
                     closestDelta = abs(stateValue - stepValue)
                 }
-                ParsedState.NumberState.withValue(state, stepValue, stepSize != ceil(stepSize))
+                state.withValue(stepValue)
             }
 
             val dialogView = inflater.inflate(R.layout.dialog_numberpicker, null)
@@ -731,8 +727,7 @@ class WidgetAdapter(
             }
 
             if (newValue >= widget.minValue && newValue <= widget.maxValue) {
-                connection.httpClient.sendItemUpdate(widget.item, ParsedState.NumberState.withValue(state, newValue,
-                    stateValue != null && stateValue != ceil(stateValue)))
+                connection.httpClient.sendItemUpdate(widget.item, state.withValue(newValue))
             }
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -53,6 +53,8 @@ import org.openhab.habdroid.ui.widget.SegmentedControlButton
 import org.openhab.habdroid.ui.widget.WidgetImageView
 import org.openhab.habdroid.util.*
 import java.util.*
+import kotlin.math.abs
+import kotlin.math.ceil
 
 /**
  * This class provides openHAB widgets adapter for list view.
@@ -687,17 +689,17 @@ class WidgetAdapter(
             // This prevents an exception below, but could lead to
             // user confusion if this case is ever encountered.
             val stepSize = if (widget.minValue == widget.maxValue) 1F else widget.step
-            val stepCount = (Math.abs(widget.maxValue - widget.minValue) / stepSize).toInt() + 1
+            val stepCount = (abs(widget.maxValue - widget.minValue) / stepSize).toInt()
             var closestIndex = 0
             var closestDelta = java.lang.Float.MAX_VALUE
 
-            val stepValues: List<ParsedState.NumberState> = (1..stepCount).map { index ->
+            val stepValues: List<ParsedState.NumberState> = (0..stepCount).map { index ->
                 val stepValue = widget.minValue + index * stepSize
-                if (Math.abs(stateValue - stepValue) < closestDelta) {
+                if (abs(stateValue - stepValue) < closestDelta) {
                     closestIndex = index
-                    closestDelta = Math.abs(stateValue - stepValue)
+                    closestDelta = abs(stateValue - stepValue)
                 }
-                ParsedState.NumberState.withValue(state, stepValue)
+                ParsedState.NumberState.withValue(state, stepValue, stepSize != ceil(stepSize))
             }
 
             val dialogView = inflater.inflate(R.layout.dialog_numberpicker, null)
@@ -725,7 +727,8 @@ class WidgetAdapter(
 
             val newValue = if (down) stateValue - widget.step else stateValue + widget.step
             if (newValue >= widget.minValue && newValue <= widget.maxValue) {
-                connection.httpClient.sendItemUpdate(widget.item, ParsedState.NumberState.withValue(state, newValue))
+                connection.httpClient.sendItemUpdate(widget.item, ParsedState.NumberState.withValue(state, newValue,
+                    stateValue != ceil(stateValue)))
             }
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -683,9 +683,9 @@ class WidgetAdapter(
         }
 
         private fun openSelection() {
-            val widget = boundWidget
-            val state = widget?.state?.asNumber ?: return
-            val stateValue = state.value.toFloat()
+            val widget = boundWidget ?: return
+            val state = widget.state?.asNumber
+            val stateValue = state?.value?.toFloat() ?: widget.minValue
             // This prevents an exception below, but could lead to
             // user confusion if this case is ever encountered.
             val stepSize = if (widget.minValue == widget.maxValue) 1F else widget.step
@@ -723,12 +723,16 @@ class WidgetAdapter(
         private fun handleUpDown(down: Boolean) {
             val widget = boundWidget
             val state = widget?.state?.asNumber
-            val stateValue = state?.value?.toFloat() ?: return
+            val stateValue = state?.value?.toFloat()
+            val newValue = when {
+                stateValue == null -> widget?.minValue ?: return
+                down -> stateValue - widget.step
+                else -> stateValue + widget.step
+            }
 
-            val newValue = if (down) stateValue - widget.step else stateValue + widget.step
             if (newValue >= widget.minValue && newValue <= widget.maxValue) {
                 connection.httpClient.sendItemUpdate(widget.item, ParsedState.NumberState.withValue(state, newValue,
-                    stateValue != ceil(stateValue)))
+                    stateValue != null && stateValue != ceil(stateValue)))
             }
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/util/SuggestedCommandsFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/SuggestedCommandsFactory.kt
@@ -20,6 +20,7 @@ import org.openhab.habdroid.R
 import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.model.ParsedState
 import org.openhab.habdroid.model.Widget
+import org.openhab.habdroid.model.withValue
 import java.util.*
 
 class SuggestedCommandsFactory(private val context: Context, private val showUndef: Boolean) {
@@ -39,8 +40,8 @@ class SuggestedCommandsFactory(private val context: Context, private val showUnd
             val state = widget.state?.asNumber
             if (state != null) {
                 add(suggestedCommands, state.toString())
-                add(suggestedCommands, ParsedState.NumberState.withValue(state, widget.minValue).toString())
-                add(suggestedCommands, ParsedState.NumberState.withValue(state, widget.maxValue).toString())
+                add(suggestedCommands, state.withValue(widget.minValue).toString())
+                add(suggestedCommands, state.withValue(widget.maxValue).toString())
                 if (widget.switchSupport) {
                     addOnOffCommands(suggestedCommands)
                 }


### PR DESCRIPTION
* Parse state as Float if step size is a Float. Fixes #1389
* Fix not showing min value, but one step over max value.
* Fix Setpoint if state is null. Fixes #1397