### PR TITLE
Remove special anchor handling for WebViews.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/ViewExtensions.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ViewExtensions.kt
@@ -28,6 +28,7 @@ import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import okhttp3.HttpUrl
 import org.openhab.habdroid.core.connection.Connection
 import org.openhab.habdroid.util.openInBrowser
 
@@ -48,14 +49,14 @@ fun SwipeRefreshLayout.applyColors(@AttrRes vararg colorAttrIds: Int) {
     setColorSchemeColors(*colors)
 }
 
-fun WebView.setUpForConnection(connection: Connection, url: String) {
+fun WebView.setUpForConnection(connection: Connection, url: HttpUrl) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         val webViewDatabase = WebViewDatabase.getInstance(context)
-        webViewDatabase.setHttpAuthUsernamePassword(url.toUri().host, "",
+        webViewDatabase.setHttpAuthUsernamePassword(url.host(), "",
             connection.username, connection.password)
     } else {
         @Suppress("DEPRECATION")
-        setHttpAuthUsernamePassword(url.toUri().host, "",
+        setHttpAuthUsernamePassword(url.host(), "",
             connection.username, connection.password)
     }
 
@@ -65,6 +66,7 @@ fun WebView.setUpForConnection(connection: Connection, url: String) {
         setSupportMultipleWindows(true)
     }
 
+    webViewClient = ConnectionWebViewClient(connection)
     webChromeClient = object : WebChromeClient() {
         override fun onCreateWindow(view: WebView, dialog: Boolean, userGesture: Boolean, resultMsg: Message): Boolean {
             val href = view.handler.obtainMessage()

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -893,14 +893,13 @@ class WidgetAdapter(
 
         @SuppressLint("SetJavaScriptEnabled")
         override fun bind(widget: Widget) {
-            val url = connection.httpClient.buildUrl(widget.url!!).toString()
+            val url = connection.httpClient.buildUrl(widget.url!!)
             with(webView) {
                 adjustForWidgetHeight(widget, 0)
                 loadUrl("about:blank")
 
                 setUpForConnection(connection, url)
-                webViewClient = AnchorWebViewClient(url, connection.username, connection.password)
-                loadUrl(url)
+                loadUrl(url.toString())
             }
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/WebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/WebViewFragment.kt
@@ -46,7 +46,7 @@ import kotlinx.coroutines.withContext
 import org.openhab.habdroid.R
 import org.openhab.habdroid.core.connection.CloudConnection
 import org.openhab.habdroid.core.connection.ConnectionFactory
-import org.openhab.habdroid.ui.AnchorWebViewClient
+import org.openhab.habdroid.ui.ConnectionWebViewClient
 import org.openhab.habdroid.ui.MainActivity
 import org.openhab.habdroid.ui.setUpForConnection
 
@@ -177,9 +177,12 @@ class WebViewFragment : Fragment(), ConnectionFactory.UpdateListener {
         updateViewVisibility(error = false, loading = true)
 
         val webView = webView ?: return
-        val url = conn.httpClient.buildUrl(urlToLoad).toString()
+        val url = conn.httpClient.buildUrl(urlToLoad)
 
-        webView.webViewClient = object : AnchorWebViewClient(url, conn.username, conn.password) {
+        webView.setUpForConnection(conn, url)
+        webView.setBackgroundColor(Color.TRANSPARENT)
+
+        webView.webViewClient = object : ConnectionWebViewClient(conn) {
             override fun onPageFinished(view: WebView, url: String) {
                 updateViewVisibility(error = false, loading = false)
             }
@@ -198,9 +201,7 @@ class WebViewFragment : Fragment(), ConnectionFactory.UpdateListener {
                 updateViewVisibility(error = true, loading = false)
             }
         }
-        webView.setUpForConnection(conn, url)
-        webView.loadUrl(url)
-        webView.setBackgroundColor(Color.TRANSPARENT)
+        webView.loadUrl(url.toString())
     }
 
     private fun updateViewVisibility(error: Boolean, loading: Boolean) {


### PR DESCRIPTION
PR #105 introduced special code to jump to anchors after page load if
they were passed in the URL. As this both causes issues (fragment can
also be something that's not an anchor, see #1549) and seemingly isn't
needed anymore with newer WebView versions, remove that special
handling.

Fixes #1549 