### PR TITLE
Hide Sitemaps in drawer

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -672,7 +672,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
             manageHabPanelShortcut(props.hasHabPanelInstalled())
             val sitemaps = props.sitemaps.sortedWithDefaultName(prefs.getDefaultSitemap())
 
-            if (sitemaps.isNotEmpty() && prefs.areSitemapsShownInDrawer()) {
+            if (sitemaps.size > 1 && prefs.areSitemapsShownInDrawer()) {
                 sitemapItem.isVisible = true
                 val menu = sitemapItem.subMenu
                 menu.clear()

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -100,6 +100,7 @@ import org.openhab.habdroid.util.Constants
 import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.ScreenLockMode
 import org.openhab.habdroid.util.Util
+import org.openhab.habdroid.util.areSitemapsShownInDrawer
 import org.openhab.habdroid.util.getDefaultSitemap
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.isDebugModeEnabled
@@ -334,6 +335,9 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
                 }
                 if (data.getBooleanExtra(PreferencesActivity.RESULT_EXTRA_SITEMAP_CLEARED, false)) {
                     executeOrStoreAction(PendingAction.ChooseSitemap())
+                }
+                if (data.getBooleanExtra(PreferencesActivity.RESULT_EXTRA_SITEMAP_DRAWER_CHANGED, false)) {
+                    updateSitemapAndHabPanelDrawerItems()
                 }
                 if (data.getBooleanExtra(PreferencesActivity.RESULT_EXTRA_THEME_CHANGED, false)) {
                     recreate()
@@ -668,9 +672,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
             manageHabPanelShortcut(props.hasHabPanelInstalled())
             val sitemaps = props.sitemaps.sortedWithDefaultName(prefs.getDefaultSitemap())
 
-            if (sitemaps.isEmpty()) {
-                sitemapItem.isVisible = false
-            } else {
+            if (sitemaps.isNotEmpty() && prefs.areSitemapsShownInDrawer()) {
                 sitemapItem.isVisible = true
                 val menu = sitemapItem.subMenu
                 menu.clear()
@@ -679,6 +681,8 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
                     val item = menu.add(GROUP_ID_SITEMAPS, sitemap.name.hashCode(), index, sitemap.label)
                     loadSitemapIcon(sitemap, item)
                 }
+            } else {
+                sitemapItem.isVisible = false
             }
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -225,6 +225,7 @@ class PreferencesActivity : AbstractBaseActivity() {
             val accentColorPref = getPreference(Constants.PREFERENCE_ACCENT_COLOR) as ColorPreferenceCompat
             val clearCachePref = getPreference(Constants.PREFERENCE_CLEAR_CACHE)
             val clearDefaultSitemapPref = getPreference(Constants.PREFERENCE_CLEAR_DEFAULT_SITEMAP)
+            val showSitemapInDrawerPref = getPreference(Constants.PREFERENCE_SHOW_SITEMAPS_IN_DRAWER)
             val ringtonePref = getPreference(Constants.PREFERENCE_TONE)
             val fullscreenPreference = getPreference(Constants.PREFERENCE_FULLSCREEN)
             val sendDeviceInfoPrefixPref = getPreference(Constants.PREFERENCE_SEND_DEVICE_INFO_PREFIX)
@@ -287,6 +288,11 @@ class PreferencesActivity : AbstractBaseActivity() {
 
             clearCachePref.setOnPreferenceClickListener { pref ->
                 clearImageCache(pref.context)
+                true
+            }
+
+            showSitemapInDrawerPref.setOnPreferenceChangeListener { _, _ ->
+                parentActivity.resultIntent.putExtra(RESULT_EXTRA_SITEMAP_DRAWER_CHANGED, true)
                 true
             }
 
@@ -608,6 +614,7 @@ class PreferencesActivity : AbstractBaseActivity() {
     companion object {
         const val RESULT_EXTRA_THEME_CHANGED = "theme_changed"
         const val RESULT_EXTRA_SITEMAP_CLEARED = "sitemap_cleared"
+        const val RESULT_EXTRA_SITEMAP_DRAWER_CHANGED = "sitemap_drawer_changed"
         const val START_EXTRA_SERVER_PROPERTIES = "server_properties"
         const val ITEM_UPDATE_WIDGET_ITEM = "item"
         const val ITEM_UPDATE_WIDGET_STATE = "state"

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.kt
@@ -48,6 +48,7 @@ object Constants {
     const val PREFERENCE_TASKER_PLUGIN_ENABLED = "taskerPlugin"
     const val PREFERENCE_NFC_INFO_HINT_SHOWN = "nfcInfoHintShown"
     const val PREFERENCE_SCREEN_LOCK = "screen_lock"
+    const val PREFERENCE_SHOW_SITEMAPS_IN_DRAWER = "show_sitemaps"
 
     const val PREV_SERVER_FLAGS = "prevServerFlags"
 

--- a/mobile/src/main/java/org/openhab/habdroid/util/PrefExtensions.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/PrefExtensions.kt
@@ -102,6 +102,10 @@ fun SharedPreferences.getDayNightMode(context: Context): Int {
     }
 }
 
+fun SharedPreferences.areSitemapsShownInDrawer(): Boolean {
+    return getBoolean(Constants.PREFERENCE_SHOW_SITEMAPS_IN_DRAWER, false)
+}
+
 fun SharedPreferences.getString(key: String): String {
     return getString(key, "").orEmpty()
 }

--- a/mobile/src/main/res/menu/left_drawer.xml
+++ b/mobile/src/main/res/menu/left_drawer.xml
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <item
         android:id="@+id/sitemaps"
         android:title="@string/mainmenu_openhab_sitemaps">
         <menu />
     </item>
+    <item
+        android:id="@+id/default_sitemap"
+        android:visible="false"
+        tools:visible="true"
+        android:icon="@drawable/ic_openhab_appicon_24dp"
+        android:title="@string/mainmenu_openhab_no_default_sitemap" />
     <item
         android:id="@+id/habpanel"
         android:icon="@drawable/ic_view_dashboard_outline_black_24dp"

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -341,4 +341,5 @@
     <string name="item_update_widget_text">%1$s: %2$s</string>
     <string name="item_update_widget_item_picker_title">Select an Item</string>
     <string name="item_update_widget_success_toast">%1$s set to %2$s</string>
+    <string name="settings_show_sitemaps_in_drawer">Show sitemaps in drawer</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <!-- App settings strings -->
     <string name="settings_connection_title">Connection</string>
     <string name="settings_display_title">Display</string>
+    <string name="settings_sitemap_title">Sitemap</string>
     <string name="settings_misc_title">Miscellaneous</string>
     <string name="settings_openhab_url">Local server URL</string>
     <string name="settings_openhab_url_summary">The URL of the openHAB dashboard (based on hostname or IP). If configured, autodiscovery is disabled. Current setting: %s</string>
@@ -41,7 +42,6 @@
     <string name="settings_accent_color">Accent color</string>
     <string name="settings_select_a_color">Select a color</string>
     <string name="settings_openhab_fullscreen">Fullscreen</string>
-    <string name="settings_openhab_fullscreen_summary">Display in fullscreen mode</string>
     <string name="settings_openhab_icon_format">Icon format</string>
     <string name="settings_openhab_icon_format_value_png" translatable="false">PNG</string>
     <string name="settings_openhab_icon_format_value_svg" translatable="false">SVG</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -84,6 +84,7 @@
     <string name="settings_screen_lock_off_value" translatable="false">off</string>
     <string name="settings_screen_lock_kiosk_value" translatable="false">kiosk</string>
     <string name="settings_screen_lock_on_value" translatable="false">on</string>
+    <string name="settings_show_sitemaps_in_drawer">Show all Sitemaps in side menu</string>
 
     <!-- App messages strings -->
     <string name="title_voice_widget">Voice commands</string>
@@ -341,5 +342,4 @@
     <string name="item_update_widget_text">%1$s: %2$s</string>
     <string name="item_update_widget_item_picker_title">Select an Item</string>
     <string name="item_update_widget_success_toast">%1$s set to %2$s</string>
-    <string name="settings_show_sitemaps_in_drawer">Show sitemaps in drawer</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
 
     <!-- Main menu items -->
     <string name="mainmenu_openhab_sitemaps">Sitemaps</string>
+    <string name="mainmenu_openhab_no_default_sitemap">No default Sitemap set</string>
     <string name="mainmenu_openhab_preferences">Settings</string>
     <string name="mainmenu_openhab_habpanel">HABPanel</string>
     <string name="habpanel_error">An error occurred while loading HABPanel</string>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -31,6 +31,10 @@
             android:clickable="true"
             android:key="default_openhab_clear_default_sitemap"
             android:title="@string/settings_clear_default_sitemap" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="show_sitemaps"
+            android:title="@string/settings_show_sitemaps_in_drawer" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_display_title">
         <ListPreference

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -27,6 +27,8 @@
             android:summary="@string/settings_openhab_none"
             android:title="@string/settings_openhab_sslclientcert"
             android:dependency="default_openhab_demomode" />
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/settings_sitemap_title">
         <Preference
             android:clickable="true"
             android:key="default_openhab_clear_default_sitemap"
@@ -35,6 +37,28 @@
             android:defaultValue="false"
             android:key="show_sitemaps"
             android:title="@string/settings_show_sitemaps_in_drawer" />
+        <ListPreference
+            android:title="@string/settings_openhab_icon_format"
+            android:key="iconFormatType"
+            android:defaultValue="@string/settings_openhab_icon_format_value_png"
+            android:summary="%s"
+            android:entries="@array/iconTypeNames"
+            android:entryValues="@array/iconTypeValues"
+            android:icon="@drawable/ic_image_outline_grey_24dp" />
+        <Preference
+            android:clickable="true"
+            android:key="default_openhab_cleacache"
+            android:title="@string/mainmenu_openhab_clearcache" />
+        <org.openhab.habdroid.ui.preference.ChartScalingPreference
+            android:title="@string/settings_chart_scaling"
+            android:summary="@string/settings_chart_scaling_summary"
+            android:key="chartScalingFactor"
+            android:defaultValue="1.5" />
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="default_openhab_chart_hq"
+            android:summary="@string/settings_openhab_chart_hq_summary"
+            android:title="@string/settings_openhab_chart_hq" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_display_title">
         <ListPreference
@@ -54,28 +78,6 @@
             app:cpv_dialogTitle="@string/settings_select_a_color"
             app:cpv_colorPresets="@array/accentColors"
             android:title="@string/settings_accent_color"/>
-        <ListPreference
-            android:title="@string/settings_openhab_icon_format"
-            android:key="iconFormatType"
-            android:defaultValue="@string/settings_openhab_icon_format_value_png"
-            android:summary="%s"
-            android:entries="@array/iconTypeNames"
-            android:entryValues="@array/iconTypeValues"
-            android:icon="@drawable/ic_image_outline_grey_24dp" />
-        <org.openhab.habdroid.ui.preference.ChartScalingPreference
-            android:title="@string/settings_chart_scaling"
-            android:summary="@string/settings_chart_scaling_summary"
-            android:key="chartScalingFactor"
-            android:defaultValue="1.5" />
-        <SwitchPreference
-            android:defaultValue="true"
-            android:key="default_openhab_chart_hq"
-            android:summary="@string/settings_openhab_chart_hq_summary"
-            android:title="@string/settings_openhab_chart_hq" />
-        <Preference
-            android:clickable="true"
-            android:key="default_openhab_cleacache"
-            android:title="@string/mainmenu_openhab_clearcache" />
         <SwitchPreference
             android:defaultValue="false"
             android:key="default_openhab_screentimeroff"
@@ -84,7 +86,6 @@
         <SwitchPreference
             android:defaultValue="false"
             android:key="default_openhab_fullscreen"
-            android:summary="@string/settings_openhab_fullscreen_summary"
             android:title="@string/settings_openhab_fullscreen" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/send_device_info_to_server"


### PR DESCRIPTION
The Sitemaps are hidden in the drawer by default, but there's a setting to change that.

See #392
Closes #1305

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>