### PR TITLE
Fix url validation in UrlInputPreference

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -295,7 +295,7 @@ class ConnectionFactory internal constructor(
         passwordKey: String
     ): AbstractConnection? {
         val url = prefs.getString(urlKey).toNormalizedUrl()
-        if (url.isEmpty()) {
+        if (url.isNullOrEmpty()) {
             return null
         }
         return DefaultConnection(httpClient, type, url,

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/DefaultConnection.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/DefaultConnection.kt
@@ -15,8 +15,8 @@ package org.openhab.habdroid.core.connection
 
 import android.net.Network
 import android.util.Log
-import androidx.core.net.toUri
 import kotlinx.coroutines.delay
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import org.openhab.habdroid.util.bindToNetworkIfPossible
 import java.io.IOException
@@ -40,7 +40,7 @@ open class DefaultConnection : AbstractConnection {
 
     suspend fun isReachableViaNetwork(network: Network?): Boolean {
         Log.d(TAG, "Checking reachability of $baseUrl (via $network)")
-        val uri = baseUrl.toUri()
+        val uri = baseUrl.toHttpUrl()
         val checkPort = when {
             uri.scheme == "http" && uri.port == -1 -> 80
             uri.scheme == "https" && uri.port == -1 -> 443

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/DefaultConnection.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/DefaultConnection.kt
@@ -40,13 +40,8 @@ open class DefaultConnection : AbstractConnection {
 
     suspend fun isReachableViaNetwork(network: Network?): Boolean {
         Log.d(TAG, "Checking reachability of $baseUrl (via $network)")
-        val uri = baseUrl.toHttpUrl()
-        val checkPort = when {
-            uri.scheme == "http" && uri.port == -1 -> 80
-            uri.scheme == "https" && uri.port == -1 -> 443
-            else -> uri.port
-        }
-        val s = createConnectedSocket(InetSocketAddress(uri.host, checkPort), network)
+        val url = baseUrl.toHttpUrl()
+        val s = createConnectedSocket(InetSocketAddress(url.host, url.port), network)
         s?.close()
         return s != null
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/LogActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/LogActivity.kt
@@ -23,13 +23,13 @@ import android.view.View
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
-import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.openhab.habdroid.R
 import org.openhab.habdroid.util.getLocalUrl
 import org.openhab.habdroid.util.getPrefs
@@ -208,7 +208,7 @@ class LogActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListener
     }
 
     private fun redactHost(text: String, url: String?, replacement: String): String {
-        val host = url?.toUri()?.host
+        val host = url?.toHttpUrlOrNull()?.host
         return if (!host.isNullOrEmpty()) text.replace(host, replacement) else text
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -35,7 +35,6 @@ import androidx.core.app.NavUtils
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.graphics.drawable.DrawableCompat
-import androidx.core.net.toUri
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.commit
 import androidx.preference.Preference
@@ -45,6 +44,7 @@ import androidx.preference.PreferenceGroup
 import com.jaredrummler.android.colorpicker.ColorPreferenceCompat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.openhab.habdroid.R
 import org.openhab.habdroid.model.ServerProperties
 import org.openhab.habdroid.ui.homescreenwidget.ItemUpdateWidget
@@ -523,7 +523,7 @@ class PreferencesActivity : AbstractBaseActivity() {
             private const val REQUEST_CODE_RINGTONE = 1000
 
             @VisibleForTesting fun beautifyUrl(url: String): String {
-                val host = url.toUri().host ?: url
+                val host = url.toHttpUrlOrNull()?.host ?: url
                 return if (host.matches("^(home.)?myopenhab.org$".toRegex())) "myopenHAB" else host
             }
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.kt
@@ -210,7 +210,7 @@ class PageConnectionHolderFragment : Fragment(), CoroutineScope {
 
         init {
             if (callback.serverProperties?.hasSseSupport() == true) {
-                val segments = url.toUri().pathSegments
+                val segments = url.toHttpUrlOrNull()?.pathSegments ?: emptyList()
                 if (segments.size > 2) {
                     val sitemap = segments[segments.size - 2]
                     val pageId = segments[segments.size - 1]

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/UrlInputPreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/UrlInputPreference.kt
@@ -26,9 +26,9 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.preference.EditTextPreferenceDialogFragmentCompat
 import com.google.android.material.textfield.TextInputLayout
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.openhab.habdroid.R
 import java.net.MalformedURLException
-import java.net.URL
 
 class UrlInputPreference constructor(context: Context, attrs: AttributeSet) :
     CustomInputTypePreference(context, attrs) {
@@ -96,9 +96,9 @@ class UrlInputPreference constructor(context: Context, attrs: AttributeSet) :
                     urlIsValid = false
                 } else {
                     try {
-                        val url = URL(value)
+                        val url = value.toHttpUrl()
                         urlIsValid = true
-                        when (url.protocol) {
+                        when (url.scheme) {
                             "https" -> portSeemsInvalid = url.port == 80 || url.port == 8080
                             "http" -> if (isHttpEnabled) {
                                 portSeemsInvalid = url.port == 443 || url.port == 8443

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/UrlInputPreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/UrlInputPreference.kt
@@ -98,15 +98,15 @@ class UrlInputPreference constructor(context: Context, attrs: AttributeSet) :
                     try {
                         val url = value.toHttpUrl()
                         urlIsValid = true
-                        when (url.scheme) {
-                            "https" -> portSeemsInvalid = url.port == 80 || url.port == 8080
-                            "http" -> if (isHttpEnabled) {
-                                portSeemsInvalid = url.port == 443 || url.port == 8443
-                            } else {
+                        portSeemsInvalid = when {
+                            url.isHttps -> url.port == 80 || url.port == 8080
+                            !isHttpEnabled -> {
                                 urlIsValid = false
+                                false
                             }
+                            else -> url.port == 443 || url.port == 8443
                         }
-                    } catch (e: MalformedURLException) {
+                    } catch (e: IllegalArgumentException) {
                         urlIsValid = false
                     }
                 }

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -37,6 +37,7 @@ import es.dmoral.toasty.Toasty
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType
 import okhttp3.ResponseBody
 import org.json.JSONArray
@@ -49,10 +50,8 @@ import java.io.EOFException
 import java.io.IOException
 import java.io.InputStream
 import java.net.ConnectException
-import java.net.MalformedURLException
 import java.net.Socket
 import java.net.SocketTimeoutException
-import java.net.URL
 import java.net.UnknownHostException
 import java.security.cert.CertPathValidatorException
 import java.security.cert.CertificateExpiredException
@@ -85,16 +84,17 @@ fun String.obfuscate(clearTextCharCount: Int = 3): String {
     return substring(0, clearTextCharCount) + "*".repeat(length - clearTextCharCount)
 }
 
-fun String?.toNormalizedUrl(): String {
+fun String?.toNormalizedUrl(): String? {
     return try {
-        val url = URL(orEmpty())
-            .toString()
+        val url = toString()
             .replace("\n", "")
             .replace(" ", "")
+            .toHttpUrl()
+            .toString()
         if (url.endsWith("/")) url else "$url/"
-    } catch (e: MalformedURLException) {
+    } catch (e: IllegalArgumentException) {
         Log.d(Util.TAG, "normalizeUrl(): invalid URL '$this'")
-        ""
+        null
     }
 }
 

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -86,8 +86,9 @@ fun String.obfuscate(clearTextCharCount: Int = 3): String {
 }
 
 fun String?.toNormalizedUrl(): String? {
+    this ?: return null
     return try {
-        val url = toString()
+        val url = this
             .replace("\n", "")
             .replace(" ", "")
             .toHttpUrl()

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType
 import okhttp3.ResponseBody
 import org.json.JSONArray
@@ -278,7 +279,7 @@ fun Context.getHumanReadableErrorMessage(url: String, httpCode: Int, error: Thro
     } else if (error.hasCause(SSLPeerUnverifiedException::class.java)) {
         getString(
             if (short) R.string.error_short_certificate_wrong_host else R.string.error_certificate_wrong_host,
-            url.toUri().host
+            url.toHttpUrlOrNull()?.host
         )
     } else if (error.hasCause(CertPathValidatorException::class.java)) {
         getString(if (short) R.string.error_short_certificate_not_trusted else R.string.error_certificate_not_trusted)

--- a/mobile/src/test/java/org/openhab/habdroid/util/PreferencesUtilTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/util/PreferencesUtilTest.kt
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-package org.openhab.habdroid.ui
+package org.openhab.habdroid.util
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -20,7 +20,7 @@ import org.junit.Test
 import org.openhab.habdroid.ui.PreferencesActivity.AbstractSettingsFragment.Companion.isWeakPassword
 import org.openhab.habdroid.ui.PreferencesActivity.MainSettingsFragment.Companion.beautifyUrl
 
-class PreferencesActivityTest {
+class PreferencesUtilTest {
     @Test
     fun testIsWeakPassword() {
         assertTrue(isWeakPassword(""))
@@ -43,6 +43,6 @@ class PreferencesActivityTest {
             beautifyUrl("https://home.myopenhab.org"))
         assertEquals("not.myopenhab.org", beautifyUrl("https://not.myopenhab.org"))
         assertEquals("notmyopenhab.org", beautifyUrl("https://notmyopenhab.org"))
-        assertEquals("myopenhab.WRONG_TLD", beautifyUrl("https://myopenhab.WRONG_TLD"))
+        assertEquals("myopenhab.wrong_tld", beautifyUrl("https://myopenhab.WRONG_TLD"))
     }
 }

--- a/mobile/src/test/java/org/openhab/habdroid/util/UtilTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/util/UtilTest.kt
@@ -133,7 +133,6 @@ class UtilTest {
 
         assertEquals("https://127.0.0.1:81/abc/", "https://127.0.0.1:81/abc".toNormalizedUrl())
 
-
         assertEquals("http://localhost/", " http://localhost/".toNormalizedUrl())
         assertEquals("http://localhost/", "http://localhost/ ".toNormalizedUrl())
         assertEquals("http://localhost/", "http:// localhost/".toNormalizedUrl())

--- a/mobile/src/test/java/org/openhab/habdroid/util/UtilTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/util/UtilTest.kt
@@ -132,6 +132,19 @@ class UtilTest {
         assertEquals("https://127.0.0.1/abc/", "https://127.0.0.1/abc".toNormalizedUrl())
 
         assertEquals("https://127.0.0.1:81/abc/", "https://127.0.0.1:81/abc".toNormalizedUrl())
+
+
+        assertEquals("http://localhost/", " http://localhost/".toNormalizedUrl())
+        assertEquals("http://localhost/", "http://localhost/ ".toNormalizedUrl())
+        assertEquals("http://localhost/", "http:// localhost/".toNormalizedUrl())
+        assertEquals("http://localhost/", "http://local\nhost/".toNormalizedUrl())
+
+        assertEquals("Empty string should return null", null, "".toNormalizedUrl())
+        assertEquals("Null should return null", null, null.toNormalizedUrl())
+        assertEquals("Url with one slash after the protocol should be fixed",
+            "http://localhost/", "http:/localhost/".toNormalizedUrl())
+        assertEquals("Url with invalid protocol should return null",
+            null, "http//localhost/".toNormalizedUrl())
     }
 
     @Test


### PR DESCRIPTION
It was possible to enter invalid urls like ´http:/example.com´.

> Instances of [HttpUrl] are well-formed and always have a scheme, host, and path. With
> `java.net.URL` it's possible to create an awkward URL like `http:/` with scheme and path but no
> hostname. Building APIs that consume such malformed values is difficult!

from HttpUrl.kt docs

Fixes #1825

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>