### PR TITLE
Bind local connections to their respective networks

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/AbstractConnection.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/AbstractConnection.kt
@@ -119,7 +119,6 @@ abstract class AbstractConnection : Connection, SocketFactory {
         return Socket(host, port, clientAddress, clientPort)
     }
 
-
     companion object {
         private val TAG = AbstractConnection::class.java.simpleName
     }

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/AbstractConnection.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/AbstractConnection.kt
@@ -19,12 +19,14 @@ import okhttp3.OkHttpClient
 import org.openhab.habdroid.util.HttpClient
 
 import java.io.IOException
+import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.net.SocketTimeoutException
 import java.net.URL
+import javax.net.SocketFactory
 
-abstract class AbstractConnection : Connection {
+abstract class AbstractConnection : Connection, SocketFactory {
     final override val connectionType: Int
     final override val username: String?
     final override val password: String?
@@ -43,7 +45,7 @@ abstract class AbstractConnection : Connection {
         this.password = password
         this.baseUrl = baseUrl
         this.connectionType = connectionType
-        this.httpClient = HttpClient(httpClient, baseUrl, username, password)
+        this.httpClient = HttpClient(httpClient.newBuilder().socketFactory(this).build(), baseUrl, username, password)
     }
 
     internal constructor(base: AbstractConnection, connectionType: Int) {
@@ -73,7 +75,7 @@ abstract class AbstractConnection : Connection {
     }
 
     private fun createConnectedSocket(socketAddress: InetSocketAddress): Socket? {
-        val s = Socket()
+        val s = createSocket()
         var retries = 0
         while (retries < 10) {
             try {
@@ -96,6 +98,27 @@ abstract class AbstractConnection : Connection {
         }
         return null
     }
+
+    override fun createSocket(): Socket {
+        return Socket()
+    }
+
+    override fun createSocket(host: String?, port: Int): Socket {
+        return Socket(host, port)
+    }
+
+    override fun createSocket(host: String?, port: Int, clientAddress: InetAddress?, clientPort: Int): Socket {
+        return Socket(host, port, clientAddress, clientPort)
+    }
+
+    override fun createSocket(host: InetAddress?, port: Int): Socket {
+        return Socket(host, port)
+    }
+
+    override fun createSocket(host: InetAddress?, port: Int, clientAddress: InetAddress?, clientPort: Int): Socket {
+        return Socket(host, port, clientAddress, clientPort)
+    }
+
 
     companion object {
         private val TAG = AbstractConnection::class.java.simpleName

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -325,7 +325,10 @@ class ConnectionFactory internal constructor(
             }
         }
 
-        return when (val type = connectionHelper.currentConnection) {
+        val type = connectionHelper.currentConnection
+        Log.d(TAG, "checkAvailableConnection: found connection type $type")
+
+        return when (type) {
             is ConnectionManagerHelper.ConnectionType.None -> {
                 Log.e(TAG, "Network is not available")
                 throw NetworkNotAvailableException()

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -347,7 +347,7 @@ class ConnectionFactory internal constructor(
             }
             // Else we treat other networks types as unsupported
             else -> {
-                Log.e(TAG, "Network type ${type} is unsupported")
+                Log.e(TAG, "Network type $type is unsupported")
                 throw NetworkNotSupportedException()
             }
         }

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionManagerHelper.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionManagerHelper.kt
@@ -41,7 +41,7 @@ interface ConnectionManagerHelper {
         class Ethernet(val network: Network?) : ConnectionType()
         class Mobile(val network: Network?) : ConnectionType()
         class Unknown(val network: Network?) : ConnectionType()
-        class Vpn(val network: Network?): ConnectionType()
+        class Vpn(val network: Network?) : ConnectionType()
     }
 
     companion object {

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionManagerHelper.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionManagerHelper.kt
@@ -181,7 +181,7 @@ interface ConnectionManagerHelper {
                     .map { network -> Pair(network, connectivityManager.getNetworkInfo(network)) }
                     .filter { (network, info) -> info?.isConnected == true }
 
-            val knownTypes= listOf(
+            val knownTypes = listOf(
                 ConnectivityManager.TYPE_VPN to ConnectionType.Vpn,
                 ConnectivityManager.TYPE_WIFI to ConnectionType.Wifi,
                 ConnectivityManager.TYPE_ETHERNET to ConnectionType.Ethernet,

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/DefaultConnection.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/DefaultConnection.kt
@@ -31,9 +31,8 @@ open class DefaultConnection : AbstractConnection {
     internal constructor(baseConnection: AbstractConnection, connectionType: Int) :
         super(baseConnection, connectionType)
 
-    override fun createSocket(): Socket {
-        val s = super.createSocket()
-        network?.bindSocket(s)
-        return s
+    override fun prepareSocket(socket: Socket): Socket {
+        network?.bindSocket(socket)
+        return socket
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/DefaultConnection.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/DefaultConnection.kt
@@ -13,9 +13,13 @@
 
 package org.openhab.habdroid.core.connection
 
+import android.net.Network
 import okhttp3.OkHttpClient
+import java.net.Socket
 
 open class DefaultConnection : AbstractConnection {
+    internal var network: Network? = null
+
     internal constructor(
         httpClient: OkHttpClient,
         connectionType: Int,
@@ -26,4 +30,10 @@ open class DefaultConnection : AbstractConnection {
 
     internal constructor(baseConnection: AbstractConnection, connectionType: Int) :
         super(baseConnection, connectionType)
+
+    override fun createSocket(): Socket {
+        val s = super.createSocket()
+        network?.bindSocket(s)
+        return s
+    }
 }

--- a/mobile/src/test/java/org/openhab/habdroid/core/connection/ConnectionFactoryTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/core/connection/ConnectionFactoryTest.kt
@@ -163,7 +163,7 @@ class ConnectionFactoryTest {
     @Test(expected = NetworkNotAvailableException::class)
     @Throws(ConnectionException::class)
     fun testGetAnyConnectionNoNetwork() {
-        mockConnectionHelper.update(ConnectionManagerHelper.ConnectionType.None)
+        mockConnectionHelper.update(ConnectionManagerHelper.ConnectionType.None())
         updateAndWaitForConnections()
         ConnectionFactory.usableConnection
     }
@@ -171,7 +171,7 @@ class ConnectionFactoryTest {
     @Test(expected = NetworkNotSupportedException::class)
     @Throws(ConnectionException::class)
     fun testGetAnyConnectionUnsupportedNetwork() {
-        mockConnectionHelper.update(ConnectionManagerHelper.ConnectionType.Unknown)
+        mockConnectionHelper.update(ConnectionManagerHelper.ConnectionType.Unknown(null))
         updateAndWaitForConnections()
         ConnectionFactory.usableConnection
     }
@@ -184,7 +184,7 @@ class ConnectionFactoryTest {
         server.start()
 
         whenever(mockPrefs.getString(eq(Constants.PREFERENCE_REMOTE_URL), any())) doReturn server.url("/").toString()
-        mockConnectionHelper.update(ConnectionManagerHelper.ConnectionType.Wifi)
+        mockConnectionHelper.update(ConnectionManagerHelper.ConnectionType.Wifi(null))
         updateAndWaitForConnections()
 
         val conn = ConnectionFactory.usableConnection
@@ -205,7 +205,7 @@ class ConnectionFactoryTest {
 
         whenever(mockPrefs.getString(eq(Constants.PREFERENCE_REMOTE_URL), any())) doReturn server.url("/").toString()
         whenever(mockPrefs.getString(eq(Constants.PREFERENCE_LOCAL_URL), any())) doReturn "https://myopenhab.org:443"
-        mockConnectionHelper.update(ConnectionManagerHelper.ConnectionType.Wifi)
+        mockConnectionHelper.update(ConnectionManagerHelper.ConnectionType.Wifi(null))
         updateAndWaitForConnections()
 
         val conn = ConnectionFactory.usableConnection
@@ -221,16 +221,16 @@ class ConnectionFactoryTest {
     @Throws(ConnectionException::class)
     fun testGetAnyConnectionWifiNoLocalNoRemote() {
         whenever(mockPrefs.getString(any(), any())) doReturn null
-        mockConnectionHelper.update(ConnectionManagerHelper.ConnectionType.Wifi)
+        mockConnectionHelper.update(ConnectionManagerHelper.ConnectionType.Wifi(null))
         updateAndWaitForConnections()
         ConnectionFactory.usableConnection
     }
 
     private inner class MockConnectionHelper : ConnectionManagerHelper {
         override var changeCallback: ConnectionChangedCallback? = null
-        private var currentType = ConnectionManagerHelper.ConnectionType.Unknown
-        override val currentConnection: ConnectionManagerHelper.ConnectionResult
-            get() = ConnectionManagerHelper.ConnectionResult(currentType, null)
+        private var currentType: ConnectionManagerHelper.ConnectionType =
+            ConnectionManagerHelper.ConnectionType.Unknown(null)
+        override val currentConnection: ConnectionManagerHelper.ConnectionType get() = currentType
 
         fun update(type: ConnectionManagerHelper.ConnectionType) {
             currentType = type

--- a/mobile/src/test/java/org/openhab/habdroid/core/connection/ConnectionFactoryTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/core/connection/ConnectionFactoryTest.kt
@@ -229,7 +229,8 @@ class ConnectionFactoryTest {
     private inner class MockConnectionHelper : ConnectionManagerHelper {
         override var changeCallback: ConnectionChangedCallback? = null
         private var currentType = ConnectionManagerHelper.ConnectionType.Unknown
-        override val currentConnection: ConnectionManagerHelper.ConnectionType get() = currentType
+        override val currentConnection: ConnectionManagerHelper.ConnectionResult
+            get() = ConnectionManagerHelper.ConnectionResult(currentType, null)
 
         fun update(type: ConnectionManagerHelper.ConnectionType) {
             currentType = type


### PR DESCRIPTION
~~For local (ethernet, Wi-Fi) networks it's very likely we don't need
internet connection for connecting to the (local) server, and for
cellular network we indirectly check for internet connection via the
validation flag.~~

In case one is connected to a Wifi network without internet connection,
and one has a working mobile network at that time, Android routes all
traffic through the mobile network. Since we want local connections to
actually be local, enforce those connections to be routed through the
network we determined the connection type from.

Closes #1633 