### PR TITLE
Send battery level to server

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -134,6 +134,30 @@ then
 end
 ```
 
+#### Battery level
+
+The openHAB app will send the current battery level to the server if you enable it in the settings.
+While charging the battery level is sent every 10 to 15 minutes, otherwise every 2 to 6 hours.
+In addition devices running Android 7 or lower send the level whenever the charger is plugged in or out or when the level changes between low and ok.
+
+Example item definition:
+```java
+String BatteryLevel
+```
+
+Example rule:
+```java
+rule "Battery level changed"
+when
+    Item BatteryLevel changed
+then
+    if (BatteryLevel.state < 25) {
+        // Battery level is low
+    }
+
+end
+```
+
 ### Tasker Action Plugin
 
 The Tasker Action Plugin can be used to send Item commands to the server.

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -159,6 +159,12 @@
                 <action android:name="android.intent.action.PHONE_STATE" />
             </intent-filter>
             <intent-filter>
+                <action android:name="android.intent.action.ACTION_POWER_CONNECTED"/>
+                <action android:name="android.intent.action.ACTION_POWER_DISCONNECTED"/>
+                <action android:name="android.intent.action.BATTERY_LOW"/>
+                <action android:name="android.intent.action.BATTERY_OKAY"/>
+            </intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.LOCALE_CHANGED" />
             </intent-filter>
             <intent-filter>

--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -65,7 +65,7 @@ class BackgroundTasksManager : BroadcastReceiver() {
             Intent.ACTION_POWER_CONNECTED, Intent.ACTION_POWER_DISCONNECTED,
             Intent.ACTION_BATTERY_LOW, Intent.ACTION_BATTERY_OKAY -> {
                 Log.d(TAG, "Battery state changed: ${intent.action}")
-                scheduleWorker(context, PrefKeys.BATTERY_PERCENTAGE)
+                scheduleWorker(context, PrefKeys.BATTERY_LEVEL)
             }
             Intent.ACTION_LOCALE_CHANGED -> {
                 Log.d(TAG, "Locale changed, recreate notification channels")
@@ -183,10 +183,10 @@ class BackgroundTasksManager : BroadcastReceiver() {
         internal val KNOWN_KEYS = listOf(
             PrefKeys.ALARM_CLOCK,
             PrefKeys.PHONE_STATE,
-            PrefKeys.BATTERY_PERCENTAGE
+            PrefKeys.BATTERY_LEVEL
         )
         private val KNOWN_PERIODIC_KEYS = listOf(
-            PrefKeys.BATTERY_PERCENTAGE
+            PrefKeys.BATTERY_LEVEL
         )
         private val IGNORED_PACKAGES_FOR_ALARM = listOf(
             "net.dinglisch.android.taskerm",
@@ -389,7 +389,7 @@ class BackgroundTasksManager : BroadcastReceiver() {
 
                 time?.let { ItemUpdateWorker.ValueWithInfo(it, type = ItemUpdateWorker.ValueType.Timestamp) }
             }
-            VALUE_GETTER_MAP[PrefKeys.BATTERY_PERCENTAGE] = { context ->
+            VALUE_GETTER_MAP[PrefKeys.BATTERY_LEVEL] = { context ->
                 val bm = context.getSystemService(BATTERY_SERVICE) as BatteryManager
                 val batLevel = bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
                 ItemUpdateWorker.ValueWithInfo(batLevel.toString())

--- a/mobile/src/main/java/org/openhab/habdroid/background/PeriodicItemUpdateWorker.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/PeriodicItemUpdateWorker.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.habdroid.background
+
+import android.content.Context
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+
+class PeriodicItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
+    override fun doWork(): Result {
+        BackgroundTasksManager.triggerPeriodicWork(applicationContext)
+        return Result.success()
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -233,6 +233,7 @@ class PreferencesActivity : AbstractBaseActivity() {
             val sendDeviceInfoPrefixPref = getPreference(PrefKeys.SEND_DEVICE_INFO_PREFIX)
             val alarmClockPref = getPreference(PrefKeys.ALARM_CLOCK) as ItemUpdatingPreference
             val phoneStatePref = getPreference(PrefKeys.PHONE_STATE) as ItemUpdatingPreference
+            val batteryPercentagePref = getPreference(PrefKeys.BATTERY_PERCENTAGE) as ItemUpdatingPreference
             val iconFormatPreference = getPreference(PrefKeys.ICON_FORMAT)
             val taskerPref = getPreference(PrefKeys.TASKER_PLUGIN_ENABLED)
             val vibrationPref = getPreference(PrefKeys.NOTIFICATION_VIBRATION)
@@ -375,6 +376,7 @@ class PreferencesActivity : AbstractBaseActivity() {
                 updatePrefixSummary(sendDeviceInfoPrefixPref, prefix)
                 alarmClockPref.updateSummaryAndIcon(prefix)
                 phoneStatePref.updateSummaryAndIcon(prefix)
+                batteryPercentagePref.updateSummaryAndIcon(prefix)
                 true
             }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -233,7 +233,7 @@ class PreferencesActivity : AbstractBaseActivity() {
             val sendDeviceInfoPrefixPref = getPreference(PrefKeys.SEND_DEVICE_INFO_PREFIX)
             val alarmClockPref = getPreference(PrefKeys.ALARM_CLOCK) as ItemUpdatingPreference
             val phoneStatePref = getPreference(PrefKeys.PHONE_STATE) as ItemUpdatingPreference
-            val batteryPercentagePref = getPreference(PrefKeys.BATTERY_PERCENTAGE) as ItemUpdatingPreference
+            val batteryLevelPref = getPreference(PrefKeys.BATTERY_LEVEL) as ItemUpdatingPreference
             val iconFormatPreference = getPreference(PrefKeys.ICON_FORMAT)
             val taskerPref = getPreference(PrefKeys.TASKER_PLUGIN_ENABLED)
             val vibrationPref = getPreference(PrefKeys.NOTIFICATION_VIBRATION)
@@ -376,7 +376,7 @@ class PreferencesActivity : AbstractBaseActivity() {
                 updatePrefixSummary(sendDeviceInfoPrefixPref, prefix)
                 alarmClockPref.updateSummaryAndIcon(prefix)
                 phoneStatePref.updateSummaryAndIcon(prefix)
-                batteryPercentagePref.updateSummaryAndIcon(prefix)
+                batteryLevelPref.updateSummaryAndIcon(prefix)
                 true
             }
 

--- a/mobile/src/main/java/org/openhab/habdroid/util/PrefKeys.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/PrefKeys.kt
@@ -43,6 +43,7 @@ object PrefKeys {
     const val SEND_DEVICE_INFO_PREFIX = "sendDeviceInfoPrefix"
     const val ALARM_CLOCK = "alarmClock"
     const val PHONE_STATE = "phoneState"
+    const val BATTERY_PERCENTAGE = "batteryPercentage"
 
     const val SCREEN_LOCK = "screen_lock"
     const val TASKER_PLUGIN_ENABLED = "taskerPlugin"

--- a/mobile/src/main/java/org/openhab/habdroid/util/PrefKeys.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/PrefKeys.kt
@@ -43,7 +43,7 @@ object PrefKeys {
     const val SEND_DEVICE_INFO_PREFIX = "sendDeviceInfoPrefix"
     const val ALARM_CLOCK = "alarmClock"
     const val PHONE_STATE = "phoneState"
-    const val BATTERY_PERCENTAGE = "batteryPercentage"
+    const val BATTERY_LEVEL = "battery_level"
 
     const val SCREEN_LOCK = "screen_lock"
     const val TASKER_PLUGIN_ENABLED = "taskerPlugin"

--- a/mobile/src/main/res/drawable/ic_battery_off_outline_grey_24dp.xml
+++ b/mobile/src/main/res/drawable/ic_battery_off_outline_grey_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#757575">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M18,17.35L3.38,2.73L2.11,4L6,7.89V20.67A1.34,1.34 0,0 0,7.33 22H16.67A1.34,1.34 0,0 0,18 20.67V19.89L20.84,22.73L22.11,21.46M16,20H8V9.89L16,17.89M16,6V12.8L18,14.8V5.33A1.34,1.34 0,0 0,16.67 4H15V2H9V4H7.21L9.21,6Z"/>
+</vector>

--- a/mobile/src/main/res/drawable/ic_battery_outline_grey_24dp.xml
+++ b/mobile/src/main/res/drawable/ic_battery_outline_grey_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#757575">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M16,20H8V6H16M16.67,4H15V2H9V4H7.33A1.33,1.33 0,0 0,6 5.33V20.67C6,21.4 6.6,22 7.33,22H16.67A1.33,1.33 0,0 0,18 20.67V5.33C18,4.6 17.4,4 16.67,4Z"/>
+</vector>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -201,6 +201,10 @@
     <string name="settings_phone_state_howto_url" translatable="false">https://www.openhab.org/docs/apps/android.html#call-state</string>
     <string name="settings_phone_state_summary_on">Sends call state to item \'%1$s\'</string>
     <string name="settings_phone_state_summary_off">Don\'t send call state to server</string>
+    <string name="settings_battery_level">Send battery level to openHAB</string>
+    <string name="settings_battery_level_howto_url" translatable="false">https://www.openhab.org/docs/apps/android.html#battery-level</string>
+    <string name="settings_battery_level_summary_on">Sends battery level to item \'%1$s\'</string>
+    <string name="settings_battery_level_summary_off">Don\'t send battery level to server</string>
     <string name="settings_phone_state_permission_denied">Sending call state has been disabled due to missing permissions</string>
     <string name="settings_phone_state_permission_allow">Allow</string>
     <string name="settings_item_pref_item_name">Item name</string>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -118,6 +118,17 @@
             android:dependency="default_openhab_demomode"
             app:iconEnabled="@drawable/ic_phone_outline_grey_24dp"
             app:iconDisabled="@drawable/ic_phone_off_outline_grey_24dp" />
+        <org.openhab.habdroid.ui.preference.ItemUpdatingPreference
+            android:defaultValue="false|BatteryLevel"
+            android:key="batteryPercentage"
+            app:helpHint="@string/settings_item_update_pref_howto_summary"
+            app:helpUrl="@string/settings_battery_level_howto_url"
+            app:summaryEnabled="@string/settings_battery_level_summary_on"
+            app:summaryDisabled="@string/settings_battery_level_summary_off"
+            android:title="@string/settings_battery_level"
+            android:dependency="default_openhab_demomode"
+            app:iconEnabled="@drawable/ic_battery_outline_grey_24dp"
+            app:iconDisabled="@drawable/ic_battery_off_outline_grey_24dp" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_misc_title">
         <ListPreference

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -120,7 +120,7 @@
             app:iconDisabled="@drawable/ic_phone_off_outline_grey_24dp" />
         <org.openhab.habdroid.ui.preference.ItemUpdatingPreference
             android:defaultValue="false|BatteryLevel"
-            android:key="batteryPercentage"
+            android:key="battery_level"
             app:helpHint="@string/settings_item_update_pref_howto_summary"
             app:helpUrl="@string/settings_battery_level_howto_url"
             app:summaryEnabled="@string/settings_battery_level_summary_on"


### PR DESCRIPTION
Periodic workers don't have a failed state, so the notification listener
doesn't know if the job has failed or not. Because of that I used a
periodic worker for triggering a one time worker that sends the battery
level.
While charging the frequency is lowered to 10 - 15 minutes, if the
battery isn't low.

Closes #269

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>