### PR TITLE
Refactor server reachability check logic.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/Connection.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/Connection.kt
@@ -35,11 +35,6 @@ interface Connection {
      */
     val connectionType: Int
 
-    /**
-     * @return Whether the this connection is currently reachable.
-     */
-    fun checkReachabilityInBackground(): Boolean
-
     companion object {
         /**
          * Represents a connection to a locally hosted openHAB server, which is most likely the instance

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -304,7 +304,7 @@ class ConnectionFactory internal constructor(
             secretPrefs.getString(passwordKey, null))
     }
 
-    private fun checkAvailableConnection(local: Connection?, remote: Connection?): Connection {
+    private suspend fun checkAvailableConnection(local: Connection?, remote: Connection?): Connection {
         val available = connectionHelper.currentConnections
             .sortedBy { type -> when (type) {
                 is ConnectionManagerHelper.ConnectionType.Vpn -> 1
@@ -328,12 +328,9 @@ class ConnectionFactory internal constructor(
                         type is ConnectionManagerHelper.ConnectionType.Vpn
                 }
             for (type in localCandidates) {
-                Log.d(TAG, "Checking local server availability via $type (network ${type.network})")
-                if (local is DefaultConnection) {
-                    local.network = type.network
-                }
-                if (local.checkReachabilityInBackground()) {
+                if (local is DefaultConnection && local.isReachableViaNetwork(type.network)) {
                     Log.d(TAG, "Connecting to local URL via $type")
+                    local.network = type.network
                     return local
                 }
             }

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionManagerHelper.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionManagerHelper.kt
@@ -41,6 +41,10 @@ interface ConnectionManagerHelper {
         class Unknown(network: Network?) : ConnectionType(network)
         class Vpn(network: Network?) : ConnectionType(network)
         class Wifi(network: Network?) : ConnectionType(network)
+
+        override fun toString(): String {
+            return "ConnectionType(type = ${javaClass.simpleName}, network=$network)"
+        }
     }
 
     companion object {

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -23,6 +23,7 @@ import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
+import android.net.Network
 import android.net.Uri
 import android.os.Build
 import android.util.DisplayMetrics
@@ -49,6 +50,7 @@ import java.io.IOException
 import java.io.InputStream
 import java.net.ConnectException
 import java.net.MalformedURLException
+import java.net.Socket
 import java.net.SocketTimeoutException
 import java.net.URL
 import java.net.UnknownHostException
@@ -312,5 +314,13 @@ fun Activity.finishAndRemoveTaskIfPossible() {
         finishAndRemoveTask()
     } else {
         finish()
+    }
+}
+
+fun Socket.bindToNetworkIfPossible(network: Network?) {
+    try {
+        network?.bindSocket(this)
+    } catch (e: IOException) {
+        Log.d(Util.TAG, "Binding socket $this to network $network failed: $e")
     }
 }


### PR DESCRIPTION
Instead of relying on the connection's socket factory for doing the
reachability check, pass the network to be used for the check directly
to the check method, which makes sure we aren't disturbing any ongoing
foreground operations on this connection while doing the check.

While at it, also move the checking code to DefaultConnection (it's only
needed for actual server connections, after all) and make the check
cancelable by using delay() instead of Thread.sleep().

Closes #1804