### PR TITLE
WorkManager: Use foreground service for item updates

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
@@ -52,7 +52,9 @@ import javax.xml.parsers.ParserConfigurationException
 
 class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
     override fun doWork(): Result {
-        setForegroundAsync(createForegroundInfo())
+        if (inputData.getBoolean(INPUT_DATA_IS_IMPORTANT, false)) {
+            setForegroundAsync(createForegroundInfo())
+        }
         runBlocking {
             ConnectionFactory.waitForInitialization()
         }
@@ -247,6 +249,7 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
             .putBoolean(OUTPUT_DATA_SHOW_TOAST, inputData.getBoolean(INPUT_DATA_SHOW_TOAST, false))
             .putString(OUTPUT_DATA_TASKER_INTENT, inputData.getString(INPUT_DATA_TASKER_INTENT))
             .putString(OUTPUT_DATA_AS_COMMAND, inputData.getString(INPUT_DATA_AS_COMMAND))
+            .putString(OUTPUT_DATA_IS_IMPORTANT, inputData.getString(INPUT_DATA_IS_IMPORTANT))
             .putLong(OUTPUT_DATA_TIMESTAMP, System.currentTimeMillis())
             .build()
     }
@@ -286,6 +289,7 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
         private const val INPUT_DATA_SHOW_TOAST = "showToast"
         private const val INPUT_DATA_TASKER_INTENT = "taskerIntent"
         private const val INPUT_DATA_AS_COMMAND = "command"
+        private const val INPUT_DATA_IS_IMPORTANT = "is_important"
 
         const val OUTPUT_DATA_HAS_CONNECTION = "hasConnection"
         const val OUTPUT_DATA_HTTP_STATUS = "httpStatus"
@@ -295,6 +299,7 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
         const val OUTPUT_DATA_SHOW_TOAST = "showToast"
         const val OUTPUT_DATA_TASKER_INTENT = "taskerIntent"
         const val OUTPUT_DATA_AS_COMMAND = "command"
+        const val OUTPUT_DATA_IS_IMPORTANT = "is_important"
         const val OUTPUT_DATA_TIMESTAMP = "timestamp"
 
         fun buildData(
@@ -303,7 +308,8 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
             value: ValueWithInfo,
             showToast: Boolean,
             taskerIntent: String?,
-            asCommand: Boolean
+            asCommand: Boolean,
+            isImportant: Boolean
         ): Data {
             return Data.Builder()
                 .putString(INPUT_DATA_ITEM_NAME, itemName)
@@ -312,6 +318,7 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
                 .putBoolean(INPUT_DATA_SHOW_TOAST, showToast)
                 .putString(INPUT_DATA_TASKER_INTENT, taskerIntent)
                 .putBoolean(INPUT_DATA_AS_COMMAND, asCommand)
+                .putBoolean(INPUT_DATA_IS_IMPORTANT, isImportant)
                 .build()
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
@@ -144,7 +144,8 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
 
     companion object {
         private const val NOTIFICATION_ID_BACKGROUND_WORK = 1000
-        private const val CHANNEL_ID_BACKGROUND = "background"
+        const val NOTIFICATION_ID_BACKGROUND_WORK_RUNNING = 1001
+        const val CHANNEL_ID_BACKGROUND = "background"
         const val CHANNEL_ID_BACKGROUND_ERROR = "backgroundError"
         @Suppress("MemberVisibilityCanBePrivate") // Used in full flavor
         const val CHANNEL_ID_MESSAGE_DEFAULT = "default"

--- a/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
@@ -91,6 +91,7 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
                 val itemName = data.getString(ItemUpdateWorker.OUTPUT_DATA_ITEM_NAME)
                 val label = data.getString(ItemUpdateWorker.OUTPUT_DATA_LABEL)
                 val value = data.getValueWithInfo(ItemUpdateWorker.OUTPUT_DATA_VALUE)
+                val isImportant = data.getBoolean(ItemUpdateWorker.OUTPUT_DATA_IS_IMPORTANT, false)
                 val showToast = data.getBoolean(ItemUpdateWorker.OUTPUT_DATA_SHOW_TOAST, false)
                 val taskerIntent = data.getString(ItemUpdateWorker.OUTPUT_DATA_TASKER_INTENT)
                 val asCommand = data.getBoolean(ItemUpdateWorker.OUTPUT_DATA_AS_COMMAND, false)
@@ -104,6 +105,7 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
                             itemName,
                             label,
                             value,
+                            isImportant,
                             showToast,
                             taskerIntent,
                             asCommand


### PR DESCRIPTION
> Example use-cases for this new feature include [...] a task that's important to the user of the app.

https://developer.android.com/topic/libraries/architecture/workmanager/advanced/long-running

Especially item updates done by NFC tags or widgets are important enough
to start a foreground service.

~~Maybe the input data should signal the worker if it's important or not. The last retry should always be treated as important, as well as when the user manually retries any failed workers.
Though in this case the previous "Items are currently being updated" would be shown.~~