### PR TITLE
Be lenient about binding sockets to a given network.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/AbstractConnection.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/AbstractConnection.kt
@@ -125,6 +125,6 @@ abstract class AbstractConnection : Connection {
     }
 
     companion object {
-        private val TAG = AbstractConnection::class.java.simpleName
+        internal val TAG = AbstractConnection::class.java.simpleName
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -328,6 +328,7 @@ class ConnectionFactory internal constructor(
                         type is ConnectionManagerHelper.ConnectionType.Vpn
                 }
             for (type in localCandidates) {
+                Log.d(TAG, "Checking local server availability via $type (network ${type.network})")
                 if (local is DefaultConnection) {
                     local.network = type.network
                 }

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/DefaultConnection.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/DefaultConnection.kt
@@ -14,7 +14,9 @@
 package org.openhab.habdroid.core.connection
 
 import android.net.Network
+import android.util.Log
 import okhttp3.OkHttpClient
+import java.io.IOException
 import java.net.Socket
 
 open class DefaultConnection : AbstractConnection {
@@ -32,7 +34,11 @@ open class DefaultConnection : AbstractConnection {
         super(baseConnection, connectionType)
 
     override fun prepareSocket(socket: Socket): Socket {
-        network?.bindSocket(socket)
+        try {
+            network?.bindSocket(socket)
+        } catch (e: IOException) {
+            Log.w(TAG, "Failed binding socket to network $network, continuing without binding", e)
+        }
         return socket
     }
 }


### PR DESCRIPTION
We bind to networks only to ensure servers only reachable via one
network are connected via that network, we don't attach other properties
(e.g. desired security) to that bind request. If the binding operation
fails (e.g. because a VPN app installed a global VPN which prevents us
from using other networks), don't fail the socket creation due to that
failure.

Fixes #1804 