### PR TITLE
Fix NPE in AsyncServiceResolver

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/util/AsyncServiceResolver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/AsyncServiceResolver.kt
@@ -17,8 +17,12 @@ import android.content.Context
 import android.net.wifi.WifiManager
 import android.net.wifi.WifiManager.MulticastLock
 import android.util.Log
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.net.BindException
 import java.net.Inet4Address
 import java.net.InetAddress
@@ -46,7 +50,7 @@ class AsyncServiceResolver(
             while (en.hasMoreElements()) {
                 val intf = en.nextElement()
                 val enumIpAddr = intf.inetAddresses
-                while (enumIpAddr.hasMoreElements()) {
+                while (enumIpAddr?.hasMoreElements() == true) {
                     val inetAddress = enumIpAddr.nextElement()
                     Log.i(TAG, "IP: ${inetAddress.hostAddress}")
                     if (!inetAddress.isLoopbackAddress && inetAddress is Inet4Address) {
@@ -55,8 +59,8 @@ class AsyncServiceResolver(
                     }
                 }
             }
-        } catch (ex: SocketException) {
-            Log.e(TAG, ex.toString())
+        } catch (e: SocketException) {
+            Log.e(TAG, e.toString())
         }
 
         return null


### PR DESCRIPTION
````
Fatal Exception: java.lang.NullPointerException: Attempt to invoke interface method 'boolean java.util.Enumeration.hasMoreElements()' on a null object reference
       at org.openhab.habdroid.util.AsyncServiceResolver.getLocalIpv4Address(AsyncServiceResolver.kt:49)
       at org.openhab.habdroid.util.AsyncServiceResolver.access$getLocalIpv4Address$p(AsyncServiceResolver.kt:32)
       at org.openhab.habdroid.util.AsyncServiceResolver$resolve$2.invokeSuspend(AsyncServiceResolver.kt:82)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
       at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:561)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:727)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:667)
       at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:655)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>