### PR TITLE
Add notification channel groups

### DIFF
--- a/mobile/src/full/res/values/strings.xml
+++ b/mobile/src/full/res/values/strings.xml
@@ -7,8 +7,8 @@
     <string name="info_openhab_gcm_failed">Push notification registration failed</string>
     <string name="info_openhab_gcm_failed_play_services">Push notification registration failed due to a Google Play Services issue: %s</string>
     <string name="info_openhab_gcm_connected">Device successfully registered with Firebase Cloud Messaging</string>
-    <string name="notification_channel_default">Default</string>
     <string name="notification_channel_severity_value">Severity \'%1$s\'</string>
+    <string name="notification_channel_severity_value_description">Notifications sent by the server with severity \'%1$s\'</string>
 
     <plurals name="summary_notification_text">
         <item quantity="one">%d new notification</item>

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -72,6 +72,7 @@ import kotlinx.coroutines.launch
 import okhttp3.Request
 import org.openhab.habdroid.R
 import org.openhab.habdroid.background.BackgroundTasksManager
+import org.openhab.habdroid.background.NotificationUpdateObserver
 import org.openhab.habdroid.core.CloudMessagingHelper
 import org.openhab.habdroid.core.UpdateBroadcastReceiver
 import org.openhab.habdroid.core.VoiceService
@@ -93,8 +94,8 @@ import org.openhab.habdroid.ui.homescreenwidget.VoiceWidget
 import org.openhab.habdroid.ui.homescreenwidget.VoiceWidgetWithIcon
 import org.openhab.habdroid.ui.preference.toItemUpdatePrefValue
 import org.openhab.habdroid.util.AsyncServiceResolver
-import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.HttpClient
+import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.RemoteLog
 import org.openhab.habdroid.util.ScreenLockMode
 import org.openhab.habdroid.util.Util
@@ -208,6 +209,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         if (prefs.getBoolean(PrefKeys.FIRST_START, true) ||
             prefs.getBoolean(PrefKeys.RECENTLY_RESTORED, false)
         ) {
+            NotificationUpdateObserver.createNotificationChannels(this)
             Log.d(TAG, "Start intro")
             val intent = Intent(this, IntroActivity::class.java)
             startActivity(intent)

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -210,6 +210,10 @@
     <string name="notification_channel_background_description">Used to display pending background tasks</string>
     <string name="notification_channel_background_error">Error in background tasks</string>
     <string name="notification_channel_background_error_description">Used to notify about errors in background tasks</string>
+    <string name="notification_channel_messages_default_severity">Default</string>
+    <string name="notification_channel_messages_default_severity_description">Notifications sent by the server with no defined severity</string>
+    <string name="notification_channel_group_messages">Messages</string>
+    <string name="notification_channel_group_other">Other</string>
     <plurals name="item_update_error_title">
         <item quantity="one">%d Item could not be updated</item>
         <item quantity="other">%d Items could not be updated</item>


### PR DESCRIPTION
The default severity channel is now created by default. Otherwise the
"Other" group wouldn't make much sense.

![Screenshot_20200323-213735](https://user-images.githubusercontent.com/22525368/77361175-1fb4ad80-6d4f-11ea-861e-db8009b7c41b.png)