### PR TITLE
Implement data saver

### DIFF
--- a/mobile/src/foss/java/org/openhab/habdroid/ui/MapViewHelper.kt
+++ b/mobile/src/foss/java/org/openhab/habdroid/ui/MapViewHelper.kt
@@ -60,11 +60,11 @@ object MapViewHelper {
     private class OsmViewHolder(
         inflater: LayoutInflater,
         parent: ViewGroup,
-        private val connection: Connection,
+        connection: Connection,
         colorMapper: WidgetAdapter.ColorMapper
     ) : WidgetAdapter.AbstractMapViewHolder(inflater, parent, connection, colorMapper),
         Marker.OnMarkerDragListener {
-        private val mapView: MapView = itemView.findViewById(R.id.mapview)
+        private val mapView = baseMapView as MapView
         private val handler: Handler = Handler()
         private var started: Boolean = false
         override val dialogManager = WidgetAdapter.DialogManager()
@@ -90,11 +90,7 @@ object MapViewHelper {
             }
         }
 
-        override fun bind(widget: Widget) {
-            super.bind(widget)
-
-            mapView.adjustForWidgetHeight(widget, 5)
-            updateUiState(mapView)
+        override fun loadWidget(widget: Widget) {
             handler.post {
                 mapView.applyPositionAndLabel(boundItem, labelView.text, 15.0f,
                     allowDrag = false, allowScroll = false, markerDragListener = this)

--- a/mobile/src/foss/res/layout/widgetlist_mapitem.xml
+++ b/mobile/src/foss/res/layout/widgetlist_mapitem.xml
@@ -39,4 +39,6 @@
 
     <include layout="@layout/widgetlist_mapitem_no_position" />
 
+    <include layout="@layout/widgetlist_data_saver" />
+
 </LinearLayout>

--- a/mobile/src/full/java/org/openhab/habdroid/core/FcmMessageListenerService.kt
+++ b/mobile/src/full/java/org/openhab/habdroid/core/FcmMessageListenerService.kt
@@ -36,6 +36,7 @@ import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.getNotificationTone
 import org.openhab.habdroid.util.getNotificationVibrationPattern
 import org.openhab.habdroid.util.getPrefs
+import org.openhab.habdroid.util.isDataSaverActive
 
 class FcmMessageListenerService : FirebaseMessagingService() {
     override fun onNewToken(token: String) {
@@ -125,10 +126,10 @@ class FcmMessageListenerService : FirebaseMessagingService() {
 
         if (icon != null) {
             val connection = ConnectionFactory.cloudConnectionOrNull
-            if (connection != null) {
+            if (connection != null && !applicationContext.isDataSaverActive()) {
                 try {
                     iconBitmap = connection.httpClient
-                            .get(icon.toUrl(this), timeoutMillis = 1000)
+                            .get(icon.toUrl(this, true), timeoutMillis = 1000)
                             .asBitmap(resources.getDimensionPixelSize(R.dimen.svg_image_default_size), false)
                             .response
                 } catch (e: HttpClient.HttpException) {

--- a/mobile/src/full/java/org/openhab/habdroid/ui/MapViewHelper.kt
+++ b/mobile/src/full/java/org/openhab/habdroid/ui/MapViewHelper.kt
@@ -47,11 +47,11 @@ object MapViewHelper {
     private class GoogleMapsViewHolder(
         inflater: LayoutInflater,
         parent: ViewGroup,
-        private val connection: Connection,
+        connection: Connection,
         colorMapper: WidgetAdapter.ColorMapper
     ) : WidgetAdapter.AbstractMapViewHolder(inflater, parent, connection, colorMapper),
         GoogleMap.OnMarkerDragListener {
-        private val mapView: MapView = itemView.findViewById(R.id.mapview)
+        private val mapView = baseMapView as MapView
         private var map: GoogleMap? = null
         private var started: Boolean = false
         override val dialogManager = WidgetAdapter.DialogManager()
@@ -69,16 +69,11 @@ object MapViewHelper {
                     true
                 }
                 map.setOnMapClickListener { openPopup() }
-                map.applyPositionAndLabel(boundItem, labelView.text, 15.0f, false)
             }
         }
 
-        override fun bind(widget: Widget) {
+        override fun loadWidget(widget: Widget) {
             super.bind(widget)
-
-            mapView.adjustForWidgetHeight(widget, 5)
-
-            updateUiState(mapView)
             map?.clear()
             map?.applyPositionAndLabel(boundItem, labelView.text, 15.0f, false)
         }

--- a/mobile/src/full/res/layout/widgetlist_mapitem.xml
+++ b/mobile/src/full/res/layout/widgetlist_mapitem.xml
@@ -41,4 +41,6 @@
 
     <include layout="@layout/widgetlist_mapitem_no_position" />
 
+    <include layout="@layout/widgetlist_data_saver" />
+
 </LinearLayout>

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/Connection.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/Connection.kt
@@ -27,6 +27,9 @@ interface Connection {
      */
     val username: String?
 
+    /**
+     * @return The password used for this connection.
+     */
     val password: String?
 
     /**

--- a/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
@@ -33,12 +33,12 @@ class IconResource internal constructor(
     internal val isOh2: Boolean,
     internal val customState: String?
 ) : Parcelable {
-    fun toUrl(context: Context): String {
-        return toUrl(context.getPrefs().getIconFormat())
+    fun toUrl(context: Context, includeState: Boolean): String {
+        return toUrl(includeState, context.getPrefs().getIconFormat())
     }
 
     @VisibleForTesting
-    fun toUrl(iconFormat: IconFormat): String {
+    fun toUrl(includeState: Boolean, iconFormat: IconFormat): String {
         if (!isOh2) {
             return "images/$icon.png"
         }
@@ -54,7 +54,7 @@ class IconResource internal constructor(
             .appendQueryParameter("format", suffix)
             .appendQueryParameter("anyFormat", true)
 
-        if (!customState.isNullOrEmpty()) {
+        if (!customState.isNullOrEmpty() && includeState) {
             builder.appendQueryParameter("state", customState)
         }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ChartActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ChartActivity.kt
@@ -30,6 +30,7 @@ import org.openhab.habdroid.model.Widget
 import org.openhab.habdroid.ui.widget.WidgetImageView
 import org.openhab.habdroid.util.ScreenLockMode
 import org.openhab.habdroid.util.getPrefs
+import org.openhab.habdroid.util.isDataSaverActive
 import org.openhab.habdroid.util.orDefaultIfEmpty
 import java.util.Random
 
@@ -168,7 +169,7 @@ class ChartActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListen
 
         Log.d(TAG, "Load chart with url $chartUrl")
         chart.setImageUrl(connection, chartUrl, chart.width, forceLoad = true)
-        if (widget.refresh > 0) {
+        if (widget.refresh > 0 && !isDataSaverActive()) {
             chart.startRefreshing(widget.refresh)
         }
         swipeLayout.isRefreshing = false

--- a/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationAdapter.kt
@@ -25,6 +25,7 @@ import org.openhab.habdroid.R
 import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.model.CloudNotification
 import org.openhab.habdroid.ui.widget.WidgetImageView
+import org.openhab.habdroid.util.isDataSaverActive
 import java.util.ArrayList
 
 class CloudNotificationAdapter(context: Context, private val loadMoreListener: () -> Unit) :
@@ -110,7 +111,7 @@ class CloudNotificationAdapter(context: Context, private val loadMoreListener: (
             if (notification.icon != null && conn != null) {
                 iconView.setImageUrl(
                     conn,
-                    notification.icon.toUrl(itemView.context),
+                    notification.icon.toUrl(itemView.context, !itemView.context.isDataSaverActive()),
                     itemView.resources.getDimensionPixelSize(R.dimen.notificationlist_icon_size),
                     2000
                 )

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ItemPickerAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ItemPickerAdapter.kt
@@ -24,6 +24,7 @@ import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.model.toOH2IconResource
 import org.openhab.habdroid.ui.widget.WidgetImageView
+import org.openhab.habdroid.util.isDataSaverActive
 import java.util.ArrayList
 import java.util.Comparator
 import java.util.Locale
@@ -121,7 +122,12 @@ class ItemPickerAdapter(context: Context, private val itemClickListener: ItemCli
             val icon = item.category.toOH2IconResource()
             if (icon != null && connection != null) {
                 val size = iconView.resources.getDimensionPixelSize(R.dimen.notificationlist_icon_size)
-                iconView.setImageUrl(connection, icon.toUrl(itemView.context), size, 2000)
+                iconView.setImageUrl(
+                    connection,
+                    icon.toUrl(itemView.context, !itemView.context.isDataSaverActive()),
+                    size,
+                    2000
+                )
             } else {
                 iconView.setImageResource(R.drawable.ic_openhab_appicon_24dp)
             }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -101,6 +101,7 @@ import org.openhab.habdroid.util.areSitemapsShownInDrawer
 import org.openhab.habdroid.util.getDefaultSitemap
 import org.openhab.habdroid.util.getHumanReadableErrorMessage
 import org.openhab.habdroid.util.getPrefs
+import org.openhab.habdroid.util.isDataSaverActive
 import org.openhab.habdroid.util.isDebugModeEnabled
 import org.openhab.habdroid.util.isResolvable
 import org.openhab.habdroid.util.isScreenTimerDisabled
@@ -741,13 +742,14 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
     private fun loadSitemapIcon(sitemap: Sitemap, item: MenuItem) {
         val defaultIcon = ContextCompat.getDrawable(this, R.drawable.ic_openhab_appicon_24dp)
         item.icon = applyDrawerIconTint(defaultIcon)
+        val conn = connection
 
-        if (sitemap.icon == null || connection == null) {
+        if (sitemap.icon == null || conn == null) {
             return
         }
         launch {
             try {
-                item.icon = connection!!.httpClient.get(sitemap.icon.toUrl(this@MainActivity))
+                item.icon = conn.httpClient.get(sitemap.icon.toUrl(this@MainActivity, !isDataSaverActive()))
                     .asBitmap(defaultIcon!!.intrinsicWidth, true)
                     .response
                     .toDrawable(resources)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/homescreenwidget/ItemUpdateWidget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/homescreenwidget/ItemUpdateWidget.kt
@@ -165,7 +165,7 @@ open class ItemUpdateWidget : AppWidgetProvider() {
         appWidgetId: Int,
         appWidgetManager: AppWidgetManager
     ) = GlobalScope.launch {
-        val iconUrl = data.icon?.withCustomState(data.state)?.toUrl(context)
+        val iconUrl = data.icon?.withCustomState(data.state)?.toUrl(context, true)
 
         if (iconUrl != null) {
             val cm = CacheManager.getInstance(context)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/AutoHeightVideoView.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/AutoHeightVideoView.kt
@@ -47,7 +47,7 @@ class AutoHeightVideoView constructor(context: Context, attrs: AttributeSet) : V
     }
 
     override fun setPlayer(player: SessionPlayer) {
-        currentPlayer?.let { p -> p.unregisterPlayerCallback(playerCallback) }
+        currentPlayer?.unregisterPlayerCallback(playerCallback)
         super.setPlayer(player)
         player.registerPlayerCallback(executor, playerCallback)
     }

--- a/mobile/src/main/java/org/openhab/habdroid/util/CacheManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/CacheManager.kt
@@ -53,6 +53,10 @@ class CacheManager private constructor(appContext: Context) {
         bitmapCache.put(url, bitmap)
     }
 
+    fun isBitmapCached(url: HttpUrl): Boolean {
+        return getCachedBitmap(url) != null
+    }
+
     fun saveWidgetIcon(widgetId: Int, iconData: InputStream, format: IconFormat) {
         FileOutputStream(getWidgetIconFile(widgetId, format)).use {
             iconData.copyTo(it)

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -22,6 +22,8 @@ import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
+import android.net.ConnectivityManager
+import android.net.ConnectivityManager.RESTRICT_BACKGROUND_STATUS_DISABLED
 import android.net.Network
 import android.net.Uri
 import android.os.Build
@@ -317,6 +319,15 @@ fun Context.openInAppStore(app: String) {
     } else {
         "http://play.google.com/store/apps/details?id=$app".toUri().openInBrowser(this)
     }
+}
+
+fun Context.isDataSaverActive(): Boolean {
+    val dataSaverPref = getPrefs().getBoolean(PrefKeys.PREFERENCE_DATA_SAVER, false)
+    if (dataSaverPref || Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+        return dataSaverPref
+    }
+    val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    return cm.restrictBackgroundStatus != RESTRICT_BACKGROUND_STATUS_DISABLED
 }
 
 fun Activity.finishAndRemoveTaskIfPossible() {

--- a/mobile/src/main/java/org/openhab/habdroid/util/PrefKeys.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/PrefKeys.kt
@@ -51,6 +51,7 @@ object PrefKeys {
     const val TONE = "default_openhab_alertringtone"
     const val NOTIFICATION_VIBRATION = "default_openhab_notification_vibration"
     const val NOTIFICATION_TONE_VIBRATION = "default_openhab_alertringtone_vibration"
+    const val PREFERENCE_DATA_SAVER = "data_saver"
     const val DEBUG_MESSAGES = "default_openhab_debug_messages"
     const val LOG = "default_openhab_log"
 

--- a/mobile/src/main/res/drawable/ic_data_usage_black_48dp.xml
+++ b/mobile/src/main/res/drawable/ic_data_usage_black_48dp.xml
@@ -1,0 +1,8 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="48dp"
+    android:width="48dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path android:fillColor="#FF000000" android:pathData="M13,2.05v3.03c3.39,0.49 6,3.39 6,6.92 0,0.9 -0.18,1.75 -0.48,2.54l2.6,1.53c0.56,-1.24 0.88,-2.62 0.88,-4.07 0,-5.18 -3.95,-9.45 -9,-9.95zM12,19c-3.87,0 -7,-3.13 -7,-7 0,-3.53 2.61,-6.43 6,-6.92V2.05c-5.06,0.5 -9,4.76 -9,9.95 0,5.52 4.47,10 9.99,10 3.31,0 6.24,-1.61 8.06,-4.09l-2.6,-1.53C16.17,17.98 14.21,19 12,19z"/>
+</vector>

--- a/mobile/src/main/res/layout/widgetlist_chartitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_chartitem.xml
@@ -10,7 +10,7 @@
     android:paddingEnd="@dimen/widgetlist_item_side_margin">
 
     <org.openhab.habdroid.ui.widget.WidgetImageView
-        android:id="@+id/chart"
+        android:id="@+id/widget_content"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
@@ -18,5 +18,7 @@
         android:layout_margin="4dip"
         app:emptyHeightToWidthRatio="50%"
         app:progressIndicator="@drawable/ic_image_loading_themed" />
+
+    <include layout="@layout/widgetlist_data_saver" />
 
 </FrameLayout>

--- a/mobile/src/main/res/layout/widgetlist_data_saver.xml
+++ b/mobile/src/main/res/layout/widgetlist_data_saver.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/data_saver"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center_vertical"
+    android:padding="16dp"
+    android:orientation="vertical"
+    android:visibility="gone"
+    tools:visibility="visible">
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/watermark"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:src="@drawable/ic_data_usage_black_48dp"
+        app:tint="@color/empty_list_text_color"
+        app:tintMode="src_in" />
+
+    <TextView
+        android:id="@+id/data_saver_hint"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:padding="8dp"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="@color/empty_list_text_color"
+        tools:text="Webcam is not loaded to save data" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/data_saver_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:text="@string/data_saver_load" />
+</LinearLayout>

--- a/mobile/src/main/res/layout/widgetlist_imageitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_imageitem.xml
@@ -9,11 +9,13 @@
     android:paddingEnd="@dimen/widgetlist_item_side_margin">
 
     <org.openhab.habdroid.ui.widget.WidgetImageView
-        android:id="@+id/image"
+        android:id="@+id/widget_content"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="4dip"
         android:adjustViewBounds="true"
         app:progressIndicator="@drawable/ic_image_loading_themed" />
+
+    <include layout="@layout/widgetlist_data_saver" />
 
 </FrameLayout>

--- a/mobile/src/main/res/layout/widgetlist_videoitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_videoitem.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<org.openhab.habdroid.ui.widget.AutoHeightVideoView
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/video"
-    android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="4dip"
-    android:paddingStart="@dimen/widgetlist_item_side_margin"
-    android:paddingEnd="@dimen/widgetlist_item_side_margin" />
+    android:layout_width="match_parent">
+
+    <org.openhab.habdroid.ui.widget.AutoHeightVideoView
+        android:id="@+id/widget_content"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="4dip"
+        android:paddingStart="@dimen/widgetlist_item_side_margin"
+        android:paddingEnd="@dimen/widgetlist_item_side_margin" />
+
+    <include layout="@layout/widgetlist_data_saver" />
+
+</FrameLayout>

--- a/mobile/src/main/res/layout/widgetlist_videomjpegitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_videomjpegitem.xml
@@ -9,12 +9,14 @@
     android:paddingEnd="@dimen/widgetlist_item_side_margin">
 
     <org.openhab.habdroid.ui.widget.WidgetImageView
-        android:id="@+id/mjpeg_image"
+        android:id="@+id/widget_content"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:adjustViewBounds="true"
         android:layout_margin="4dip"
         android:contentDescription="@string/content_description_video"
         app:progressIndicator="@drawable/ic_image_loading_themed" />
+
+    <include layout="@layout/widgetlist_data_saver" />
 
 </FrameLayout>

--- a/mobile/src/main/res/layout/widgetlist_webitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_webitem.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<WebView
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/webview"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_margin="4dp"
-    android:paddingStart="@dimen/widgetlist_item_side_margin"
-    android:paddingEnd="@dimen/widgetlist_item_side_margin" />
+    android:layout_height="match_parent">
+
+    <WebView
+        android:id="@+id/widget_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="4dp"
+        android:paddingStart="@dimen/widgetlist_item_side_margin"
+        android:paddingEnd="@dimen/widgetlist_item_side_margin" />
+
+    <include layout="@layout/widgetlist_data_saver" />
+
+</FrameLayout>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -443,4 +443,14 @@
     <string name="item_update_widget_auto_generate_widget_label">Auto generate widget label</string>
     <string name="item_update_widget_widget_label">Widget label</string>
     <string name="item_update_widget_default_label"><![CDATA[<Item label>: <Action>]]></string>
+    <string name="data_saver_title">Data saver</string>
+    <string name="data_saver_on">Reduce data usage</string>
+    <string name="data_saver_off">Respect device setting</string>
+    <string name="data_saver_load">Load anyway</string>
+    <string name="data_saver_hint">%s was not loaded to save data</string>
+    <string name="widget_type_image">Image</string>
+    <string name="widget_type_webview">WebView</string>
+    <string name="widget_type_video">Video</string>
+    <string name="widget_type_mapview">Map</string>
+    <string name="widget_type_chart">Chart</string>
 </resources>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -173,6 +173,12 @@
             android:title="@string/settings_notification_ringtone_vibration"
             android:icon="@drawable/ic_bell_outline_grey_24dp" />
         <SwitchPreference
+            android:key="data_saver"
+            android:defaultValue="false"
+            android:title="@string/data_saver_title"
+            android:summaryOn="@string/data_saver_on"
+            android:summaryOff="@string/data_saver_off" />
+        <SwitchPreference
             android:defaultValue="false"
             android:key="default_openhab_debug_messages"
             android:title="@string/settings_debug_messages_title" />

--- a/mobile/src/test/java/org/openhab/habdroid/model/SitemapTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/model/SitemapTest.kt
@@ -58,7 +58,8 @@ class SitemapTest {
     @Test
     fun testGetIcon() {
         assertNull(demoSitemapWithLabel.icon)
-        assertEquals("icon/home?format=SVG&anyFormat=true", homeSitemapWithoutLabel.icon?.toUrl(IconFormat.Svg))
+        assertEquals("icon/home?format=SVG&anyFormat=true", homeSitemapWithoutLabel.icon?.toUrl(false, IconFormat.Svg))
+        assertEquals("icon/home?format=SVG&anyFormat=true", homeSitemapWithoutLabel.icon?.toUrl(true, IconFormat.Svg))
     }
 
     @Test

--- a/mobile/src/test/java/org/openhab/habdroid/model/WidgetTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/model/WidgetTest.kt
@@ -51,17 +51,26 @@ class WidgetTest {
 
     @Test
     fun getIconPath_iconExists_returnIconUrlFromImages() {
-        assertEquals("images/groupicon.png", sutXml[0].icon?.toUrl(IconFormat.Png))
+        assertEquals("images/groupicon.png", sutXml[0].icon?.toUrl(false, IconFormat.Png))
+        assertEquals("images/groupicon.png", sutXml[0].icon?.toUrl(true, IconFormat.Png))
     }
 
     @Test
     fun testGetIconPath() {
-        assertEquals("icon/groupicon?format=PNG&anyFormat=true&state=OFF", sut1[0].icon?.toUrl(IconFormat.Png))
-        assertEquals("icon/groupicon?format=SVG&anyFormat=true&state=ON", sut2[0].icon?.toUrl(IconFormat.Svg))
-        assertEquals("icon/slider?format=SVG&anyFormat=true&state=81", sut3[1].icon?.toUrl(IconFormat.Svg))
+        assertEquals("icon/groupicon?format=PNG&anyFormat=true&state=OFF",
+            sut1[0].icon?.toUrl(true, IconFormat.Png))
+        assertEquals("icon/groupicon?format=SVG&anyFormat=true&state=ON",
+            sut2[0].icon?.toUrl(true, IconFormat.Svg))
+        assertEquals("icon/slider?format=SVG&anyFormat=true&state=81",
+            sut3[1].icon?.toUrl(true, IconFormat.Svg))
         assertEquals("Rollersutter icon must always be 0 to 100, not ON/OFF",
-                "icon/rollershutter?format=SVG&anyFormat=true&state=0", sut3[2].icon?.toUrl(IconFormat.Svg))
-        assertEquals("icon/rollershutter?format=SVG&anyFormat=true&state=42", sut3[3].icon?.toUrl(IconFormat.Svg))
+            "icon/rollershutter?format=SVG&anyFormat=true&state=0",
+            sut3[2].icon?.toUrl(true, IconFormat.Svg))
+        assertEquals("icon/rollershutter?format=SVG&anyFormat=true&state=42",
+            sut3[3].icon?.toUrl(true, IconFormat.Svg))
+        assertEquals("If data saver is active, icon paths must not contain a state",
+            "icon/rollershutter?format=SVG&anyFormat=true",
+            sut3[3].icon?.toUrl(false, IconFormat.Svg))
     }
 
     @Test


### PR DESCRIPTION
Respect device wide data saver and add setting to enable data saver for
openHAB only.

If enabled, ...
* widgets with high data usage are replaced by a button that shows them
* automatic image refresh is disabled
* icon paths don't contain the state => reduces icon downloads
* chart resolution is lowered

Fixes #660