### PR TITLE
Refactor connection check logic.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -323,9 +323,9 @@ class ConnectionFactory internal constructor(
         if (local != null) {
             val localCandidates = available
                 .filter { type ->
-                    type is ConnectionManagerHelper.ConnectionType.Wifi
-                        || type is ConnectionManagerHelper.ConnectionType.Ethernet
-                        || type is ConnectionManagerHelper.ConnectionType.Vpn
+                    type is ConnectionManagerHelper.ConnectionType.Wifi ||
+                        type is ConnectionManagerHelper.ConnectionType.Ethernet ||
+                        type is ConnectionManagerHelper.ConnectionType.Vpn
                 }
             for (type in localCandidates) {
                 if (local is DefaultConnection) {

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionManagerHelper.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionManagerHelper.kt
@@ -36,11 +36,11 @@ interface ConnectionManagerHelper {
     fun shutdown()
 
     sealed class ConnectionType constructor(val network: Network?) {
-        class Wifi(network: Network?) : ConnectionType(network)
         class Ethernet(network: Network?) : ConnectionType(network)
         class Mobile(network: Network?) : ConnectionType(network)
         class Unknown(network: Network?) : ConnectionType(network)
         class Vpn(network: Network?) : ConnectionType(network)
+        class Wifi(network: Network?) : ConnectionType(network)
     }
 
     companion object {

--- a/mobile/src/test/java/org/openhab/habdroid/core/connection/ConnectionFactoryTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/core/connection/ConnectionFactoryTest.kt
@@ -165,7 +165,7 @@ class ConnectionFactoryTest {
     @Test(expected = NetworkNotAvailableException::class)
     @Throws(ConnectionException::class)
     fun testGetAnyConnectionNoNetwork() {
-        mockConnectionHelper.update(ConnectionManagerHelper.ConnectionType.None())
+        mockConnectionHelper.update(null)
         updateAndWaitForConnections()
         ConnectionFactory.usableConnection
     }
@@ -230,12 +230,11 @@ class ConnectionFactoryTest {
 
     private inner class MockConnectionHelper : ConnectionManagerHelper {
         override var changeCallback: ConnectionChangedCallback? = null
-        private var currentType: ConnectionManagerHelper.ConnectionType =
-            ConnectionManagerHelper.ConnectionType.Unknown(null)
-        override val currentConnection: ConnectionManagerHelper.ConnectionType get() = currentType
+        private var currentTypes: List<ConnectionManagerHelper.ConnectionType> = emptyList()
+        override val currentConnections: List<ConnectionManagerHelper.ConnectionType> get() = currentTypes
 
-        fun update(type: ConnectionManagerHelper.ConnectionType) {
-            currentType = type
+        fun update(type: ConnectionManagerHelper.ConnectionType?) {
+            currentTypes = if (type != null) listOf(type) else emptyList()
             changeCallback?.invoke()
         }
         override fun shutdown() {}


### PR DESCRIPTION
Instead of checking only the 'top priority' network for whether the
local connection is reachable, do that check for all networks that
might be local (Wifi, Ethernet, VPN) and only fall back to the remote
connection if that check fails for all of them.

Fixes #1804