### PR TITLE
Fix sitemap entries in drawer opening wrong sitemaps.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -627,9 +627,11 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
                 }
             }
             if (item.groupId == GROUP_ID_SITEMAPS) {
-                val sitemap = serverProperties!!.sitemaps[item.itemId]
-                controller.openSitemap(sitemap)
-                handled = true
+                val sitemap = serverProperties?.sitemaps?.firstOrNull { s -> s.name.hashCode() == item.itemId }
+                if (sitemap != null) {
+                    controller.openSitemap(sitemap)
+                    handled = true
+                }
             }
             handled
         }
@@ -664,7 +666,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
                 menu.clear()
 
                 sitemaps.forEachIndexed { index, sitemap ->
-                    val item = menu.add(GROUP_ID_SITEMAPS, index, index, sitemap.label)
+                    val item = menu.add(GROUP_ID_SITEMAPS, sitemap.name.hashCode(), index, sitemap.label)
                     loadSitemapIcon(sitemap, item)
                 }
             }


### PR DESCRIPTION
We added items based on the sorted sitemap list and later referenced
them by their index, but looked up the index in the unsorted list.

Fixes #1421
