### PR TITLE
Show loading indicator in home screen widgets after reboot

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/homescreenwidget/ItemUpdateWidget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/homescreenwidget/ItemUpdateWidget.kt
@@ -24,6 +24,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import android.view.View
 import android.widget.RemoteViews
 import androidx.annotation.Px
 import androidx.core.content.edit
@@ -119,6 +120,7 @@ open class ItemUpdateWidget : AppWidgetProvider() {
         views.setOnClickPendingIntent(R.id.outer_layout, pendingIntent)
         views.setTextViewText(R.id.text,
             context.getString(R.string.item_update_widget_text, data.label, data.mappedState))
+        hideLoadingIndicator(views)
         appWidgetManager.updateAppWidget(appWidgetId, views)
         fetchAndSetIcon(context, views, data, smallWidget, appWidgetId, appWidgetManager)
     }
@@ -155,6 +157,7 @@ open class ItemUpdateWidget : AppWidgetProvider() {
                 val iconBitmap = if (isSvg) convertSvgIcon(iconData) else BitmapFactory.decodeStream(iconData)
                 if (iconBitmap != null) {
                     views.setImageViewBitmap(R.id.item_icon, iconBitmap)
+                    hideLoadingIndicator(views)
                     appWidgetManager.updateAppWidget(appWidgetId, views)
                 }
             }
@@ -189,6 +192,12 @@ open class ItemUpdateWidget : AppWidgetProvider() {
                 Log.e(TAG, "Error saving icon to disk", e)
             }
         }
+    }
+
+    private fun hideLoadingIndicator(views: RemoteViews) {
+        views.setViewVisibility(R.id.item_icon, View.VISIBLE)
+        views.setViewVisibility(R.id.text, View.VISIBLE)
+        views.setViewVisibility(R.id.progress_bar, View.GONE)
     }
 
     companion object {

--- a/mobile/src/main/res/layout/widget_item_update.xml
+++ b/mobile/src/main/res/layout/widget_item_update.xml
@@ -17,6 +17,7 @@
         android:layout_height="0dp"
         android:layout_weight="50"
         android:src="@mipmap/icon"
+        android:visibility="gone"
         tools:ignore="ContentDescription" />
 
     <TextView
@@ -27,6 +28,17 @@
         android:gravity="center"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
         android:textColor="@color/light"
+        android:visibility="gone"
         tools:text="Dimmer: 33 %" />
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        style="?attr/indeterminateProgressStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_weight="100"
+        android:layout_gravity="center"
+        android:indeterminateTint="@color/openhab_orange"
+        android:indeterminateTintMode="src_in" />
 
 </LinearLayout>

--- a/mobile/src/main/res/layout/widget_item_update_small.xml
+++ b/mobile/src/main/res/layout/widget_item_update_small.xml
@@ -15,6 +15,7 @@
         android:layout_height="match_parent"
         android:alpha="0.3"
         android:src="@mipmap/icon"
+        android:visibility="gone"
         tools:ignore="ContentDescription" />
 
     <TextView
@@ -24,5 +25,16 @@
         android:gravity="center"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
         android:textColor="@color/light"
+        android:visibility="gone"
         tools:text="Dimmer: 33 %" />
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        style="?attr/indeterminateProgressStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminateTint="@color/openhab_orange"
+        android:indeterminateTintMode="src_in" />
+
 </FrameLayout>


### PR DESCRIPTION
Directly after reboot the home screen widgets are not yet initialized, so the widgets show the openHAB icon and no item text. This PR replaces the view with a progress indicator.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>