### PR TITLE
Improve preference activity startup time

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHabApplication.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHabApplication.kt
@@ -13,13 +13,32 @@
 
 package org.openhab.habdroid.core
 
+import android.content.SharedPreferences
+import android.os.Build
 import androidx.multidex.MultiDexApplication
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
 
 import org.openhab.habdroid.background.BackgroundTasksManager
 import org.openhab.habdroid.core.connection.ConnectionFactory
 
 @Suppress("UNUSED")
 class OpenHabApplication : MultiDexApplication() {
+    val secretPrefs: SharedPreferences by lazy {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+            EncryptedSharedPreferences.create(
+                "secret_shared_prefs_encrypted",
+                masterKeyAlias,
+                this,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            )
+        } else {
+            getSharedPreferences("secret_shared_prefs", MODE_PRIVATE)
+        }
+    }
+
     override fun onCreate() {
         super.onCreate()
         ConnectionFactory.initialize(this)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -239,12 +239,6 @@ class PreferencesActivity : AbstractBaseActivity() {
                     R.string.settings_current_default_sitemap, currentDefaultSitemapLabel)
             }
 
-            updateConnectionSummary(Constants.SUBSCREEN_LOCAL_CONNECTION,
-                Constants.PREFERENCE_LOCAL_URL, Constants.PREFERENCE_LOCAL_USERNAME,
-                Constants.PREFERENCE_LOCAL_PASSWORD)
-            updateConnectionSummary(Constants.SUBSCREEN_REMOTE_CONNECTION,
-                Constants.PREFERENCE_REMOTE_URL, Constants.PREFERENCE_REMOTE_USERNAME,
-                Constants.PREFERENCE_REMOTE_PASSWORD)
             updateRingtonePreferenceSummary(ringtonePref, prefs.getNotificationTone())
             updateVibrationPreferenceIcon(vibrationPref,
                 prefs.getString(Constants.PREFERENCE_NOTIFICATION_VIBRATION))

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -30,9 +30,6 @@ import android.util.Log
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
-import android.os.Build
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKeys
 import com.caverock.androidsvg.SVG
 import com.caverock.androidsvg.SVGParseException
 import es.dmoral.toasty.Toasty
@@ -41,6 +38,7 @@ import okhttp3.ResponseBody
 import org.json.JSONArray
 import org.json.JSONObject
 import org.openhab.habdroid.R
+import org.openhab.habdroid.core.OpenHabApplication
 import org.w3c.dom.Node
 import org.w3c.dom.NodeList
 import java.io.IOException
@@ -204,6 +202,10 @@ fun Context.getPrefs(): SharedPreferences {
     return PreferenceManager.getDefaultSharedPreferences(this)
 }
 
+fun Context.getSecretPrefs(): SharedPreferences {
+    return (applicationContext as OpenHabApplication).secretPrefs
+}
+
 /**
  * Shows an orange Toast with the openHAB icon. Can be called from the background.
  */
@@ -223,19 +225,4 @@ fun Context.showToast(@StringRes message: Int) {
 
 fun Context.hasPermission(permission: String): Boolean {
     return ContextCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED
-}
-
-fun Context.getSecretPrefs(): SharedPreferences {
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
-        EncryptedSharedPreferences.create(
-            "secret_shared_prefs_encrypted",
-            masterKeyAlias,
-            this,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
-    } else {
-        getSharedPreferences("secret_shared_prefs", Context.MODE_PRIVATE)
-    }
 }


### PR DESCRIPTION
Creating the shared prefs instance is an operation that isn't trivial
(takes ~50ms on a OnePlus 6), so avoid doing it over and over again.
