### PR TITLE
Add 'clear errors' action to background error notification

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -78,6 +78,9 @@ class BackgroundTasksManager : BroadcastReceiver() {
                     )
                 }
             }
+            ACTION_CLEAR_UPLOAD -> {
+                WorkManager.getInstance(context).pruneWork()
+            }
             TaskerIntent.ACTION_QUERY_CONDITION, TaskerIntent.ACTION_FIRE_SETTING -> {
                 if (!context.getPrefs().isTaskerPluginEnabled()) {
                     Log.d(TAG, "Tasker plugin is disabled")
@@ -159,6 +162,7 @@ class BackgroundTasksManager : BroadcastReceiver() {
         private val TAG = BackgroundTasksManager::class.java.simpleName
 
         internal const val ACTION_RETRY_UPLOAD = "org.openhab.habdroid.background.action.RETRY_UPLOAD"
+        internal const val ACTION_CLEAR_UPLOAD = "org.openhab.habdroid.background.action.CLEAR_UPLOAD"
         internal const val EXTRA_RETRY_INFO_LIST = "retryInfoList"
 
         private const val WORKER_TAG_ITEM_UPLOADS = "itemUploads"

--- a/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
@@ -227,7 +227,7 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
                 val clearPendingIntent = PendingIntent.getBroadcast(context, 0,
                     clearIntent, PendingIntent.FLAG_UPDATE_CURRENT)
                 nb.addAction(NotificationCompat.Action(R.drawable.ic_clear_grey_24dp,
-                    context.getString(R.string.clear_errors), clearPendingIntent))
+                    context.getString(R.string.ignore), clearPendingIntent))
             }
 
             return nb.build()

--- a/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
@@ -221,6 +221,13 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
                     retryIntent, PendingIntent.FLAG_UPDATE_CURRENT)
                 nb.addAction(NotificationCompat.Action(R.drawable.ic_refresh_grey_24dp,
                     context.getString(R.string.retry), retryPendingIntent))
+
+                val clearIntent = Intent(context, BackgroundTasksManager::class.java)
+                    .setAction(BackgroundTasksManager.ACTION_CLEAR_UPLOAD)
+                val clearPendingIntent = PendingIntent.getBroadcast(context, 0,
+                    clearIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+                nb.addAction(NotificationCompat.Action(R.drawable.ic_clear_grey_24dp,
+                    context.getString(R.string.clear_errors), clearPendingIntent))
             }
 
             return nb.build()

--- a/mobile/src/main/res/drawable/ic_clear_grey_24dp.xml
+++ b/mobile/src/main/res/drawable/ic_clear_grey_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:tint="#757575"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -154,6 +154,7 @@
     <string name="error_short_certificate_wrong_host">Certificate not valid for %s</string>
     <string name="error_short_http_code_401">Authentication failed (HTTP code %d)</string>
     <string name="error_short_http_code_403" translatable="false">@string/error_short_http_code_401</string>
+    <string name="error_short_http_code_404">Not found (HTTP code %d)</string>
     <string name="error_short_http_code_407" translatable="false">@string/error_short_http_code_401</string>
     <string name="error_short_http_code_414">URL too long (HTTP code %d)</string>
     <string name="error_short_http_code_426">HTTPS required (HTTP code %d)</string>
@@ -220,6 +221,7 @@
     <string name="item_update_connection_error_label">%1$s update failed (No connection)</string>
     <string name="error_sending_alarm_clock_item_empty">Please enter a valid Item name</string>
     <string name="retry">Retry</string>
+    <string name="clear_errors">Clear errors</string>
 
     <!-- Notification list strings -->
     <string name="notification_list_empty">No notifications were sent so far</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -221,7 +221,7 @@
     <string name="item_update_connection_error_label">%1$s update failed (No connection)</string>
     <string name="error_sending_alarm_clock_item_empty">Please enter a valid Item name</string>
     <string name="retry">Retry</string>
-    <string name="clear_errors">Clear errors</string>
+    <string name="ignore">Ignore</string>
 
     <!-- Notification list strings -->
     <string name="notification_list_empty">No notifications were sent so far</string>


### PR DESCRIPTION
Otherwise it's not possible to get rid of 404 errors if an item has been removed from the server, but the client still has a corresponding widget.

Also add a 404 error string for notifications.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>