### PR TITLE
Fix crash when parsing SVG

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -162,6 +162,8 @@ fun ResponseBody.toBitmap(targetSize: Int, enforceSize: Boolean = false): Bitmap
         bitmap
     } catch (e: SVGParseException) {
         throw IOException("SVG decoding failed", e)
+    } catch (e: IllegalArgumentException) {
+        throw IOException("SVG decoding failed", e)
     }
 }
 


### PR DESCRIPTION
````
Fatal Exception: java.lang.IllegalArgumentException: SVG document is empty
       at com.caverock.androidsvg.SVG.setDocumentHeight + 792(SVG.java:792)
       at org.openhab.habdroid.util.ExtensionFuncsKt.toBitmap + 122(ExtensionFuncs.kt:122)
       at org.openhab.habdroid.util.HttpClient$HttpResult$asBitmap$bitmap$1.invokeSuspend + 182(HttpClient.kt:182)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>