### PR TITLE
Try to fix IllegalStateException in ContentController

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -235,7 +235,6 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
     override fun onStart() {
         Log.d(TAG, "onStart()")
         super.onStart()
-        isStarted = true
 
         ConnectionFactory.addListener(this)
 
@@ -251,7 +250,6 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
 
     public override fun onStop() {
         Log.d(TAG, "onStop()")
-        isStarted = false
         super.onStop()
         ConnectionFactory.removeListener(this)
         serviceResolveJob?.cancel()
@@ -264,6 +262,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
 
     override fun onResume() {
         Log.d(TAG, "onResume()")
+        isStarted = true
         super.onResume()
 
         val nfcAdapter = NfcAdapter.getDefaultAdapter(this)
@@ -279,6 +278,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
 
     override fun onPause() {
         Log.d(TAG, "onPause()")
+        isStarted = false
         super.onPause()
         val nfcAdapter = NfcAdapter.getDefaultAdapter(this)
         nfcAdapter?.disableForegroundDispatch(this)


### PR DESCRIPTION
````
Fatal Exception: java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
       at androidx.fragment.app.FragmentManagerImpl.checkStateLoss + 1536(FragmentManagerImpl.java:1536)
       at androidx.fragment.app.FragmentManagerImpl.enqueueAction + 1558(FragmentManagerImpl.java:1558)
       at androidx.fragment.app.BackStackRecord.commitInternal + 317(BackStackRecord.java:317)
       at androidx.fragment.app.BackStackRecord.commit + 282(BackStackRecord.java:282)
       at org.openhab.habdroid.ui.activity.ContentControllerOnePane.executeStateUpdate$mobile_fullBetaRelease + 50(ContentControllerOnePane.kt:50)
       at org.openhab.habdroid.ui.activity.ContentController.updateFragmentState + 450(ContentController.kt:450)
       at org.openhab.habdroid.ui.activity.ContentController.onLoadFailure + 438(ContentController.kt:438)
       at org.openhab.habdroid.ui.activity.PageConnectionHolderFragment$ConnectionHandler$load$1.invokeSuspend + 298(PageConnectionHolderFragment.kt:298)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith + 33(ContinuationImpl.kt:33)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>