### PR TITLE
Clean up WiFi SSID sending code.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -438,13 +438,15 @@ class BackgroundTasksManager : BroadcastReceiver() {
             }
             VALUE_GETTER_MAP[PrefKeys.SEND_WIFI_SSID] = { context ->
                 val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
-                val isConnected = wifiManager.connectionInfo.networkId != -1
-                var ssid = wifiManager.connectionInfo.ssid
-                // WifiInfo#getSSID() may surround the SSID with double quote marks
-                if (ssid.first() == '"' && ssid.last() == '"') {
-                    ssid = ssid.substring(1, ssid.length - 1)
+                val ssidToSend = wifiManager.connectionInfo.let { info ->
+                    if (info.networkId == -1) {
+                        "UNDEF"
+                    } else {
+                        // WifiInfo#getSSID() may surround the SSID with double quote marks
+                        info.ssid.removeSurrounding("\"")
+                    }
                 }
-                ItemUpdateWorker.ValueWithInfo(if (isConnected) ssid else "UNDEF")
+                ItemUpdateWorker.ValueWithInfo(ssidToSend)
             }
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -992,18 +992,16 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
     }
 
     private fun showMissingPermissionsWarningIfNeeded() {
-        val tasksWithPermissions = arrayListOf(PrefKeys.SEND_PHONE_STATE to Manifest.permission.READ_PHONE_STATE)
+        val tasksWithPermissions = mutableMapOf(PrefKeys.SEND_PHONE_STATE to Manifest.permission.READ_PHONE_STATE)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            tasksWithPermissions.add(PrefKeys.SEND_WIFI_SSID to Manifest.permission.ACCESS_FINE_LOCATION)
+            tasksWithPermissions[PrefKeys.SEND_WIFI_SSID] = Manifest.permission.ACCESS_FINE_LOCATION
         }
-        val missingPermissions = arrayListOf<String>()
 
-        tasksWithPermissions.forEach { task ->
-            if (prefs.getString(task.first, null)?.toItemUpdatePrefValue()?.first == true &&
-                !hasPermission(task.second)) {
-                missingPermissions.add(task.second)
+        val missingPermissions = tasksWithPermissions
+            .filter { entry ->
+                prefs.getString(entry.key, null)?.toItemUpdatePrefValue()?.first == true && !hasPermission(entry.value)
             }
-        }
+            .map { entry -> entry.value }
 
         if (missingPermissions.isNotEmpty()) {
             Log.d(TAG, "At least on permission for background tasks have been denied")

--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -51,7 +51,6 @@ import org.openhab.habdroid.ui.homescreenwidget.ItemUpdateWidget
 import org.openhab.habdroid.ui.preference.CustomInputTypePreference
 import org.openhab.habdroid.ui.preference.ItemUpdatingPreference
 import org.openhab.habdroid.ui.preference.UrlInputPreference
-import org.openhab.habdroid.ui.preference.disableItemUpdatingPref
 import org.openhab.habdroid.util.CacheManager
 import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.ToastType
@@ -206,6 +205,9 @@ class PreferencesActivity : AbstractBaseActivity() {
         override val titleResId: Int @StringRes get() = R.string.action_settings
         @ColorInt var previousColor: Int = 0
 
+        lateinit var phoneStatePref: ItemUpdatingPreference
+        lateinit var wifiSsidPref: ItemUpdatingPreference
+
         override fun onStart() {
             super.onStart()
             updateConnectionSummary(PrefKeys.SUBSCREEN_LOCAL_CONNECTION,
@@ -232,10 +234,10 @@ class PreferencesActivity : AbstractBaseActivity() {
             val fullscreenPreference = getPreference(PrefKeys.FULLSCREEN)
             val sendDeviceInfoPrefixPref = getPreference(PrefKeys.SEND_DEVICE_INFO_PREFIX)
             val alarmClockPref = getPreference(PrefKeys.SEND_ALARM_CLOCK) as ItemUpdatingPreference
-            val phoneStatePref = getPreference(PrefKeys.SEND_PHONE_STATE) as ItemUpdatingPreference
+            phoneStatePref = getPreference(PrefKeys.SEND_PHONE_STATE) as ItemUpdatingPreference
             val batteryLevelPref = getPreference(PrefKeys.SEND_BATTERY_LEVEL) as ItemUpdatingPreference
             val chargingStatePref = getPreference(PrefKeys.SEND_CHARGING_STATE) as ItemUpdatingPreference
-            val wifiSsidPref = getPreference(PrefKeys.SEND_CHARGING_STATE) as ItemUpdatingPreference
+            wifiSsidPref = getPreference(PrefKeys.SEND_CHARGING_STATE) as ItemUpdatingPreference
             val iconFormatPreference = getPreference(PrefKeys.ICON_FORMAT)
             val taskerPref = getPreference(PrefKeys.TASKER_PLUGIN_ENABLED)
             val vibrationPref = getPreference(PrefKeys.NOTIFICATION_VIBRATION)
@@ -375,8 +377,10 @@ class PreferencesActivity : AbstractBaseActivity() {
             wifiSsidPref.setOnPreferenceChangeListener { preference, newValue ->
                 @Suppress("UNCHECKED_CAST")
                 val value = newValue as Pair<Boolean, String>
-                if (value.first && !preference.context.hasPermission(Manifest.permission.ACCESS_FINE_LOCATION) &&
-                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                if (value.first &&
+                    !preference.context.hasPermission(Manifest.permission.ACCESS_FINE_LOCATION) &&
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+                ) {
                     Log.d(TAG, "Request ACCESS_FINE_LOCATION permission")
                     requestPermissions(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
                         PERMISSIONS_REQUEST_ACCESS_FINE_LOCATION)
@@ -426,15 +430,13 @@ class PreferencesActivity : AbstractBaseActivity() {
                 PERMISSIONS_REQUEST_READ_PHONE_STATE -> {
                     if (grantResults.isEmpty() || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
                         context?.showToast(R.string.settings_phone_state_permission_denied, ToastType.ERROR)
-                        disableItemUpdatingPref(prefs, PrefKeys.SEND_PHONE_STATE)
-                        activity?.recreate()
+                        phoneStatePref.setValue(checked = false)
                     }
                 }
                 PERMISSIONS_REQUEST_ACCESS_FINE_LOCATION -> {
                     if (grantResults.isEmpty() || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
                         context?.showToast(R.string.settings_wifi_ssid_permission_denied, ToastType.ERROR)
-                        disableItemUpdatingPref(prefs, PrefKeys.SEND_WIFI_SSID)
-                        activity?.recreate()
+                        wifiSsidPref.setValue(checked = false)
                     }
                 }
             }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/ItemUpdatingPreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/ItemUpdatingPreference.kt
@@ -14,7 +14,6 @@
 package org.openhab.habdroid.ui.preference
 
 import android.content.Context
-import android.content.SharedPreferences
 import android.content.res.TypedArray
 import android.graphics.drawable.Drawable
 import android.text.Editable
@@ -28,7 +27,6 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SwitchCompat
-import androidx.core.content.edit
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.preference.DialogPreference
@@ -87,7 +85,7 @@ class ItemUpdatingPreference constructor(context: Context, attrs: AttributeSet?)
         return PrefDialogFragment.newInstance(key)
     }
 
-    private fun applyValue(checked: Boolean, value: String) {
+    fun setValue(checked: Boolean = this.value?.first ?: false, value: String = this.value?.second.orEmpty()) {
         val newValue = Pair(checked, value)
         if (callChangeListener(newValue)) {
             if (shouldPersist()) {
@@ -148,7 +146,7 @@ class ItemUpdatingPreference constructor(context: Context, attrs: AttributeSet?)
         override fun onDialogClosed(positiveResult: Boolean) {
             if (positiveResult) {
                 val pref = preference as ItemUpdatingPreference
-                pref.applyValue(switch.isChecked, editor.text.toString())
+                pref.setValue(switch.isChecked, editor.text.toString())
             }
         }
 
@@ -205,11 +203,4 @@ fun String?.toItemUpdatePrefValue(): Pair<Boolean, String> {
         return Pair(false, "")
     }
     return Pair(this!!.substring(0, pos).toBoolean(), substring(pos + 1))
-}
-
-fun disableItemUpdatingPref(prefs: SharedPreferences, key: String) {
-    val item = prefs.getString(key).toItemUpdatePrefValue().second
-    prefs.edit {
-        putString(key, "false|$item")
-    }
 }


### PR DESCRIPTION
Add some fixes that didn't make it in time for #1897:
- Don't recreate activity on missing permission, instead disable the
  respective prefs directly
- Use more Kotlinesque language constructs