### PR TITLE
Send UNDEF instead of 0 if no alarm is active

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -288,19 +288,19 @@ class BackgroundTasksManager : BroadcastReceiver() {
                 val sender = info?.showIntent?.creatorPackage
                 Log.d(TAG, "Alarm sent by $sender")
                 var time: String? = if (sender in IGNORED_PACKAGES_FOR_ALARM) {
-                    "0"
+                    "UNDEF"
                 } else {
                     (info?.triggerTime ?: 0).toString()
                 }
 
                 val prefs = context.getPrefs()
 
-                if (time == "0" && prefs.getBoolean(Constants.PREFERENCE_ALARM_CLOCK_LAST_VALUE_WAS_ZERO, false)) {
+                if (time == "UNDEF" && prefs.getBoolean(Constants.PREFERENCE_ALARM_CLOCK_LAST_VALUE_WAS_UNDEF, false)) {
                     time = null
                 }
 
                 prefs.edit {
-                    putBoolean(Constants.PREFERENCE_ALARM_CLOCK_LAST_VALUE_WAS_ZERO, time == "0" || time == null)
+                    putBoolean(Constants.PREFERENCE_ALARM_CLOCK_LAST_VALUE_WAS_UNDEF, time == "UNDEF" || time == null)
                 }
 
                 time?.let { ItemUpdateWorker.ValueWithInfo(it, type = ItemUpdateWorker.ValueType.Timestamp) }

--- a/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
@@ -100,7 +100,7 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
                     value.mappedValue.orDefaultIfEmpty(value.value)
                 }
 
-                val result = if (inputData.getBoolean(INPUT_DATA_AS_COMMAND, false)) {
+                val result = if (inputData.getBoolean(INPUT_DATA_AS_COMMAND, false) && valueToBeSent != "UNDEF") {
                     connection.httpClient
                         .post("rest/items/$itemName", valueToBeSent, "text/plain;charset=UTF-8")
                         .asStatus()
@@ -127,7 +127,8 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
 
     private fun mapValueAccordingToItemTypeAndValue(value: ValueWithInfo, item: Item) = when {
         value.value == "TOGGLE" && item.canBeToggled() -> determineOppositeState(item)
-        value.type == ValueType.Timestamp && item.isOfTypeOrGroupType(Item.Type.DateTime) -> convertToTimestamp(value)
+        value.type == ValueType.Timestamp && item.isOfTypeOrGroupType(Item.Type.DateTime) && value.value != "UNDEF" ->
+            convertToTimestamp(value)
         else -> value.value
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.kt
@@ -43,7 +43,7 @@ object Constants {
     const val PREFERENCE_CHART_HQ = "default_openhab_chart_hq"
     const val PREFERENCE_ICON_FORMAT = "iconFormatType"
     const val PREFERENCE_ALARM_CLOCK = "alarmClock"
-    const val PREFERENCE_ALARM_CLOCK_LAST_VALUE_WAS_ZERO = "alarmClockLastWasZero"
+    const val PREFERENCE_ALARM_CLOCK_LAST_VALUE_WAS_UNDEF = "alarmClockLastWasZero"
     const val PREFERENCE_PHONE_STATE = "phoneState"
     const val PREFERENCE_SEND_DEVICE_INFO_PREFIX = "sendDeviceInfoPrefix"
     const val PREFERENCE_TASKER_PLUGIN_ENABLED = "taskerPlugin"


### PR DESCRIPTION
`0` is actually a valid time stamp, so sent `UNDEF` instead.

Fixes #1737

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>