### PR TITLE
Ignore "com.android.providers.calendar" for alarm clock

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -150,7 +150,8 @@ class BackgroundTasksManager : BroadcastReceiver() {
             Constants.PREFERENCE_PHONE_STATE
         )
         private val IGNORED_PACKAGES_FOR_ALARM = listOf(
-            "net.dinglisch.android.taskerm"
+            "net.dinglisch.android.taskerm",
+            "com.android.providers.calendar"
         )
         private val VALUE_GETTER_MAP = HashMap<String, (Context) -> String?>()
 


### PR DESCRIPTION
See https://community.openhab.org/t/android-app-beta/41382/145

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>