### PR TITLE
Run periodic work on application start

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
@@ -146,7 +146,9 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
         private const val NOTIFICATION_ID_BACKGROUND_WORK = 1000
         private const val CHANNEL_ID_BACKGROUND = "background"
         const val CHANNEL_ID_BACKGROUND_ERROR = "backgroundError"
+        @Suppress("MemberVisibilityCanBePrivate") // Used in full flavor
         const val CHANNEL_ID_MESSAGE_DEFAULT = "default"
+        @Suppress("MemberVisibilityCanBePrivate") // Used in full flavor
         const val CHANNEL_GROUP_MESSAGES = "messages"
         private const val CHANNEL_GROUP_OTHER = "other"
 

--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHabApplication.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHabApplication.kt
@@ -59,6 +59,7 @@ class OpenHabApplication : MultiDexApplication() {
         ConnectionFactory.initialize(this)
         BackgroundTasksManager.initialize(this)
         RemoteLog.initialize(this)
+        BackgroundTasksManager.triggerPeriodicWork(this)
     }
 
     override fun onTerminate() {

--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHabApplication.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHabApplication.kt
@@ -59,7 +59,6 @@ class OpenHabApplication : MultiDexApplication() {
         ConnectionFactory.initialize(this)
         BackgroundTasksManager.initialize(this)
         RemoteLog.initialize(this)
-        BackgroundTasksManager.triggerPeriodicWork(this)
     }
 
     override fun onTerminate() {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -531,6 +531,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         }
         propsUpdateHandle = ServerProperties.fetch(this, connection!!,
             successCb, this::handlePropertyFetchFailure)
+        BackgroundTasksManager.triggerPeriodicWork(this)
     }
 
     private fun chooseSitemap() {


### PR DESCRIPTION
Especially for testing it's useful to force the app to do periodic background work. This is a nice way to do so and device and radio are already awake.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>