### PR TITLE
Beautify success messages

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
@@ -21,11 +21,13 @@ import androidx.work.WorkerParameters
 import kotlinx.coroutines.runBlocking
 import org.json.JSONException
 import org.json.JSONObject
+import org.openhab.habdroid.R
 import org.openhab.habdroid.core.connection.Connection
 import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.model.toItem
 import org.openhab.habdroid.util.HttpClient
+import org.openhab.habdroid.util.showErrorToast
 import org.openhab.habdroid.util.showToast
 import org.xml.sax.InputSource
 import org.xml.sax.SAXException
@@ -43,9 +45,15 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
         Log.d(TAG, "Trying to get connection")
         val connection = ConnectionFactory.usableConnectionOrNull
 
+        val showToast = inputData.getBoolean(INPUT_DATA_SHOW_TOAST, false)
+
         if (connection == null) {
             Log.e(TAG, "Got no connection")
             return if (runAttemptCount <= MAX_RETRIES) {
+                if (showToast) {
+                    applicationContext.showErrorToast(
+                        applicationContext.getString(R.string.item_update_error_no_connection))
+                }
                 Result.retry()
             } else {
                 Result.failure(buildOutputData(false, 0))
@@ -54,7 +62,12 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
 
         val itemName = inputData.getString(INPUT_DATA_ITEM_NAME)!!
         var value = inputData.getString(INPUT_DATA_VALUE)!!
-        val successToastMessage = inputData.getString(INPUT_DATA_SUCCESS_TOAST_MESSAGE)
+
+        var label = inputData.getString(INPUT_DATA_LABEL)
+        if (label.isNullOrEmpty()) label = itemName
+
+        var mappedValue = inputData.getString(INPUT_DATA_MAPPED_VALUE)
+        if (mappedValue.isNullOrEmpty()) mappedValue = value
 
         return runBlocking {
             try {
@@ -62,13 +75,15 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
                     ?: return@runBlocking Result.failure(buildOutputData(true, 500))
                 if (value == "TOGGLE") {
                     value = determineOppositeState(item)
+                    mappedValue = value
                 }
                 val result = connection.httpClient
                     .post("rest/items/$itemName", value, "text/plain;charset=UTF-8")
                     .asStatus()
                 Log.d(TAG, "Item '$itemName' successfully updated to value $value")
-                if (successToastMessage != null) {
-                    applicationContext.showToast(successToastMessage)
+                if (showToast) {
+                    applicationContext.showToast(
+                        getItemUpdateSuccessMessage(applicationContext, label, value, mappedValue!!))
                 }
                 Result.success(buildOutputData(true, result.statusCode))
             } catch (e: HttpClient.HttpException) {
@@ -130,8 +145,32 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
             .putString(OUTPUT_DATA_LABEL, inputData.getString(INPUT_DATA_LABEL))
             .putString(OUTPUT_DATA_VALUE, inputData.getString(INPUT_DATA_VALUE))
             .putString(OUTPUT_DATA_MAPPED_VALUE, inputData.getString(INPUT_DATA_MAPPED_VALUE))
+            .putString(OUTPUT_DATA_SHOW_TOAST, inputData.getString(INPUT_DATA_SHOW_TOAST))
             .putLong(OUTPUT_DATA_TIMESTAMP, System.currentTimeMillis())
             .build()
+    }
+
+
+    private fun getItemUpdateSuccessMessage(context: Context, label: String, value: String, mappedValue: String): String {
+        return when (value) {
+            "ON" -> context.getString(R.string.item_update_success_message_on, label)
+            "OFF" -> context.getString(R.string.item_update_success_message_off, label)
+            "UP" -> context.getString(R.string.item_update_success_message_up, label)
+            "DOWN" -> context.getString(R.string.item_update_success_message_down, label)
+            "MOVE" -> context.getString(R.string.item_update_success_message_move, label)
+            "STOP" -> context.getString(R.string.item_update_success_message_stop, label)
+            "INCREASE" -> context.getString(R.string.item_update_success_message_increase, label)
+            "DECREASE" -> context.getString(R.string.item_update_success_message_decrease, label)
+            "UNDEF" -> context.getString(R.string.item_update_success_message_undefined, label)
+            "" -> context.getString(R.string.item_update_success_message_empty_string, label)
+            "PLAY" -> context.getString(R.string.item_update_success_message_play, label)
+            "PAUSE" -> context.getString(R.string.item_update_success_message_pause, label)
+            "NEXT" -> context.getString(R.string.item_update_success_message_next, label)
+            "PREVIOUS" -> context.getString(R.string.item_update_success_message_previous, label)
+            "REWIND" -> context.getString(R.string.item_update_success_message_rewind, label)
+            "FASTFORWARD" -> context.getString(R.string.item_update_success_message_fastforward, label)
+            else -> context.getString(R.string.item_update_success_message_generic, label, mappedValue)
+        }
     }
 
     companion object {
@@ -142,7 +181,7 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
         private const val INPUT_DATA_LABEL = "label"
         private const val INPUT_DATA_VALUE = "value"
         private const val INPUT_DATA_MAPPED_VALUE = "mappedValue"
-        private const val INPUT_DATA_SUCCESS_TOAST_MESSAGE = "successToast"
+        private const val INPUT_DATA_SHOW_TOAST = "showToast"
 
         const val OUTPUT_DATA_HAS_CONNECTION = "hasConnection"
         const val OUTPUT_DATA_HTTP_STATUS = "httpStatus"
@@ -150,6 +189,7 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
         const val OUTPUT_DATA_LABEL = "label"
         const val OUTPUT_DATA_VALUE = "value"
         const val OUTPUT_DATA_MAPPED_VALUE = "mappedValue"
+        const val OUTPUT_DATA_SHOW_TOAST = "showToast"
         const val OUTPUT_DATA_TIMESTAMP = "timestamp"
 
         fun buildData(
@@ -157,14 +197,14 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
             label: String?,
             value: String,
             mappedValue: String?,
-            successToast: String?
+            showToast: Boolean
         ): Data {
             return Data.Builder()
                 .putString(INPUT_DATA_ITEM_NAME, itemName)
                 .putString(INPUT_DATA_LABEL, label)
                 .putString(INPUT_DATA_VALUE, value)
                 .putString(INPUT_DATA_MAPPED_VALUE, mappedValue)
-                .putString(INPUT_DATA_SUCCESS_TOAST_MESSAGE, successToast)
+                .putBoolean(INPUT_DATA_SHOW_TOAST, showToast)
                 .build()
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
@@ -150,8 +150,12 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
             .build()
     }
 
-
-    private fun getItemUpdateSuccessMessage(context: Context, label: String, value: String, mappedValue: String): String {
+    private fun getItemUpdateSuccessMessage(
+        context: Context,
+        label: String,
+        value: String,
+        mappedValue: String
+    ): String {
         return when (value) {
             "ON" -> context.getString(R.string.item_update_success_message_on, label)
             "OFF" -> context.getString(R.string.item_update_success_message_off, label)

--- a/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
@@ -90,11 +90,13 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
                 val label = data.getString(ItemUpdateWorker.OUTPUT_DATA_LABEL)
                 val value = data.getString(ItemUpdateWorker.OUTPUT_DATA_VALUE)
                 val mappedValue = data.getString(ItemUpdateWorker.OUTPUT_DATA_MAPPED_VALUE)
+                val showSuccessMessage = data.getBoolean(ItemUpdateWorker.OUTPUT_DATA_SHOW_TOAST, false)
                 val hadConnection = data.getBoolean(ItemUpdateWorker.OUTPUT_DATA_HAS_CONNECTION, false)
                 val httpStatus = data.getInt(ItemUpdateWorker.OUTPUT_DATA_HTTP_STATUS, 0)
 
                 if (itemName != null && value != null) {
-                    retryInfoList.add(BackgroundTasksManager.RetryInfo(tag, itemName, label, value, mappedValue))
+                    retryInfoList.add(
+                        BackgroundTasksManager.RetryInfo(tag, itemName, label, value, mappedValue, showSuccessMessage))
                 }
                 errors.add(if (hadConnection) {
                     if (label.isNullOrEmpty()) {

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -207,6 +207,15 @@ fun Context.getSecretPrefs(): SharedPreferences {
 }
 
 /**
+ * Shows a red Toast. Can be called from the background.
+ */
+fun Context.showErrorToast(message: CharSequence) {
+    Handler(Looper.getMainLooper()).post {
+        Toasty.error(this, message).show()
+    }
+}
+
+/**
  * Shows an orange Toast with the openHAB icon. Can be called from the background.
  */
 fun Context.showToast(message: CharSequence) {

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -148,8 +148,6 @@
     <string name="info_openhab_uuid_label">openHAB UUID</string>
     <string name="info_openhab_push_notification_label">Push notification status</string>
     <string name="action_settings">Settings</string>
-    <string name="nfc_tag_recognized_label">NFC tag for \"%s\" recognized</string>
-    <string name="nfc_tag_recognized_item">NFC tag for Item \"%s\" recognized</string>
     <string name="nfc_info_hint">Item updates can be written to NFC tags. You can select an Item here or you can long click a widget on the Sitemap.</string>
     <string name="info_not_set">Not set</string>
     <string name="empty_page">This page doesn\'t contain any widgets that are set to be visible</string>
@@ -343,5 +341,22 @@
     <string name="item_update_widget_content_description">Widget for changing Item state</string>
     <string name="item_update_widget_text">%1$s: %2$s</string>
     <string name="item_update_widget_item_picker_title">Select an Item</string>
-    <string name="item_update_widget_success_toast">%1$s set to %2$s</string>
+    <string name="item_update_success_message_generic">%1$s has been set to %2$s</string>
+    <string name="item_update_success_message_on">%s has been turned on</string>
+    <string name="item_update_success_message_off">%s has been turned off</string>
+    <string name="item_update_success_message_up">%s starts moving up</string>
+    <string name="item_update_success_message_down">%s starts moving down</string>
+    <string name="item_update_success_message_move">%s starts moving</string>
+    <string name="item_update_success_message_stop">%s has been stopped</string>
+    <string name="item_update_success_message_increase">%s has been increased</string>
+    <string name="item_update_success_message_decrease">%s has been decreased</string>
+    <string name="item_update_success_message_undefined">%s has been set to undefined</string>
+    <string name="item_update_success_message_empty_string">%s has been set to an empty string</string>
+    <string name="item_update_success_message_play">%s is playing</string>
+    <string name="item_update_success_message_pause">%s has been paused</string>
+    <string name="item_update_success_message_next">%s is showing the next title</string>
+    <string name="item_update_success_message_previous">%s is showing the previous title</string>
+    <string name="item_update_success_message_rewind">%s is rewinding</string>
+    <string name="item_update_success_message_fastforward">%s is fast forwarding</string>
+    <string name="item_update_error_no_connection">Error sending Item update, retrying\u2026</string>
 </resources>


### PR DESCRIPTION
"Light set to On" doesn't sound nice. This PR makes success toasts for a
few common states translatable. The success messages are not used for
NFC tags, because they are too long to be saved to the tag.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>