### PR TITLE
Fix UninitializedPropertyAccessException in ItemUpdatingPreference.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/ItemUpdatingPreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/ItemUpdatingPreference.kt
@@ -71,6 +71,8 @@ class ItemUpdatingPreference constructor(context: Context, attrs: AttributeSet?)
         editor = v.findViewById(R.id.itemName)
         editor.addTextChangedListener(this)
         editorWrapper = v.findViewById(R.id.itemNameWrapper)
+        helpIcon = v.findViewById(R.id.help_icon)
+        helpIcon.setupHelpIcon(howtoUrl.orEmpty(), howtoHint.orEmpty())
 
         val label = v.findViewById<TextView>(R.id.enabledLabel)
         label.text = title
@@ -80,9 +82,6 @@ class ItemUpdatingPreference constructor(context: Context, attrs: AttributeSet?)
             switch.isChecked = value.first
             editor.setText(value.second)
         }
-
-        helpIcon = v.findViewById(R.id.help_icon)
-        helpIcon.setupHelpIcon(howtoUrl.orEmpty(), howtoHint.orEmpty())
 
         onCheckedChanged(switch, switch.isChecked)
 


### PR DESCRIPTION
If the pref was set already, the help icon was accessed via
switch.isChecked -> onCheckedChanged before it was initialized.

(See https://github.com/openhab/openhab-android/pull/1356#issuecomment-504702834)