### PR TITLE
Fix slider behavior for color items.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.kt
@@ -118,7 +118,7 @@ data class ParsedState internal constructor(
             val hsbMatcher = HSB_PATTERN.matcher(state)
             if (hsbMatcher.find()) {
                 try {
-                    return hsbMatcher.group(3)?.toInt()
+                    return hsbMatcher.group(3)?.toFloat()?.roundToInt()
                 } catch (e: NumberFormatException) {
                     // fall through
                 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -460,7 +460,7 @@ class WidgetAdapter(
             } else {
                 val number = state.asNumber
                 if (number != null) {
-                    val progress = (number.value.toFloat() - widget.minValue) / widget.step
+                    val progress = (number.value - widget.minValue) / widget.step
                     seekBar.progress = Math.round(progress)
                 }
             }
@@ -486,8 +486,12 @@ class WidgetAdapter(
             Log.d(TAG, "onStopTrackingTouch position = $progress")
             val widget = boundWidget
             val item = widget?.item ?: return
-            val newValue = widget.minValue + widget.step * progress
-            connection.httpClient.sendItemUpdate(item, item.state?.asNumber.withValue(newValue))
+            if (item.isOfTypeOrGroupType(Item.Type.Color)) {
+                connection.httpClient.sendItemCommand(item, progress.toString())
+            } else {
+                val newValue = widget.minValue + widget.step * progress
+                connection.httpClient.sendItemUpdate(item, item.state?.asNumber.withValue(newValue))
+            }
         }
     }
 


### PR DESCRIPTION
The item update sent e.g. '45.0' as brightness, which then yielded a HSB state string
like '0,0,45.0', which we couldn't parse when getting it back. Fix the command sending
to send the (integer) progress instead, as this matches what we're doing when actually
binding the view.

Fixes #1658