### PR TITLE
Use notification channels in MTM

### DIFF
--- a/mobile/src/main/java/de/duenndns/ssl/MemorizingTrustManager.java
+++ b/mobile/src/main/java/de/duenndns/ssl/MemorizingTrustManager.java
@@ -635,6 +635,7 @@ public class MemorizingTrustManager implements X509TrustManager {
             .setAutoCancel(true);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationUpdateObserver.createNotificationChannels(context);
             notification.setChannelId(NotificationUpdateObserver.CHANNEL_ID_BACKGROUND_ERROR);
         }
 

--- a/mobile/src/main/java/de/duenndns/ssl/MemorizingTrustManager.java
+++ b/mobile/src/main/java/de/duenndns/ssl/MemorizingTrustManager.java
@@ -43,6 +43,7 @@ import android.text.style.RelativeSizeSpan;
 import android.util.SparseArray;
 
 import org.openhab.habdroid.R;
+import org.openhab.habdroid.background.NotificationUpdateObserver;
 
 import java.io.File;
 import java.io.IOException;
@@ -60,7 +61,6 @@ import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.List;
@@ -619,37 +619,26 @@ public class MemorizingTrustManager implements X509TrustManager {
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     void startActivityNotification(Intent intent, int decisionId, CharSequence certName) {
-        Notification notification;
         final PendingIntent call = PendingIntent.getActivity(master, 0, intent,
                 0);
         final String mtmNotification = master.getString(R.string.mtm_notification);
         final long currentMillis = System.currentTimeMillis();
         final Context context = master.getApplicationContext();
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
-            @SuppressWarnings("deprecation")
-            // Use an extra identifier for the legacy build notification, so
-                    // that we suppress the deprecation warning. We will latter assign
-                    // this to the correct identifier.
-                    Notification n  = new Notification(android.R.drawable.ic_lock_lock,
-                    mtmNotification,
-                    currentMillis);
-            setLatestEventInfoReflective(n, context, mtmNotification, certName, call);
-            n.flags |= Notification.FLAG_AUTO_CANCEL;
-            notification = n;
-        } else {
-            notification = new Notification.Builder(master)
-                    .setContentTitle(mtmNotification)
-                    .setContentText(certName)
-                    .setTicker(certName)
-                    .setSmallIcon(android.R.drawable.ic_lock_lock)
-                    .setWhen(currentMillis)
-                    .setContentIntent(call)
-                    .setAutoCancel(true)
-                    .getNotification();
+        Notification.Builder notification = new Notification.Builder(master)
+            .setContentTitle(mtmNotification)
+            .setContentText(certName)
+            .setTicker(certName)
+            .setSmallIcon(android.R.drawable.ic_lock_lock)
+            .setWhen(currentMillis)
+            .setContentIntent(call)
+            .setAutoCancel(true);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notification.setChannelId(NotificationUpdateObserver.CHANNEL_ID_BACKGROUND_ERROR);
         }
 
-        notificationManager.notify(NOTIFICATION_ID + decisionId, notification);
+        notificationManager.notify(NOTIFICATION_ID + decisionId, notification.build());
     }
 
     /**

--- a/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
@@ -150,6 +150,7 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
          * Creates notification channels for background tasks.
          * @param context
          */
+        @JvmStatic
         fun createNotificationChannels(context: Context) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
                 return

--- a/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
@@ -144,7 +144,7 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
     companion object {
         private const val NOTIFICATION_ID_BACKGROUND_WORK = 1000
         private const val CHANNEL_ID_BACKGROUND = "background"
-        private const val CHANNEL_ID_BACKGROUND_ERROR = "backgroundError"
+        const val CHANNEL_ID_BACKGROUND_ERROR = "backgroundError"
 
         /**
          * Creates notification channels for background tasks.
@@ -155,7 +155,7 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
                 return
             }
 
-            val nm = context.getSystemService(NotificationManager::class.java)
+            val nm = context.getSystemService(NotificationManager::class.java)!!
 
             val bgChannel = NotificationChannel(CHANNEL_ID_BACKGROUND,
                 context.getString(R.string.notification_channel_background),


### PR DESCRIPTION
Otherwise there's no error message if an SSL error occurs in background tasks.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>