### PR TITLE
Try to avoid OOM on Bitmaps

### DIFF
--- a/mobile/src/full/java/org/openhab/habdroid/core/FcmMessageListenerService.kt
+++ b/mobile/src/full/java/org/openhab/habdroid/core/FcmMessageListenerService.kt
@@ -138,9 +138,10 @@ class FcmMessageListenerService : FirebaseMessagingService() {
             val connection = ConnectionFactory.cloudConnectionOrNull
             if (connection != null && !applicationContext.isDataSaverActive()) {
                 try {
+                    val size = resources.getDimensionPixelSize(R.dimen.svg_image_default_size)
                     iconBitmap = connection.httpClient
                             .get(icon.toUrl(this, true), timeoutMillis = 1000)
-                            .asBitmap(resources.getDimensionPixelSize(R.dimen.svg_image_default_size), false)
+                            .asBitmap(size, size, false)
                             .response
                 } catch (e: HttpClient.HttpException) {
                     // ignored, keep bitmap null

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ChartActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ChartActivity.kt
@@ -168,7 +168,7 @@ class ChartActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListen
         ) ?: return
 
         Log.d(TAG, "Load chart with url $chartUrl")
-        chart.setImageUrl(connection, chartUrl, chart.width, forceLoad = true)
+        chart.setImageUrl(connection, chartUrl, chart.width, chart.height, forceLoad = true)
         if (widget.refresh > 0 && !isDataSaverActive()) {
             chart.startRefreshing(widget.refresh)
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -753,7 +753,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         launch {
             try {
                 item.icon = conn.httpClient.get(sitemap.icon.toUrl(this@MainActivity, !isDataSaverActive()))
-                    .asBitmap(defaultIcon!!.intrinsicWidth, true)
+                    .asBitmap(defaultIcon!!.intrinsicWidth, defaultIcon.intrinsicHeight, true)
                     .response
                     .toDrawable(resources)
             } catch (e: HttpClient.HttpException) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -616,7 +616,7 @@ class WidgetAdapter(
                 imageView.setImageBitmap(bitmap)
                 refreshRate = 0
             } else if (widget.url != null) {
-                imageView.setImageUrl(connection, widget.url, parent.width)
+                imageView.setImageUrl(connection, widget.url, parent.width, parent.height)
                 refreshRate = widget.refresh
             } else {
                 imageView.setImageDrawable(null)
@@ -914,7 +914,7 @@ class WidgetAdapter(
             val chartUrl =
                 widget.toChartUrl(prefs, random, parent.width, chartTheme = chartTheme, density = density) ?: return
             Log.d(TAG, "Chart url = $chartUrl")
-            chart.setImageUrl(connection, chartUrl, parent.width, forceLoad = true)
+            chart.setImageUrl(connection, chartUrl, parent.width, parent.height, forceLoad = true)
             refreshRate = widget.refresh
         }
 
@@ -1344,10 +1344,12 @@ fun WidgetImageView.loadWidgetIcon(connection: Connection, widget: Widget, mappe
         setImageDrawable(null)
         return
     }
+    val iconSize = resources.getDimensionPixelSize(R.dimen.notificationlist_icon_size)
     setImageUrl(
         connection,
         widget.icon.toUrl(context, !context.isDataSaverActive()),
-        resources.getDimensionPixelSize(R.dimen.notificationlist_icon_size)
+        iconSize,
+        iconSize
     )
     val color = mapper.mapColor(widget.iconColor)
     if (color != null) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -465,7 +465,7 @@ class WidgetListFragment : Fragment(), WidgetAdapter.ItemClickListener {
             try {
                 connection.httpClient
                     .get(linkedPage.icon.toUrl(context, true))
-                    .asBitmap(foregroundSize, true)
+                    .asBitmap(foregroundSize, foregroundSize, true)
                     .response
             } catch (e: HttpClient.HttpException) {
                 null

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.kt
@@ -62,11 +62,13 @@ class WidgetImageView constructor(context: Context, attrs: AttributeSet?) : AppC
     fun setImageUrl(
         connection: Connection,
         url: String,
-        size: Int?,
+        width: Int?,
+        height: Int?,
         timeoutMillis: Long = HttpClient.DEFAULT_TIMEOUT_MS,
         forceLoad: Boolean = false
     ) {
-        val actualSize = size ?: defaultSvgSize
+        val actualWidth = width ?: defaultSvgSize
+        val actualHeight = height ?: defaultSvgSize
         val client = connection.httpClient
         val actualUrl = client.buildUrl(url)
 
@@ -78,7 +80,7 @@ class WidgetImageView constructor(context: Context, attrs: AttributeSet?) : AppC
         cancelCurrentLoad()
 
         val cached = CacheManager.getInstance(context).getCachedBitmap(actualUrl)
-        val request = HttpImageRequest(client, actualUrl, actualSize, timeoutMillis)
+        val request = HttpImageRequest(client, actualUrl, actualWidth, actualHeight, timeoutMillis)
 
         if (cached != null) {
             setBitmapInternal(cached)
@@ -221,7 +223,8 @@ class WidgetImageView constructor(context: Context, attrs: AttributeSet?) : AppC
     private inner class HttpImageRequest(
         private val client: HttpClient,
         private val url: HttpUrl,
-        private val size: Int,
+        private val widthInPixels: Int,
+        private val heightInPixels: Int,
         private val timeoutMillis: Long
     ) {
         private var job: Job? = null
@@ -237,7 +240,7 @@ class WidgetImageView constructor(context: Context, attrs: AttributeSet?) : AppC
                 try {
                     val bitmap = client.get(url.toString(),
                         timeoutMillis = timeoutMillis, caching = cachingMode)
-                        .asBitmap(size)
+                        .asBitmap(widthInPixels, heightInPixels, false)
                         .response
                     setBitmapInternal(bitmap)
                     CacheManager.getInstance(context).cacheBitmap(url, bitmap)

--- a/mobile/src/main/java/org/openhab/habdroid/util/BitmapUtils.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/BitmapUtils.kt
@@ -28,7 +28,8 @@ fun ResponseBody.toBitmap(targetWidth: Int, targetHeight: Int, enforceSize: Bool
     if (!contentType().isSvg()) {
         BitmapFactory.Options().run {
             inJustDecodeBounds = true
-            BitmapFactory.decodeStream(byteStream(), null, this)
+            val byteArray = bytes()
+            BitmapFactory.decodeStream(byteArray.inputStream(), null, this)
 
             // Calculate inSampleSize
             inSampleSize = calculateInSampleSize(this, targetWidth, targetHeight)
@@ -36,7 +37,7 @@ fun ResponseBody.toBitmap(targetWidth: Int, targetHeight: Int, enforceSize: Bool
             // Decode bitmap with inSampleSize set
             inJustDecodeBounds = false
 
-            val bitmap = BitmapFactory.decodeStream(byteStream(), null, this)
+            val bitmap = BitmapFactory.decodeStream(byteArray.inputStream(), null, this)
                 ?: throw IOException("Bitmap decoding failed")
 
             return if (enforceSize) {

--- a/mobile/src/main/java/org/openhab/habdroid/util/BitmapUtils.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/BitmapUtils.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.habdroid.util
+
+import android.content.res.Resources
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.util.DisplayMetrics
+import com.caverock.androidsvg.SVG
+import okhttp3.ResponseBody
+import java.io.IOException
+import java.io.InputStream
+
+@Throws(IOException::class)
+fun ResponseBody.toBitmap(targetWidth: Int, targetHeight: Int, enforceSize: Boolean): Bitmap {
+    if (!contentType().isSvg()) {
+        BitmapFactory.Options().run {
+            inJustDecodeBounds = true
+            BitmapFactory.decodeStream(byteStream(), null, this)
+
+            // Calculate inSampleSize
+            inSampleSize = calculateInSampleSize(this, targetWidth, targetHeight)
+
+            // Decode bitmap with inSampleSize set
+            inJustDecodeBounds = false
+
+            val bitmap = BitmapFactory.decodeStream(byteStream(), null, this)
+                ?: throw IOException("Bitmap decoding failed")
+
+            return if (enforceSize) {
+                Bitmap.createScaledBitmap(bitmap, targetWidth, targetHeight, false)
+            } else {
+                bitmap
+            }
+        }
+    }
+
+    return byteStream().svgToBitmap(targetWidth)
+}
+
+fun calculateInSampleSize(options: BitmapFactory.Options, reqWidth: Int, reqHeight: Int): Int {
+    // Raw height and width of image
+    val (height: Int, width: Int) = options.run { outHeight to outWidth }
+    var inSampleSize = 1
+
+    if (height > reqHeight || width > reqWidth) {
+
+        val halfHeight: Int = height / 2
+        val halfWidth: Int = width / 2
+
+        // Calculate the largest inSampleSize value that is a power of 2 and keeps both
+        // height and width larger than the requested height and width.
+        while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
+            inSampleSize *= 2
+        }
+    }
+
+    return inSampleSize
+}
+
+@Throws(IOException::class)
+fun InputStream.svgToBitmap(targetSize: Int): Bitmap {
+    return try {
+        val svg = SVG.getFromInputStream(this)
+        val displayMetrics = Resources.getSystem().displayMetrics
+        svg.renderDPI = DisplayMetrics.DENSITY_DEFAULT.toFloat()
+        var density: Float? = displayMetrics.density
+        svg.setDocumentHeight("100%")
+        svg.setDocumentWidth("100%")
+        var docWidth = (svg.documentWidth * displayMetrics.density).toInt()
+        var docHeight = (svg.documentHeight * displayMetrics.density).toInt()
+
+        if (docWidth < 0 || docHeight < 0) {
+            val aspectRatio = svg.documentAspectRatio
+            if (aspectRatio > 0) {
+                val heightForAspect = targetSize.toFloat() / aspectRatio
+                val widthForAspect = targetSize.toFloat() * aspectRatio
+                if (widthForAspect < heightForAspect) {
+                    docWidth = Math.round(widthForAspect)
+                    docHeight = targetSize
+                } else {
+                    docWidth = targetSize
+                    docHeight = Math.round(heightForAspect)
+                }
+            } else {
+                docWidth = targetSize
+                docHeight = targetSize
+            }
+
+            // we didn't take density into account anymore when calculating docWidth
+            // and docHeight, so don't scale with it and just let the renderer
+            // figure out the scaling
+            density = null
+        }
+
+        if (docWidth != targetSize || docHeight != targetSize) {
+            val scaleWidth = targetSize.toFloat() / docWidth
+            val scaleHeight = targetSize.toFloat() / docHeight
+            density = (scaleWidth + scaleHeight) / 2
+        }
+
+        val bitmap = Bitmap.createBitmap(targetSize, targetSize, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        if (density != null) {
+            canvas.scale(density, density)
+        }
+        svg.renderToCanvas(canvas)
+        bitmap
+    } catch (e: Exception) {
+        throw IOException("SVG decoding failed", e)
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.kt
@@ -213,8 +213,12 @@ class HttpClient constructor(client: OkHttpClient, baseUrl: String?, username: S
         }
 
         @Throws(HttpException::class)
-        suspend fun asBitmap(sizeInPixels: Int, enforceSize: Boolean = false): HttpBitmapResult = try {
-            val bitmap = withContext(Dispatchers.IO) { response.toBitmap(sizeInPixels, enforceSize) }
+        suspend fun asBitmap(
+            widthInPixels: Int,
+            heightInPixels: Int,
+            enforceSize: Boolean
+        ): HttpBitmapResult = try {
+            val bitmap = withContext(Dispatchers.IO) { response.toBitmap(widthInPixels, heightInPixels, enforceSize) }
             HttpBitmapResult(request, bitmap)
         } catch (e: IOException) {
             throw HttpException(request, originalUrl, e)


### PR DESCRIPTION
Scale down images on low ram devices to save memory.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>