### PR TITLE
Ignore "com.android.calendar" for alarm clock

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -151,7 +151,8 @@ class BackgroundTasksManager : BroadcastReceiver() {
         )
         private val IGNORED_PACKAGES_FOR_ALARM = listOf(
             "net.dinglisch.android.taskerm",
-            "com.android.providers.calendar"
+            "com.android.providers.calendar",
+            "com.android.calendar"
         )
         private val VALUE_GETTER_MAP = HashMap<String, (Context) -> String?>()
 


### PR DESCRIPTION
Fixes #1638

See https://community.openhab.org/t/android-app-beta/41382/164

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>