### PR TITLE
Run labeler every 15 minutes

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,8 +1,10 @@
 name: Labeler
-on: pull_request
+on:
+  schedule:
+    - cron: '0/15 * * * *'
 
 jobs:
-  label:
+  labeler:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v2


### PR DESCRIPTION
If it runs on pull request, the github token is not present and thus the action fails.