### PR TITLE
Fix lint issues in PreferencesActivity

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -14,7 +14,6 @@
 package org.openhab.habdroid.ui
 
 import android.content.Intent
-import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.media.RingtoneManager
 import android.net.Uri

--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -110,7 +110,7 @@ class PreferencesActivity : AbstractBaseActivity() {
         protected abstract val titleResId: Int
 
         protected val parentActivity get() = activity as PreferencesActivity
-        protected val prefs get() = preferenceScreen.sharedPreferences as SharedPreferences
+        protected val prefs get() = preferenceScreen.sharedPreferences!!
 
         override fun onStart() {
             super.onStart()


### PR DESCRIPTION
* Only set on prefs click listener if ringtone and vibration prefs are shown. This way the constants Settings.ACTION_APP_NOTIFICATION_SETTINGS and Settings.EXTRA_APP_PACKAGE are guarded by an API check.
* Use elvis operator
* Explicitly set type for `prefs`

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>