### PR TITLE
Fix NPE in ChartActivity

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -932,9 +932,11 @@ class WidgetAdapter(
 
         override fun onClick(v: View?) {
             val context = v?.context ?: return
-            val intent = Intent(context, ChartActivity::class.java)
-            intent.putExtra(ChartActivity.WIDGET, boundWidget)
-            context.startActivity(intent)
+            boundWidget?.let {
+                val intent = Intent(context, ChartActivity::class.java)
+                intent.putExtra(ChartActivity.WIDGET, it)
+                context.startActivity(intent)
+            }
         }
     }
 


### PR DESCRIPTION
````
Caused by kotlin.KotlinNullPointerException
       at org.openhab.habdroid.ui.ChartActivity.onCreate(ChartActivity.kt:51)
       at android.app.Activity.performCreate(Activity.java:7981)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>