### PR TITLE
Set alarm clock to 0 if alarm gets canceled

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.kt
@@ -43,6 +43,7 @@ object Constants {
     const val PREFERENCE_CHART_HQ = "default_openhab_chart_hq"
     const val PREFERENCE_ICON_FORMAT = "iconFormatType"
     const val PREFERENCE_ALARM_CLOCK = "alarmClock"
+    const val PREFERENCE_ALARM_CLOCK_LAST_VALUE_WAS_ZERO = "alarmClockLastWasZero"
     const val PREFERENCE_PHONE_STATE = "phoneState"
     const val PREFERENCE_SEND_DEVICE_INFO_PREFIX = "sendDeviceInfoPrefix"
     const val PREFERENCE_TASKER_PLUGIN_ENABLED = "taskerPlugin"


### PR DESCRIPTION
Instead of ignoring the alarm clock set by Tasker, send "0" to the
server. Also cache if the last sent alarm clock was 0 and don't send
again if so.

Fixes #1617

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>