### PR TITLE
Correctly handle SSE events without item.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -78,7 +78,7 @@ data class Widget(
     companion object {
         @Throws(JSONException::class)
         fun updateFromEvent(source: Widget, eventPayload: JSONObject, iconFormat: String): Widget {
-            val item = Item.updateFromEvent(source.item, eventPayload.getJSONObject("item"))
+            val item = Item.updateFromEvent(source.item, eventPayload.optJSONObject("item"))
             val icon = eventPayload.optString("icon", source.icon)
             val iconPath = determineOH2IconPath(item, source.type, icon, iconFormat,
                 source.mappings.isNotEmpty())


### PR DESCRIPTION
The code already was prepared for this by allowing passing null as item,
we just need to use the correct JSON parser method that doesn't throw an
exception if the value is missing.

Closes #1437 