### PR TITLE
Try to fix "IllegalStateException: You must disable foreground dispat…

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -282,9 +282,9 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
 
     override fun onPause() {
         Log.d(TAG, "onPause()")
-        super.onPause()
         val nfcAdapter = NfcAdapter.getDefaultAdapter(this)
         nfcAdapter?.disableForegroundDispatch(this)
+        super.onPause()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {


### PR DESCRIPTION
…ching while your activity is still resumed"

The app shouldn't crash here, because disableForegroundDispatch() is
called before onPause() is finished. From the docs:

> After calling enableForegroundDispatch, an activity must call this method before its onPause callback completes.

Let's see if this fixes the crash.

````
Caused by java.lang.IllegalStateException: You must disable foreground dispatching while your activity is still resumed
       at android.nfc.NfcAdapter.disableForegroundDispatchInternal(NfcAdapter.java:1247)
       at android.nfc.NfcAdapter.disableForegroundDispatch(NfcAdapter.java:1233)
       at org.openhab.habdroid.ui.MainActivity.onPause(MainActivity.kt:287)
       at android.app.Activity.performPause(Activity.java:6397)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>