### PR TITLE
Fix "IllegalArgumentException: Malformed \uxxxx encoding."

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/util/MjpegInputStream.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MjpegInputStream.kt
@@ -21,6 +21,7 @@ import java.io.ByteArrayInputStream
 import java.io.DataInputStream
 import java.io.IOException
 import java.io.InputStream
+import java.lang.IllegalArgumentException
 import java.util.Properties
 
 class MjpegInputStream(stream: InputStream) : DataInputStream(BufferedInputStream(stream, FRAME_MAX_LENGTH)) {
@@ -51,7 +52,11 @@ class MjpegInputStream(stream: InputStream) : DataInputStream(BufferedInputStrea
     private fun parseContentLength(headerBytes: ByteArray): Int {
         val headerIn = ByteArrayInputStream(headerBytes)
         val props = Properties()
-        props.load(headerIn)
+        try {
+            props.load(headerIn)
+        } catch (e: IllegalArgumentException) {
+            throw IOException("Error loading props", e)
+        }
         return Integer.parseInt(props.getProperty(CONTENT_LENGTH))
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/util/MjpegInputStream.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MjpegInputStream.kt
@@ -21,7 +21,6 @@ import java.io.ByteArrayInputStream
 import java.io.DataInputStream
 import java.io.IOException
 import java.io.InputStream
-import java.lang.IllegalArgumentException
 import java.util.Properties
 
 class MjpegInputStream(stream: InputStream) : DataInputStream(BufferedInputStream(stream, FRAME_MAX_LENGTH)) {


### PR DESCRIPTION
````
Fatal Exception: java.lang.IllegalArgumentException: Malformed \uxxxx encoding.
       at java.util.Properties.loadConvert(Properties.java:573)
       at java.util.Properties.load0(Properties.java:388)
       at java.util.Properties.load(Properties.java:336)
       at org.openhab.habdroid.util.MjpegInputStream.parseContentLength(MjpegInputStream.kt:54)
       at org.openhab.habdroid.util.MjpegInputStream.readMjpegFrame(MjpegInputStream.kt:72)
       at org.openhab.habdroid.util.MjpegStreamer$doStream$1.invokeSuspend(MjpegStreamer.kt:50)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>