### PR TITLE
Show discrete sliders when only few states are possible

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -445,6 +445,13 @@ class WidgetAdapter(
             boundWidget = widget
 
             val stepCount = (widget.maxValue - widget.minValue) / widget.step
+
+            if (stepCount <= DISCRETE_SLIDER_STATES_THRESHOLD) {
+                seekBar.context.setTheme(R.style.Widget_AppCompat_SeekBar_Discrete)
+            } else {
+                seekBar.context.setTheme(R.style.Widget_AppCompat_SeekBar)
+            }
+
             seekBar.max = Math.ceil(stepCount.toDouble()).toInt()
             seekBar.progress = 0
 
@@ -488,6 +495,10 @@ class WidgetAdapter(
             val item = widget?.item ?: return
             val newValue = widget.minValue + widget.step * progress
             connection.httpClient.sendItemUpdate(item, item.state?.asNumber.withValue(newValue))
+        }
+
+        private companion object {
+            const val DISCRETE_SLIDER_STATES_THRESHOLD = 10
         }
     }
 


### PR DESCRIPTION
As requested per #1626, in this PR you'll see the changes needed to have a discrete slider when there are less than 10 possible states for it. Otherwise, we will have the continuous slider as usual.