### PR TITLE
Use positional formatting for strings with more than one substitution

### DIFF
--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -307,7 +307,7 @@
     <string name="item_picker_custom">Custom</string>
     <string name="item_picker_dialog_title">Select state</string>
     <string name="item_picker">openHAB Items</string>
-    <string name="item_picker_blurb">Set \"%s\" (%s) to \"%s\"</string>
+    <string name="item_picker_blurb">Set \"%1$s\" (%2$s) to \"%3$s\"</string>
     <string name="search">Search</string>
     <string name="settings_tasker_plugin">Tasker integration</string>
     <string name="settings_tasker_plugin_summary">Enable Tasker action plugin which allows updating Items via Tasker or other compatible apps</string>


### PR DESCRIPTION
Fixes lint issues in build log.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>