### PR TITLE
Bump okhttp to 4.X

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -3,7 +3,7 @@ def isFoss = taskRequests.contains("Foss") || taskRequests.contains("foss")
 
 buildscript {
     ext.kotlin_coroutines_version = '1.3.3'
-    ext.ok_http_version = '3.12.6'
+    ext.ok_http_version = '4.2.2'
     ext.work_manager_version = '2.2.0'
     ext.powermock_version = '2.0.4'
     ext.espresso_version = '3.2.0'
@@ -37,7 +37,7 @@ android {
 
     defaultConfig {
         applicationId "org.openhab.habdroid"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 232
         versionName "2.11.0"

--- a/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
@@ -179,7 +179,7 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
         val contentType = response.response.contentType()
         val content = response.asText().response
 
-        if (contentType?.type() == "application" && contentType.subtype() == "json") {
+        if (contentType?.type == "application" && contentType.subtype == "json") {
             // JSON
             return try {
                 JSONObject(content).toItem()

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -104,13 +104,13 @@ class ConnectionFactory internal constructor(
         httpClient = OkHttpClient.Builder()
             .cache(CacheManager.getInstance(context).httpCache)
             .addInterceptor(httpLogger)
-            .hostnameVerifier(trustManager.wrapHostnameVerifier(OkHostnameVerifier.INSTANCE))
+            .hostnameVerifier(trustManager.wrapHostnameVerifier(OkHostnameVerifier))
             .build()
         updateHttpClientForClientCert(true)
 
         // Relax per-host connection limit, as the default limit (max 5 connections per host) is
         // too low considering SSE connections count against that limit.
-        httpClient.dispatcher().maxRequestsPerHost = httpClient.dispatcher().maxRequests
+        httpClient.dispatcher.maxRequestsPerHost = httpClient.dispatcher.maxRequests
 
         connectionHelper.changeCallback = {
             if (listeners.isEmpty()) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ConnectionWebViewClient.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ConnectionWebViewClient.kt
@@ -47,7 +47,7 @@ open class ConnectionWebViewClient(
         } else {
             Log.e(TAG, "Invalid certificate")
             handler.cancel()
-            val host = connection.httpClient.buildUrl("").host()
+            val host = connection.httpClient.buildUrl("").host
             val errorMessage = when (error.primaryError) {
                 SslError.SSL_NOTYETVALID -> context.getString(R.string.error_certificate_not_valid_yet)
                 SslError.SSL_EXPIRED -> context.getString(R.string.error_certificate_expired)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -935,11 +935,11 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         Log.e(TAG, "Error: $error", error)
         Log.e(TAG, "HTTP status code: $statusCode")
         var message = Util.getHumanReadableErrorMessage(this,
-            request.url().toString(), statusCode, error)
+            request.url.toString(), statusCode, error)
         if (prefs.isDebugModeEnabled()) {
             message = SpannableStringBuilder(message).apply {
                 inSpans(RelativeSizeSpan(0.8f)) {
-                    append("\n\nURL: ").append(request.url().toString())
+                    append("\n\nURL: ").append(request.url.toString())
 
                     val authHeader = request.header("Authorization")
                     if (authHeader?.startsWith("Basic") == true) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ViewExtensions.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ViewExtensions.kt
@@ -52,12 +52,10 @@ fun SwipeRefreshLayout.applyColors(@AttrRes vararg colorAttrIds: Int) {
 fun WebView.setUpForConnection(connection: Connection, url: HttpUrl) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         val webViewDatabase = WebViewDatabase.getInstance(context)
-        webViewDatabase.setHttpAuthUsernamePassword(url.host(), "",
-            connection.username, connection.password)
+        webViewDatabase.setHttpAuthUsernamePassword(url.host, "", connection.username, connection.password)
     } else {
         @Suppress("DEPRECATION")
-        setHttpAuthUsernamePassword(url.host(), "",
-            connection.username, connection.password)
+        setHttpAuthUsernamePassword(url.host, "", connection.username, connection.password)
     }
 
     with(settings) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
@@ -429,7 +429,7 @@ abstract class ContentController protected constructor(private val activity: Mai
     }
 
     override fun onLoadFailure(error: HttpClient.HttpException) {
-        val url = error.request.url().toString()
+        val url = error.request.url.toString()
         val errorMessage = Util.getHumanReadableErrorMessage(activity, url, error.statusCode, error)
             .toString()
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import okhttp3.Headers
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Response
 import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
@@ -40,7 +40,6 @@ import org.xml.sax.SAXException
 import java.io.IOException
 import java.io.StringReader
 import java.util.HashMap
-
 import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.parsers.ParserConfigurationException
 
@@ -474,7 +473,7 @@ class PageConnectionHolderFragment : Fragment(), CoroutineScope {
                             throw JSONException("Unexpected status $status")
                         }
                         val headerObject = result.getJSONObject("context").getJSONObject("headers")
-                        val url = HttpUrl.parse(headerObject.getJSONArray("Location").getString(0))
+                        val url = headerObject.getJSONArray("Location").getString(0).toHttpUrlOrNull()
                         if (url != null) {
                             val u = url.newBuilder()
                                 .addQueryParameter("sitemap", sitemap)
@@ -514,7 +513,7 @@ class PageConnectionHolderFragment : Fragment(), CoroutineScope {
                 // ourselves by calling close(), so check for the reporter matching our expectations
                 // (mismatch means shutdown was called)
                 if (eventSource === eventStream) {
-                    val statusCode = response?.code() ?: 0
+                    val statusCode = response?.code ?: 0
                     Log.w(TAG, "SSE stream $eventSource failed for page $pageId with status $statusCode: ${t?.message}")
                     scope.launch {
                         failureCb(false)

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -126,7 +126,7 @@ fun ResponseBody.toBitmap(targetSize: Int, enforceSize: Boolean = false): Bitmap
 }
 
 fun MediaType?.isSvg(): Boolean {
-    return this != null && this.type() == "image" && this.subtype().contains("svg")
+    return this != null && this.type == "image" && this.subtype.contains("svg")
 }
 
 @Throws(IOException::class)

--- a/mobile/src/test/java/org/openhab/habdroid/core/connection/DefaultConnectionTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/core/connection/DefaultConnectionTest.kt
@@ -127,10 +127,10 @@ class DefaultConnectionTest {
             val result = testConnection.httpClient.get(url)
             result.close()
             assertFalse("The request should never succeed in tests", true)
-            result.request.url()
+            result.request.url
         }
     } catch (e: HttpClient.HttpException) {
-        e.request.url()
+        e.request.url
     }
 
     companion object {


### PR DESCRIPTION
This requires to bump the minApi to Android 5. I posted a topic about
that in September: https://community.openhab.org/t/raise-minimum-supported-android-version-to-android-5/82742

https://square.github.io/okhttp/upgrading_to_okhttp_4/

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>