### PR TITLE
Fix two crashes with JmDNS

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/util/AsyncServiceResolver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/AsyncServiceResolver.kt
@@ -19,7 +19,6 @@ import android.net.wifi.WifiManager.MulticastLock
 import android.util.Log
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
-import java.lang.Exception
 import java.net.BindException
 import java.net.Inet4Address
 import java.net.InetAddress


### PR DESCRIPTION
... and two lint fixes

````
Fatal Exception: java.net.BindException: Address already in use
       at java.net.PlainDatagramSocketImpl.bind0(PlainDatagramSocketImpl.java)
       at java.net.AbstractPlainDatagramSocketImpl.bind(AbstractPlainDatagramSocketImpl.java:96)
       at java.net.DatagramSocket.bind(DatagramSocket.java:390)
       at java.net.MulticastSocket.<init>(MulticastSocket.java:172)
       at java.net.MulticastSocket.<init>(MulticastSocket.java:137)
       at javax.jmdns.impl.JmDNSImpl.openMulticastSocket(JmDNSImpl.java:464)
       at javax.jmdns.impl.JmDNSImpl.<init>(JmDNSImpl.java:423)
       at javax.jmdns.JmDNS.create(JmDNS.java:99)
       at org.openhab.habdroid.util.AsyncServiceResolver$resolve$2.invokeSuspend(AsyncServiceResolver.kt:80)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
````

````
Fatal Exception: java.net.SocketException: No such device
       at java.net.PlainDatagramSocketImpl.join(PlainDatagramSocketImpl.java)
       at java.net.AbstractPlainDatagramSocketImpl.join(AbstractPlainDatagramSocketImpl.java:180)
       at java.net.MulticastSocket.joinGroup(MulticastSocket.java:319)
       at javax.jmdns.impl.JmDNSImpl.openMulticastSocket(JmDNSImpl.java:475)
       at javax.jmdns.impl.JmDNSImpl.<init>(JmDNSImpl.java:423)
       at javax.jmdns.JmDNS.create(JmDNS.java:99)
       at org.openhab.habdroid.util.AsyncServiceResolver$resolve$2.invokeSuspend(AsyncServiceResolver.kt:80)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>