### PR TITLE
Only show state in label where explicitly wanted

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -36,7 +36,7 @@ import kotlin.math.max
 data class Widget(
     val id: String,
     val parentId: String?,
-    val label: String,
+    private val rawLabel: String,
     val icon: IconResource?,
     val state: ParsedState?,
     val type: Type,
@@ -59,8 +59,8 @@ data class Widget(
     val height: Int,
     val visibility: Boolean
 ) : Parcelable {
-    val labelWithoutState get() = label.split("[", "]")[0]
-    val stateFromLabel: String? get() = label.split("[", "]").getOrNull(1)
+    val label get() = rawLabel.split("[", "]")[0]
+    val stateFromLabel: String? get() = rawLabel.split("[", "]").getOrNull(1)
 
     val mappingsOrItemOptions get() =
         if (mappings.isEmpty() && item?.options != null) item.options else mappings

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ChartActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ChartActivity.kt
@@ -56,7 +56,7 @@ class ChartActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListen
 
         setSupportActionBar(findViewById(R.id.openhab_toolbar))
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-        supportActionBar?.title = widget.labelWithoutState.orDefaultIfEmpty(getString(R.string.chart_activity_title))
+        supportActionBar?.title = widget.label.orDefaultIfEmpty(getString(R.string.chart_activity_title))
 
         chart = findViewById(R.id.chart)
         swipeLayout = findViewById(R.id.activity_content)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -326,7 +326,7 @@ class WidgetAdapter(
         private val iconView: WidgetImageView = itemView.findViewById(R.id.widgeticon)
 
         override fun bind(widget: Widget) {
-            labelView.text = widget.labelWithoutState
+            labelView.text = widget.label
             labelView.applyWidgetColor(widget.labelColor, colorMapper)
             if (valueView != null) {
                 valueView.text = widget.stateFromLabel?.replace("\n", " ")
@@ -1150,7 +1150,7 @@ class WidgetAdapter(
             }
 
             dialogManager.manage(AlertDialog.Builder(contentView.context)
-                .setTitle(boundWidget?.labelWithoutState)
+                .setTitle(boundWidget?.label)
                 .setView(contentView)
                 .setNegativeButton(R.string.close, null)
                 .show()

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -242,7 +242,7 @@ class WidgetListFragment : Fragment(), WidgetAdapter.ItemClickListener,
                             widget.item?.name ?: return@populateStatesMenu,
                             state,
                             mappedState,
-                            widget.labelWithoutState)
+                            widget.label)
                         )
                     }
                 }
@@ -291,7 +291,7 @@ class WidgetListFragment : Fragment(), WidgetAdapter.ItemClickListener,
                         widget.item?.name ?: return@populateStatesMenu,
                         state,
                         mappedState,
-                        widget.labelWithoutState)
+                        widget.label)
                     )
                 }
 

--- a/mobile/src/test/java/org/openhab/habdroid/model/WidgetTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/model/WidgetTest.kt
@@ -141,14 +141,7 @@ class WidgetTest {
     fun testGetLabel() {
         assertEquals("Group1", sut1[0].label)
         assertEquals("Group1", sut2[0].label)
-        assertEquals("Dimmer [81 %]", sut3[1].label)
-    }
-
-    @Test
-    fun testGetLabelWithoutState() {
-        assertEquals("Group1", sut1[0].labelWithoutState)
-        assertEquals("Group1", sut2[0].labelWithoutState)
-        assertEquals("Dimmer ", sut3[1].labelWithoutState)
+        assertEquals("Dimmer ", sut3[1].label)
     }
 
     @Test


### PR DESCRIPTION
I noticed the state may appear in the data saver hint for charts with a single item. Since this has been an issue in the past (#1912), I decided to remove the state completely from `label` and only show it when we really want to show it.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>