### PR TITLE
Fix crash in FCM registration

### DIFF
--- a/mobile/src/full/java/org/openhab/habdroid/core/FcmRegistrationService.kt
+++ b/mobile/src/full/java/org/openhab/habdroid/core/FcmRegistrationService.kt
@@ -112,7 +112,7 @@ class FcmRegistrationService : JobIntentService() {
 
     class ProxyReceiver : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
-            val actual = intent.getParcelableExtra<Intent>("intent")
+            val actual = intent.getParcelableExtra<Intent>("intent") ?: return
             enqueueWork(context, FcmRegistrationService::class.java, JOB_ID, actual)
         }
 


### PR DESCRIPTION
````
Fatal Exception: java.lang.RuntimeException: Unable to start receiver org.openhab.habdroid.core.FcmRegistrationService$ProxyReceiver: java.lang.IllegalArgumentException: work must not be null
        [...]
Caused by java.lang.IllegalArgumentException: work must not be null
       at androidx.core.app.JobIntentService.enqueueWork + 518(JobIntentService.java:518)
       at androidx.core.app.JobIntentService.enqueueWork + 501(JobIntentService.java:501)
       at org.openhab.habdroid.core.FcmRegistrationService$ProxyReceiver.onReceive + 116(FcmRegistrationService.kt:116)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>