### PR TITLE
Fix handling of frames without label.

### DIFF
--- a/mobile/src/androidTest/java/org/openhab/habdroid/ui/BasicWidgetTest.kt
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/ui/BasicWidgetTest.kt
@@ -45,25 +45,25 @@ class BasicWidgetTest : TestWithoutIntro() {
         val recyclerView = onView(withId(R.id.recyclerview))
 
         recyclerView
-                .perform(scrollToPosition<RecyclerView.ViewHolder>(0))
-                .check(matches(atPositionOnView(0, isDisplayed(), R.id.widgetlabel)))
-                .check(matches(atPositionOnView(0, withText("First Floor"), R.id.widgetlabel)))
+                .perform(scrollToPosition<RecyclerView.ViewHolder>(1))
+                .check(matches(atPositionOnView(1, isDisplayed(), R.id.widgetlabel)))
+                .check(matches(atPositionOnView(1, withText("First Floor"), R.id.widgetlabel)))
 
         recyclerView
-                .perform(scrollToPosition<RecyclerView.ViewHolder>(6))
-                .check(matches(atPositionOnView(6, isDisplayed(), R.id.widgetlabel)))
+                .perform(scrollToPosition<RecyclerView.ViewHolder>(7))
+                .check(matches(atPositionOnView(7, isDisplayed(), R.id.widgetlabel)))
                 .check(matches(
-                        atPositionOnView(6, withText("Astronomical Data"), R.id.widgetlabel)))
+                        atPositionOnView(7, withText("Astronomical Data"), R.id.widgetlabel)))
 
         // does it show "garden"?
         recyclerView
-                .perform(scrollToPosition<RecyclerView.ViewHolder>(3))
-                .check(matches(atPositionOnView(3, isDisplayed(), R.id.widgetlabel)))
-                .check(matches(atPositionOnView(3, withText("Garden"), R.id.widgetlabel)))
+                .perform(scrollToPosition<RecyclerView.ViewHolder>(4))
+                .check(matches(atPositionOnView(4, isDisplayed(), R.id.widgetlabel)))
+                .check(matches(atPositionOnView(4, withText("Garden"), R.id.widgetlabel)))
 
         // open widget overview
         recyclerView
-                .perform(actionOnItemAtPosition<RecyclerView.ViewHolder>(10, click()))
+                .perform(actionOnItemAtPosition<RecyclerView.ViewHolder>(11, click()))
 
         // check whether selection widget appears and click on it
         recyclerView

--- a/mobile/src/androidTest/java/org/openhab/habdroid/ui/NfcTest.kt
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/ui/NfcTest.kt
@@ -43,11 +43,11 @@ class NfcTest : TestWithoutIntro() {
         val context = InstrumentationRegistry.getTargetContext()
 
         // Long click "Widget Overview"
-        recyclerView.perform(actionOnItemAtPosition<RecyclerView.ViewHolder>(10, longClick()))
+        recyclerView.perform(actionOnItemAtPosition<RecyclerView.ViewHolder>(11, longClick()))
         checkViewWithText(context, R.string.nfc_action_to_sitemap_page)
         pressBack()
 
-        recyclerView.perform(actionOnItemAtPosition<RecyclerView.ViewHolder>(10, click()))
+        recyclerView.perform(actionOnItemAtPosition<RecyclerView.ViewHolder>(11, click()))
 
         // Long click "Toggle Switch"
         recyclerView.perform(actionOnItemAtPosition<RecyclerView.ViewHolder>(1, longClick()))

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -36,6 +36,7 @@ import androidx.appcompat.widget.SwitchCompat
 import androidx.core.net.toUri
 import androidx.core.view.children
 import androidx.core.view.get
+import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import com.larswerkman.holocolorpicker.ColorPicker
@@ -321,8 +322,7 @@ class WidgetAdapter(
         override fun bind(widget: Widget) {
             labelView.text = widget.label
             labelView.applyWidgetColor(widget.valueColor, colorMapper)
-            // hide empty frames
-            itemView.isVisible = widget.label.isNotEmpty()
+            labelView.isGone = widget.label.isEmpty()
         }
 
         fun setShownAsFirst(shownAsFirst: Boolean) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.kt
@@ -322,7 +322,6 @@ class PageConnectionHolderFragment : Fragment(), CoroutineScope {
             if (hasUpdate) {
                 // Remove frame widgets with no label text
                 val widgetList = dataSource.widgets
-                    .filterNot { w -> w.type == Widget.Type.Frame && w.label.isEmpty() }
                 Log.d(TAG, "Updated page data for URL $url (${widgetList.size} widgets)")
                 if (callback.isDetailedLoggingEnabled) {
                     widgetList.forEachIndexed { index, widget ->


### PR DESCRIPTION
We shouldn't simply filter them, as doing so
- produces wrong visual output (no spacer)
- creates issues when visibility of that frame is changed

Instead, just hide the label and leave the spacer in place.

Fixes #1437 