### PR TITLE
Correctly update widget list when updating widgets via SSE

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.kt
@@ -414,6 +414,7 @@ class PageConnectionHolderFragment : Fragment(), CoroutineScope {
                         visibility == widget.visibility
                     ) {
                         val updatedWidget = Widget.updateFromEvent(widget, jsonObject)
+                        lastWidgetList?.let { it[it.indexOf(widget)] = updatedWidget }
                         callback.onWidgetUpdated(url, updatedWidget)
                         return
                     }


### PR DESCRIPTION
Notifying the list fragment via callback only works for foreground
fragments, as background fragments will ask for (and receive) the widget
list via their onStart() -> ConnectionHandler.triggerUpdate(), which in
turn will send the last known widget list. This means we have to keep
that list up-to-date as well.

Closes #1779