### PR TITLE
Update sitemap title in drawer if only one sitemap is returned

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -804,6 +804,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
             } else if (result != null && (configuredSitemap.isEmpty() || configuredSitemap != result.name)) {
                 // update result
                 updateDefaultSitemap(result)
+                updateSitemapAndHabPanelDrawerItems()
             }
         }
 


### PR DESCRIPTION
If only the default sitemap is shown in the drawer and the server
returns only one sitemap, the sitemap entry in the drawer isn't updated.

This can be reproduced by enabling demo mode.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>