### PR TITLE
Make ItemPickerActivity abstract

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -77,7 +77,7 @@
             android:name="de.duenndns.ssl.MemorizingActivity"
             android:excludeFromRecents="true"
             android:theme="@style/Theme.AppCompat.Translucent" />
-        <activity android:name=".ui.ItemPickerActivity"
+        <activity android:name=".ui.TaskerItemPickerActivity"
             android:label="@string/item_picker" >
             <intent-filter>
                 <action android:name="com.twofortyfouram.locale.intent.action.EDIT_CONDITION" />

--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -26,7 +26,8 @@ import androidx.work.*
 import kotlinx.android.parcel.Parcelize
 import org.openhab.habdroid.R
 import org.openhab.habdroid.model.NfcTag
-import org.openhab.habdroid.ui.ItemPickerActivity
+import org.openhab.habdroid.ui.AbstractItemPickerActivity
+import org.openhab.habdroid.ui.TaskerItemPickerActivity
 import org.openhab.habdroid.ui.preference.toItemUpdatePrefValue
 import org.openhab.habdroid.util.*
 import java.util.*
@@ -56,8 +57,8 @@ class BackgroundTasksManager : BroadcastReceiver() {
                     return
                 }
                 val bundle = intent.getBundleExtra(TaskerIntent.EXTRA_BUNDLE) ?: return
-                val itemName = bundle.getString(ItemPickerActivity.EXTRA_ITEM_NAME)
-                val state = bundle.getString(ItemPickerActivity.EXTRA_ITEM_STATE)
+                val itemName = bundle.getString(AbstractItemPickerActivity.EXTRA_ITEM_NAME)
+                val state = bundle.getString(AbstractItemPickerActivity.EXTRA_ITEM_STATE)
                 if (itemName.isNullOrEmpty() || state.isNullOrEmpty()) {
                     return
                 }

--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -27,7 +27,6 @@ import kotlinx.android.parcel.Parcelize
 import org.openhab.habdroid.R
 import org.openhab.habdroid.model.NfcTag
 import org.openhab.habdroid.ui.AbstractItemPickerActivity
-import org.openhab.habdroid.ui.TaskerItemPickerActivity
 import org.openhab.habdroid.ui.preference.toItemUpdatePrefValue
 import org.openhab.habdroid.util.*
 import java.util.*

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
@@ -55,6 +55,7 @@ abstract class AbstractItemPickerActivity : AbstractBaseActivity(), SwipeRefresh
     private lateinit var emptyView: View
     private lateinit var emptyMessage: TextView
     protected lateinit var retryButton: TextView
+    protected abstract var disabledMessageId: Int
 
     private val suggestedCommandsFactory by lazy {
         SuggestedCommandsFactory(this, true)
@@ -227,14 +228,12 @@ abstract class AbstractItemPickerActivity : AbstractBaseActivity(), SwipeRefresh
         swipeLayout.isRefreshing = loading
         emptyMessage.setText(when {
             loadError -> R.string.item_picker_list_error
-            isDisabled -> getDisabledMessage()
+            isDisabled -> disabledMessageId
             else -> R.string.item_picker_list_empty
         })
         retryButton.setText(if (isDisabled) R.string.turn_on else R.string.try_again_button)
         retryButton.isVisible = loadError || isDisabled
     }
-
-    protected abstract fun getDisabledMessage() : Int
 
     companion object {
         private val TAG = AbstractItemPickerActivity::class.java.simpleName

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
@@ -39,9 +39,6 @@ import org.openhab.habdroid.model.toItem
 import org.openhab.habdroid.ui.widget.DividerItemDecoration
 import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.SuggestedCommandsFactory
-import org.openhab.habdroid.util.TaskerIntent
-import org.openhab.habdroid.util.getPrefs
-import org.openhab.habdroid.util.isTaskerPluginEnabled
 import org.openhab.habdroid.util.map
 
 abstract class AbstractItemPickerActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListener,
@@ -89,14 +86,6 @@ abstract class AbstractItemPickerActivity : AbstractBaseActivity(), SwipeRefresh
         recyclerView.layoutManager = layoutManager
         recyclerView.addItemDecoration(DividerItemDecoration(this))
         recyclerView.adapter = itemPickerAdapter
-
-        val editItem = intent.getBundleExtra(TaskerIntent.EXTRA_BUNDLE)
-        initialHighlightItemName = editItem?.getString(EXTRA_ITEM_NAME)
-
-        if (!getPrefs().isTaskerPluginEnabled()) {
-            isDisabled = true
-            updateViewVisibility(loading = false, loadError = false, isDisabled = true)
-        }
     }
 
     override fun onResume() {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/TaskerItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/TaskerItemPickerActivity.kt
@@ -1,0 +1,56 @@
+package org.openhab.habdroid.ui
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.core.content.edit
+import androidx.core.os.bundleOf
+import org.openhab.habdroid.R
+import org.openhab.habdroid.model.Item
+import org.openhab.habdroid.util.Constants
+import org.openhab.habdroid.util.TaskerIntent
+import org.openhab.habdroid.util.getPrefs
+import org.openhab.habdroid.util.isTaskerPluginEnabled
+
+class TaskerItemPickerActivity : AbstractItemPickerActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        retryButton.setOnClickListener {
+            if (isDisabled) {
+                getPrefs().edit {
+                    putBoolean(Constants.PREFERENCE_TASKER_PLUGIN_ENABLED, true)
+                }
+                isDisabled = false
+                loadItems()
+            }
+        }
+
+        if (!getPrefs().isTaskerPluginEnabled()) {
+            isDisabled = true
+            updateViewVisibility(loading = false, loadError = false, isDisabled = true)
+        }
+
+        val editItem = intent.getBundleExtra(TaskerIntent.EXTRA_BUNDLE)
+        initialHighlightItemName = editItem?.getString(EXTRA_ITEM_NAME)
+    }
+
+    override fun finish(item: Item, state: String) {
+        val intent = Intent().apply {
+            val blurb = getString(R.string.item_picker_blurb, item.label, item.name, state)
+            putExtra(TaskerIntent.EXTRA_STRING_BLURB, blurb)
+
+            putExtra(TaskerIntent.EXTRA_BUNDLE, bundleOf(
+                EXTRA_ITEM_NAME to item.name,
+                EXTRA_ITEM_STATE to state
+            ))
+        }
+
+        setResult(RESULT_OK, intent)
+        finish()
+    }
+
+    override fun getDisabledMessage(): Int {
+        return R.string.settings_tasker_plugin_summary
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/ui/TaskerItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/TaskerItemPickerActivity.kt
@@ -11,7 +11,8 @@ import org.openhab.habdroid.util.TaskerIntent
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.isTaskerPluginEnabled
 
-class TaskerItemPickerActivity : AbstractItemPickerActivity() {
+class TaskerItemPickerActivity(override var disabledMessageId: Int = R.string.settings_tasker_plugin_summary) :
+    AbstractItemPickerActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -48,9 +49,5 @@ class TaskerItemPickerActivity : AbstractItemPickerActivity() {
 
         setResult(RESULT_OK, intent)
         finish()
-    }
-
-    override fun getDisabledMessage(): Int {
-        return R.string.settings_tasker_plugin_summary
     }
 }


### PR DESCRIPTION
Renaming ItemPickerActivity to TaskerItemPickerActivity breaks
configured actions in Tasker. I want to rename it, before the Tasker
plugin goes live in the stable version.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>