### PR TITLE
Fix IllegalStateException.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionManagerHelper.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionManagerHelper.kt
@@ -132,8 +132,8 @@ interface ConnectionManagerHelper {
         }
 
         override fun onAvailable(network: Network?) {
-            if (network != null) {
-                val caps = connectivityManager.getNetworkCapabilities(network)
+            val caps = network?.let { connectivityManager.getNetworkCapabilities(it) }
+            if (caps != null) {
                 if (caps.isUsable()) {
                     scheduleCallback()
                 }


### PR DESCRIPTION
ConnectivityManager.getNetworkCapabilities() might return null in case
the network can't be found.

Closes #1427
