### PR TITLE
Fix NPE in isAutomationAppInstalled()

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -540,7 +540,8 @@ class PreferencesActivity : AbstractBaseActivity() {
             val pm = activity?.packageManager ?: return false
             return listOf("net.dinglisch.android.taskerm", "com.twofortyfouram.locale").any { pkg ->
                 try {
-                    pm.getApplicationInfo(pkg, 0).enabled
+                    @Suppress("UNNECESSARY_SAFE_CALL")
+                    pm.getApplicationInfo(pkg, 0)?.enabled == true
                 } catch (e: PackageManager.NameNotFoundException) {
                     false
                 }


### PR DESCRIPTION
The docs of getApplicationInfo() say that it returns non-null, but sometime the following crash happens:

````
Fatal Exception: java.lang.NullPointerException: Attempt to read from field 'boolean android.content.pm.ApplicationInfo.enabled' on a null object reference
       at org.openhab.habdroid.ui.PreferencesActivity.isAutomationAppInstalled(PreferencesActivity.kt:519)
       at org.openhab.habdroid.ui.PreferencesActivity.onCreatePreferences(PreferencesActivity.kt:310)
       at androidx.preference.PreferenceFragmentCompat.onCreate(PreferenceFragmentCompat.java:160)
       at androidx.fragment.app.Fragment.performCreate(Fragment.java:2684)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>