### PR TITLE
Beautify section switch.

### DIFF
--- a/mobile/src/main/res/layout/widgetlist_sectionswitchitem_button.xml
+++ b/mobile/src/main/res/layout/widgetlist_sectionswitchitem_button.xml
@@ -2,5 +2,8 @@
 <com.google.android.material.button.MaterialButton
     xmlns:android="http://schemas.android.com/apk/res/android"
     style="?materialButtonOutlinedStyle"
+    android:theme="@style/ThemeOverlay.MaterialComponents.SecondaryAsPrimary"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content" />
+    android:layout_height="wrap_content"
+    android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+    android:minWidth="0dp" />

--- a/mobile/src/main/res/values/themes.xml
+++ b/mobile/src/main/res/values/themes.xml
@@ -22,19 +22,19 @@
 
     <style name="openHAB.DayNight.orange" parent="openHAB.DayNight">
         <item name="colorPrimary">@color/openhab_orange</item>
-        <item name="colorAccent">@color/openhab_orange</item>
+        <item name="colorSecondary">@color/openhab_orange</item>
         <item name="colorPrimaryDark">@color/openhab_orange_dark</item>
     </style>
 
     <style name="openHAB.DayNight.basicui" parent="openHAB.DayNight">
         <item name="colorPrimary">@color/indigo_500</item>
-        <item name="colorAccent">@color/pink_a200</item>
+        <item name="colorSecondary">@color/pink_a200</item>
         <item name="colorPrimaryDark">@color/indigo_800</item>
     </style>
 
     <style name="openHAB.DayNight.grey" parent="openHAB.DayNight">
         <item name="colorPrimary">@color/blue_grey_700</item>
-        <item name="colorAccent">@color/blue_grey_700</item>
+        <item name="colorSecondary">@color/blue_grey_700</item>
         <item name="colorPrimaryDark">@color/blue_grey_900</item>
     </style>
 
@@ -44,6 +44,10 @@
         <item name="android:colorBackgroundCacheHint">@null</item>
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowAnimationStyle">@null</item>
+    </style>
+
+    <style name="ThemeOverlay.MaterialComponents.SecondaryAsPrimary">
+        <item name="colorPrimary">?colorSecondary</item>
     </style>
 
     <style name="Theme.MaterialComponents.Translucent" parent="Theme.MaterialComponents.TranslucentBase" />


### PR DESCRIPTION
The new section switch implementation using MaterialButtonToggleGroup
(#1598) made the button much larger than they used to be, and moved the
highlight color from the secondary/accent color to the primary one.
Adjust styling of the buttons to roll back to previous behaviour in that
regard.

Fixes #1602