### PR TITLE
Replace item prefix with device identifier

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -65,7 +65,7 @@ If you want to use openHAB Android on a wall mounted tablet, go to settings and 
 You have to enable every information you want to send in the settings.
 Every settings has a default item name which is also used for example item definitions and rules below.
 
-If you have more than one device, it's recommended to fill out the prefix settings.
+If you have more than one device, it's recommended to fill out the [device identifier](#device-identifier) on the main settings page.
 This prefixes every item name, e.g. with the Prefix `John` the item `AlarmClock` becomes `JohnAlarmClock`.
 This way you don't have to change every item name.
 
@@ -247,6 +247,14 @@ then
     }
 end
 ```
+
+### Device identifier
+
+The device identifier can be any string and should be unique for all devices accessing your openHAB server.
+You can use it to distinguish between multiple clients:
+* Prefix the voice command with `<Device identifier>|`
+* Prefix the item names of [Send device information to openHAB](#send-device-information-to-openhab)
+* Use it as state on NFC tags
 
 ### Tasker Action Plugin
 

--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -241,7 +241,7 @@ class BackgroundTasksManager : BroadcastReceiver() {
         fun enqueueNfcUpdateIfNeeded(context: Context, tag: NfcTag?) {
             if (tag != null && tag.sitemap == null && tag.item != null && tag.state != null) {
                 val value = if (tag.deviceId) {
-                    val deviceId = context.getPrefs().getString(PrefKeys.DEV_ID)
+                    val deviceId = context.getPrefs().getStringOrEmpty(PrefKeys.DEV_ID)
                     ItemUpdateWorker.ValueWithInfo(deviceId, deviceId)
                 } else {
                     ItemUpdateWorker.ValueWithInfo(tag.state, tag.mappedState)

--- a/mobile/src/main/java/org/openhab/habdroid/core/VoiceService.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/VoiceService.kt
@@ -23,6 +23,8 @@ import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.core.connection.exception.ConnectionException
 import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.ToastType
+import org.openhab.habdroid.util.getPrefixForVoice
+import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.showToast
 import java.util.Locale
 
@@ -31,11 +33,17 @@ import java.util.Locale
  */
 class VoiceService : IntentService("VoiceService") {
     override fun onHandleIntent(intent: Intent?) {
-        val voiceCommand = intent?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)?.elementAtOrNull(0)
+        var voiceCommand = intent?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)?.elementAtOrNull(0)
             ?: return
 
         Log.i(TAG, "Recognized text: $voiceCommand")
         showToast(getString(R.string.info_voice_recognized_text, voiceCommand))
+
+        val prefix = getPrefs().getPrefixForVoice()
+        if (prefix != null) {
+            voiceCommand = "$prefix|$voiceCommand"
+            Log.d(TAG, "Prefix voice command: $voiceCommand")
+        }
 
         runBlocking {
             ConnectionFactory.waitForInitialization()

--- a/mobile/src/main/java/org/openhab/habdroid/core/VoiceService.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/VoiceService.kt
@@ -39,8 +39,7 @@ class VoiceService : IntentService("VoiceService") {
         Log.i(TAG, "Recognized text: $voiceCommand")
         showToast(getString(R.string.info_voice_recognized_text, voiceCommand))
 
-        val prefix = getPrefs().getPrefixForVoice()
-        if (prefix != null) {
+        getPrefs().getPrefixForVoice()?.let { prefix ->
             voiceCommand = "$prefix|$voiceCommand"
             Log.d(TAG, "Prefix voice command: $voiceCommand")
         }

--- a/mobile/src/main/java/org/openhab/habdroid/model/NfcTag.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/NfcTag.kt
@@ -20,7 +20,8 @@ data class NfcTag(
     val item: String?,
     val label: String?,
     val state: String?,
-    val mappedState: String?
+    val mappedState: String?,
+    val deviceId: Boolean
 ) {
     companion object {
         const val SCHEME = "openhab"
@@ -30,6 +31,7 @@ data class NfcTag(
         const val DEPRECATED_QUERY_PARAMETER_STATE = "command"
         const val QUERY_PARAMETER_MAPPED_STATE = "m"
         const val QUERY_PARAMETER_ITEM_LABEL = "l"
+        const val QUERY_PARAMETER_DEVICE_ID = "d"
     }
 }
 
@@ -51,6 +53,7 @@ fun Uri.toTagData(): NfcTag? {
     val mappedState = getQueryParameter(NfcTag.QUERY_PARAMETER_MAPPED_STATE)
     val sitemapPath = path
     val sitemap = if (sitemapPath?.isNotEmpty() == true) sitemapPath else null
+    val deviceId = getBooleanQueryParameter(NfcTag.QUERY_PARAMETER_DEVICE_ID, false)
 
-    return NfcTag(sitemap, item, label, state, mappedState)
+    return NfcTag(sitemap, item, label, state, mappedState, deviceId)
 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
@@ -43,6 +43,7 @@ import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.model.toItem
 import org.openhab.habdroid.ui.widget.DividerItemDecoration
+import org.openhab.habdroid.util.CommandType
 import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.SuggestedCommandsFactory
 import org.openhab.habdroid.util.map
@@ -162,7 +163,8 @@ abstract class AbstractItemPickerActivity : AbstractBaseActivity(), SwipeRefresh
         val suggestedCommands = suggestedCommandsFactory.fill(item, !forItemCommandOnly)
         val labels = suggestedCommands.labels
         val commands = suggestedCommands.commands
-        addAdditionalCommands(labels, commands)
+        val types = suggestedCommands.types
+        addAdditionalCommands(labels, commands, types)
 
         if (suggestedCommands.shouldShowCustom) {
             labels.add(getString(R.string.item_picker_custom))
@@ -181,7 +183,8 @@ abstract class AbstractItemPickerActivity : AbstractBaseActivity(), SwipeRefresh
                     val customDialog = AlertDialog.Builder(this)
                         .setTitle(getString(R.string.item_picker_custom))
                         .setView(input)
-                        .setPositiveButton(android.R.string.ok) { _, _ -> finish(item, input.text.toString()) }
+                        .setPositiveButton(android.R.string.ok) { _, _ ->
+                            finish(item, input.text.toString(), type = CommandType.CUSTOM) }
                         .setNegativeButton(android.R.string.cancel, null)
                         .show()
                     input.setOnFocusChangeListener { _, hasFocus ->
@@ -192,13 +195,17 @@ abstract class AbstractItemPickerActivity : AbstractBaseActivity(), SwipeRefresh
                         customDialog.window?.setSoftInputMode(mode)
                     }
                 } else {
-                    finish(item, commands[which], labels[which])
+                    finish(item, commands[which], labels[which], types[which])
                 }
             }
             .show()
     }
 
-    protected open fun addAdditionalCommands(labels: MutableList<String>, commands: MutableList<String>) {
+    protected open fun addAdditionalCommands(
+        labels: MutableList<String>,
+        commands: MutableList<String>,
+        types: MutableList<CommandType>
+    ) {
         // no-op
     }
 
@@ -261,7 +268,7 @@ abstract class AbstractItemPickerActivity : AbstractBaseActivity(), SwipeRefresh
         }
     }
 
-    protected abstract fun finish(item: Item, state: String, mappedState: String = state)
+    protected abstract fun finish(item: Item, state: String, mappedState: String = state, type: CommandType)
 
     private fun handleInitialHighlight() {
         val highlightItem = initialHighlightItemName

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ItemUpdateWidgetItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ItemUpdateWidgetItemPickerActivity.kt
@@ -26,6 +26,7 @@ import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.model.toOH2IconResource
 import org.openhab.habdroid.ui.homescreenwidget.ItemUpdateWidget
 import org.openhab.habdroid.util.CacheManager
+import org.openhab.habdroid.util.CommandType
 
 class ItemUpdateWidgetItemPickerActivity(
     override var hintMessageId: Int = 0,
@@ -68,7 +69,7 @@ class ItemUpdateWidgetItemPickerActivity(
         }
     }
 
-    override fun finish(item: Item, state: String, mappedState: String) {
+    override fun finish(item: Item, state: String, mappedState: String, type: CommandType) {
         val widgetLabel = if (autoGenSwitch.isChecked) {
             null
         } else {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ItemUpdateWidgetItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ItemUpdateWidgetItemPickerActivity.kt
@@ -26,7 +26,6 @@ import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.model.toOH2IconResource
 import org.openhab.habdroid.ui.homescreenwidget.ItemUpdateWidget
 import org.openhab.habdroid.util.CacheManager
-import org.openhab.habdroid.util.CommandType
 
 class ItemUpdateWidgetItemPickerActivity(
     override var hintMessageId: Int = 0,
@@ -69,7 +68,7 @@ class ItemUpdateWidgetItemPickerActivity(
         }
     }
 
-    override fun finish(item: Item, state: String, mappedState: String, type: CommandType) {
+    override fun finish(item: Item, state: String, mappedState: String, tag: Any?) {
         val widgetLabel = if (autoGenSwitch.isChecked) {
             null
         } else {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/NfcItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/NfcItemPickerActivity.kt
@@ -18,8 +18,10 @@ import androidx.annotation.LayoutRes
 import androidx.core.content.edit
 import org.openhab.habdroid.R
 import org.openhab.habdroid.model.Item
+import org.openhab.habdroid.util.CommandType
 import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.getPrefs
+import org.openhab.habdroid.util.getString
 import org.openhab.habdroid.util.wasNfcInfoHintShown
 
 class NfcItemPickerActivity(
@@ -49,7 +51,21 @@ class NfcItemPickerActivity(
         }
     }
 
-    override fun finish(item: Item, state: String, mappedState: String) {
-        startActivity(WriteTagActivity.createItemUpdateIntent(this, item.name, state, mappedState, item.label))
+    override fun addAdditionalCommands(
+        labels: MutableList<String>,
+        commands: MutableList<String>,
+        types: MutableList<CommandType>
+    ) {
+        val deviceId = getPrefs().getString(PrefKeys.DEV_ID)
+        if (deviceId.isNotEmpty()) {
+            labels.add(getString(R.string.device_identifier_suggested_command_nfc_tag, deviceId))
+            commands.add(deviceId)
+            types.add(CommandType.DEVICE_ID)
+        }
+    }
+
+    override fun finish(item: Item, state: String, mappedState: String, type: CommandType) {
+        startActivity(WriteTagActivity.createItemUpdateIntent(this, item.name, state, mappedState, item.label,
+            type == CommandType.DEVICE_ID))
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/NfcItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/NfcItemPickerActivity.kt
@@ -18,7 +18,6 @@ import androidx.annotation.LayoutRes
 import androidx.core.content.edit
 import org.openhab.habdroid.R
 import org.openhab.habdroid.model.Item
-import org.openhab.habdroid.util.CommandType
 import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getString
@@ -51,21 +50,20 @@ class NfcItemPickerActivity(
         }
     }
 
-    override fun addAdditionalCommands(
-        labels: MutableList<String>,
-        commands: MutableList<String>,
-        types: MutableList<CommandType>
-    ) {
+    override fun addAdditionalCommands(entries: MutableList<CommandEntry>) {
         val deviceId = getPrefs().getString(PrefKeys.DEV_ID)
         if (deviceId.isNotEmpty()) {
-            labels.add(getString(R.string.device_identifier_suggested_command_nfc_tag, deviceId))
-            commands.add(deviceId)
-            types.add(CommandType.DEVICE_ID)
+            entries.add(CommandEntry(
+                deviceId,
+                getString(R.string.device_identifier_suggested_command_nfc_tag, deviceId),
+                "IsDeviceId"
+            ))
         }
     }
 
-    override fun finish(item: Item, state: String, mappedState: String, type: CommandType) {
-        startActivity(WriteTagActivity.createItemUpdateIntent(this, item.name, state, mappedState, item.label,
-            type == CommandType.DEVICE_ID))
+    override fun finish(item: Item, state: String, mappedState: String, tag: Any?) {
+        val deviceId = tag == "IsDeviceId"
+        startActivity(WriteTagActivity.createItemUpdateIntent(
+            this, item.name, state, mappedState, item.label, deviceId))
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/NfcItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/NfcItemPickerActivity.kt
@@ -20,7 +20,7 @@ import org.openhab.habdroid.R
 import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.getPrefs
-import org.openhab.habdroid.util.getString
+import org.openhab.habdroid.util.getStringOrEmpty
 import org.openhab.habdroid.util.wasNfcInfoHintShown
 
 class NfcItemPickerActivity(
@@ -51,7 +51,7 @@ class NfcItemPickerActivity(
     }
 
     override fun addAdditionalCommands(entries: MutableList<CommandEntry>) {
-        val deviceId = getPrefs().getString(PrefKeys.DEV_ID)
+        val deviceId = getPrefs().getStringOrEmpty(PrefKeys.DEV_ID)
         if (deviceId.isNotEmpty()) {
             entries.add(CommandEntry(
                 deviceId,

--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -689,14 +689,6 @@ class PreferencesActivity : AbstractBaseActivity() {
             }
         }
 
-        private fun updatePrefixSummary(pref: Preference, newValue: String?) {
-            pref.summary = if (newValue.isNullOrEmpty()) {
-                pref.context.getString(R.string.send_device_info_item_prefix_summary_not_set)
-            } else {
-                pref.context.getString(R.string.send_device_info_item_prefix_summary, newValue)
-            }
-        }
-
         override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
             when (requestCode) {
                 PERMISSIONS_REQUEST_FOR_CALL_STATE -> {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/TaskerItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/TaskerItemPickerActivity.kt
@@ -23,6 +23,7 @@ import androidx.core.os.bundleOf
 import com.google.android.material.button.MaterialButton
 import org.openhab.habdroid.R
 import org.openhab.habdroid.model.Item
+import org.openhab.habdroid.util.CommandType
 import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.TaskerIntent
 import org.openhab.habdroid.util.TaskerPlugin
@@ -78,14 +79,18 @@ class TaskerItemPickerActivity(
         }
     }
 
-    override fun addAdditionalCommands(labels: MutableList<String>, commands: MutableList<String>) {
+    override fun addAdditionalCommands(
+        labels: MutableList<String>,
+        commands: MutableList<String>,
+        types: MutableList<CommandType>
+    ) {
         relevantVars?.forEach {
             labels.add(getString(R.string.item_picker_tasker_variable, it))
             commands.add(it)
         }
     }
 
-    override fun finish(item: Item, state: String, mappedState: String) {
+    override fun finish(item: Item, state: String, mappedState: String, type: CommandType) {
         var asCommand = commandButton.isChecked
 
         if (asCommand && item.type == Item.Type.Contact) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/TaskerItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/TaskerItemPickerActivity.kt
@@ -23,7 +23,6 @@ import androidx.core.os.bundleOf
 import com.google.android.material.button.MaterialButton
 import org.openhab.habdroid.R
 import org.openhab.habdroid.model.Item
-import org.openhab.habdroid.util.CommandType
 import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.TaskerIntent
 import org.openhab.habdroid.util.TaskerPlugin
@@ -79,18 +78,13 @@ class TaskerItemPickerActivity(
         }
     }
 
-    override fun addAdditionalCommands(
-        labels: MutableList<String>,
-        commands: MutableList<String>,
-        types: MutableList<CommandType>
-    ) {
+    override fun addAdditionalCommands(entries: MutableList<CommandEntry>) {
         relevantVars?.forEach {
-            labels.add(getString(R.string.item_picker_tasker_variable, it))
-            commands.add(it)
+            entries.add(CommandEntry(it, getString(R.string.item_picker_tasker_variable, it)))
         }
     }
 
-    override fun finish(item: Item, state: String, mappedState: String, type: CommandType) {
+    override fun finish(item: Item, state: String, mappedState: String, tag: Any?) {
         var asCommand = commandButton.isChecked
 
         if (asCommand && item.type == Item.Type.Contact) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -356,7 +356,11 @@ class WidgetListFragment : Fragment(), WidgetAdapter.ItemClickListener,
                         return true
                     }
                     id < suggestedCommands.commands.size -> {
-                        callback(suggestedCommands.commands[id], suggestedCommands.labels[id], suggestedCommands.types[id])
+                        callback(
+                            suggestedCommands.commands[id],
+                            suggestedCommands.labels[id],
+                            suggestedCommands.types[id]
+                        )
                         return true
                     }
                     else -> return false

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -65,7 +65,7 @@ import org.openhab.habdroid.util.ToastType
 import org.openhab.habdroid.util.Util
 import org.openhab.habdroid.util.dpToPixel
 import org.openhab.habdroid.util.getPrefs
-import org.openhab.habdroid.util.getString
+import org.openhab.habdroid.util.getStringOrEmpty
 import org.openhab.habdroid.util.openInBrowser
 import org.openhab.habdroid.util.showToast
 
@@ -347,7 +347,7 @@ class WidgetListFragment : Fragment(), WidgetAdapter.ItemClickListener,
                         return true
                     }
                     id == CONTEXT_MENU_ID_WRITE_DEVICE_ID -> {
-                        callback(context.getPrefs().getString(PrefKeys.DEV_ID), "", id)
+                        callback(context.getPrefs().getStringOrEmpty(PrefKeys.DEV_ID), "", id)
                         return true
                     }
                     id < suggestedCommands.entries.size -> {
@@ -364,7 +364,7 @@ class WidgetListFragment : Fragment(), WidgetAdapter.ItemClickListener,
             menu.add(Menu.NONE, index, Menu.NONE, entry.label).setOnMenuItemClickListener(listener)
         }
 
-        val deviceId = context.getPrefs().getString(PrefKeys.DEV_ID)
+        val deviceId = context.getPrefs().getStringOrEmpty(PrefKeys.DEV_ID)
         if (showDeviceId && deviceId.isNotEmpty()) {
             menu.add(Menu.NONE, CONTEXT_MENU_ID_WRITE_DEVICE_ID, Menu.NONE,
                 getString(R.string.device_identifier_suggested_command_nfc_tag, deviceId)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.withContext
 import org.openhab.habdroid.R
 import org.openhab.habdroid.model.NfcTag
 import org.openhab.habdroid.util.ToastType
+import org.openhab.habdroid.util.appendQueryParameter
 import org.openhab.habdroid.util.showToast
 import java.io.IOException
 
@@ -296,22 +297,29 @@ class WriteTagActivity : AbstractBaseActivity(), CoroutineScope {
             itemName: String,
             state: String,
             mappedState: String,
-            label: String?
+            label: String?,
+            deviceId: Boolean
         ): Intent {
             require(itemName.isNotEmpty()) { "Item name is empty" }
             val labelOrItemName = if (label.isNullOrEmpty()) itemName else label
+            val stateOrUnsupported = if (deviceId) "UNSUPPORTED" else state
 
             val uriBuilder = Uri.Builder()
                 .scheme(NfcTag.SCHEME)
                 .authority("")
                 .appendQueryParameter(NfcTag.QUERY_PARAMETER_ITEM_NAME, itemName)
-                .appendQueryParameter(NfcTag.QUERY_PARAMETER_STATE, state)
+                .appendQueryParameter(NfcTag.QUERY_PARAMETER_STATE, stateOrUnsupported)
+            if (deviceId) {
+                uriBuilder.appendQueryParameter(NfcTag.QUERY_PARAMETER_DEVICE_ID, deviceId)
+            }
 
             val shortUri = uriBuilder.build()
-            val longUri = uriBuilder
-                .appendQueryParameter(NfcTag.QUERY_PARAMETER_MAPPED_STATE, mappedState)
-                .appendQueryParameter(NfcTag.QUERY_PARAMETER_ITEM_LABEL, labelOrItemName)
-                .build()
+
+            uriBuilder.appendQueryParameter(NfcTag.QUERY_PARAMETER_ITEM_LABEL, labelOrItemName)
+            if (!deviceId) {
+                uriBuilder.appendQueryParameter(NfcTag.QUERY_PARAMETER_MAPPED_STATE, mappedState)
+            }
+            val longUri = uriBuilder.build()
 
             return Intent(context, WriteTagActivity::class.java).apply {
                 putExtra(EXTRA_SHORT_URI, shortUri)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/DeviceIdentifierPreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/DeviceIdentifierPreference.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.habdroid.ui.preference
+
+import android.content.Context
+import android.os.Build
+import android.text.Editable
+import android.text.InputType
+import android.text.TextWatcher
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.EditText
+import androidx.appcompat.app.AlertDialog
+import androidx.core.content.edit
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.preference.DialogPreference
+import androidx.preference.PreferenceDialogFragmentCompat
+import com.google.android.material.switchmaterial.SwitchMaterial
+import com.google.android.material.textfield.TextInputLayout
+import org.openhab.habdroid.R
+import org.openhab.habdroid.util.PrefKeys
+import org.openhab.habdroid.util.getString
+
+class DeviceIdentifierPreference constructor(context: Context, attrs: AttributeSet) : DialogPreference(context, attrs) {
+    private var value: Any? = null
+
+    init {
+        dialogTitle = null
+        setPositiveButtonText(android.R.string.ok)
+        setNegativeButtonText(android.R.string.cancel)
+    }
+
+    override fun onSetInitialValue(defaultValue: Any?) {
+        value = defaultValue
+        super.onSetInitialValue(defaultValue)
+    }
+
+    override fun getDialogLayoutResource(): Int {
+        return R.layout.pref_dialog_device_identifier
+    }
+
+    fun createDialog(): DialogFragment {
+        return PrefFragment.newInstance(key, title)
+    }
+
+    class PrefFragment : PreferenceDialogFragmentCompat(), TextWatcher {
+        private lateinit var editorWrapper: TextInputLayout
+        private lateinit var editor: EditText
+        private lateinit var voiceButton: SwitchMaterial
+        private lateinit var backgroundTasksButton: SwitchMaterial
+
+        override fun onCreateDialogView(context: Context?): View {
+            val inflater = LayoutInflater.from(activity)
+            val v = inflater.inflate(R.layout.pref_dialog_device_identifier, null)
+
+            editorWrapper = v.findViewById(R.id.input_wrapper)
+            editor = v.findViewById(android.R.id.edit)
+            voiceButton = v.findViewById(R.id.voice_switch)
+            backgroundTasksButton = v.findViewById(R.id.background_tasks_switch)
+
+            editor.addTextChangedListener(this)
+            editor.inputType = InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+            arguments?.getCharSequence(KEY_TITLE)?.let { title ->
+                editorWrapper.hint = title
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                editor.importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO
+            }
+
+            val prefs = preference.sharedPreferences
+            editor.setText(prefs.getString(PrefKeys.DEV_ID))
+            editor.setSelection(editor.text.length)
+            voiceButton.isChecked = prefs.getBoolean(PrefKeys.DEV_ID_PREFIX_VOICE, false)
+            backgroundTasksButton.isChecked = prefs.getBoolean(PrefKeys.DEV_ID_PREFIX_BG_TASKS, true)
+
+            return v
+        }
+
+        override fun onDialogClosed(positiveResult: Boolean) {
+            if (positiveResult) {
+                val prefs = preference.sharedPreferences
+                prefs.edit {
+                    putString(PrefKeys.DEV_ID, editor.text.toString())
+                    putBoolean(PrefKeys.DEV_ID_PREFIX_VOICE, voiceButton.isChecked)
+                    putBoolean(PrefKeys.DEV_ID_PREFIX_BG_TASKS, backgroundTasksButton.isChecked)
+                }
+            }
+        }
+
+        override fun onStart() {
+            super.onStart()
+            updateOkButtonState()
+        }
+
+        override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {
+            // no-op
+        }
+
+        override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
+            // no-op
+        }
+
+        override fun afterTextChanged(s: Editable) {
+            val value = s.toString()
+            if (value.contains(" ") || value.contains("\n")) {
+                editorWrapper.error = context?.getString(R.string.error_sending_alarm_clock_item_empty)
+            } else {
+                editorWrapper.error = null
+            }
+            updateOkButtonState()
+        }
+
+        private fun updateOkButtonState() {
+            val dialog = this.dialog
+            if (dialog is AlertDialog) {
+                dialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled =
+                    !editor.isEnabled || editorWrapper.error == null
+            }
+        }
+
+        companion object {
+            private const val KEY_TITLE = "title"
+
+            fun newInstance(
+                key: String,
+                title: CharSequence
+            ): PrefFragment {
+                val f = PrefFragment()
+                f.arguments = bundleOf(ARG_KEY to key, KEY_TITLE to title)
+                return f
+            }
+        }
+    }
+}
+

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/DeviceIdentifierPreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/DeviceIdentifierPreference.kt
@@ -51,7 +51,7 @@ class DeviceIdentifierPreference constructor(context: Context, attrs: AttributeS
         return R.layout.pref_dialog_device_identifier
     }
 
-    fun updateSummary() {
+    private fun updateSummary() {
         summary = if ((value as String?).isNullOrEmpty()) {
             context.getString(R.string.device_identifier_summary_not_set)
         } else {
@@ -134,7 +134,7 @@ class DeviceIdentifierPreference constructor(context: Context, attrs: AttributeS
         override fun afterTextChanged(s: Editable) {
             val value = s.toString()
             if (value.contains(" ") || value.contains("\n")) {
-                editorWrapper.error = context?.getString(R.string.error_sending_alarm_clock_item_empty)
+                editorWrapper.error = context?.getString(R.string.error_no_valid_item_name)
             } else {
                 editorWrapper.error = null
             }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/DeviceIdentifierPreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/DeviceIdentifierPreference.kt
@@ -34,7 +34,7 @@ import org.openhab.habdroid.R
 import org.openhab.habdroid.util.PrefKeys
 
 class DeviceIdentifierPreference constructor(context: Context, attrs: AttributeSet) : DialogPreference(context, attrs) {
-    private var value: Any? = null
+    private var value: String? = null
 
     init {
         dialogTitle = null
@@ -43,7 +43,7 @@ class DeviceIdentifierPreference constructor(context: Context, attrs: AttributeS
     }
 
     override fun onSetInitialValue(defaultValue: Any?) {
-        value = defaultValue
+        value = defaultValue as String?
         updateSummary()
     }
 
@@ -52,14 +52,14 @@ class DeviceIdentifierPreference constructor(context: Context, attrs: AttributeS
     }
 
     private fun updateSummary() {
-        summary = if ((value as String?).isNullOrEmpty()) {
+        summary = if (value.isNullOrEmpty()) {
             context.getString(R.string.device_identifier_summary_not_set)
         } else {
             value as String
         }
     }
 
-    fun setValue(value: String = (this.value as String?).orEmpty()) {
+    fun setValue(value: String = this.value.orEmpty()) {
         if (callChangeListener(value)) {
             if (shouldPersist()) {
                 persistString(value)
@@ -98,7 +98,7 @@ class DeviceIdentifierPreference constructor(context: Context, attrs: AttributeS
             }
 
             val prefs = preference.sharedPreferences
-            editor.setText(((preference as DeviceIdentifierPreference).value as String?))
+            editor.setText((preference as DeviceIdentifierPreference).value)
             editor.setSelection(editor.text.length)
             voiceButton.isChecked = prefs.getBoolean(PrefKeys.DEV_ID_PREFIX_VOICE, false)
             backgroundTasksButton.isChecked = prefs.getBoolean(PrefKeys.DEV_ID_PREFIX_BG_TASKS, true)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/DeviceIdentifierPreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/DeviceIdentifierPreference.kt
@@ -32,7 +32,6 @@ import com.google.android.material.switchmaterial.SwitchMaterial
 import com.google.android.material.textfield.TextInputLayout
 import org.openhab.habdroid.R
 import org.openhab.habdroid.util.PrefKeys
-import org.openhab.habdroid.util.getString
 
 class DeviceIdentifierPreference constructor(context: Context, attrs: AttributeSet) : DialogPreference(context, attrs) {
     private var value: Any? = null
@@ -45,11 +44,29 @@ class DeviceIdentifierPreference constructor(context: Context, attrs: AttributeS
 
     override fun onSetInitialValue(defaultValue: Any?) {
         value = defaultValue
-        super.onSetInitialValue(defaultValue)
+        updateSummary()
     }
 
     override fun getDialogLayoutResource(): Int {
         return R.layout.pref_dialog_device_identifier
+    }
+
+    fun updateSummary() {
+        summary = if ((value as String?).isNullOrEmpty()) {
+            context.getString(R.string.device_identifier_summary_not_set)
+        } else {
+            value as String
+        }
+    }
+
+    fun setValue(value: String = (this.value as String?).orEmpty()) {
+        if (callChangeListener(value)) {
+            if (shouldPersist()) {
+                persistString(value)
+            }
+            this.value = value
+            updateSummary()
+        }
     }
 
     fun createDialog(): DialogFragment {
@@ -81,7 +98,7 @@ class DeviceIdentifierPreference constructor(context: Context, attrs: AttributeS
             }
 
             val prefs = preference.sharedPreferences
-            editor.setText(prefs.getString(PrefKeys.DEV_ID))
+            editor.setText(((preference as DeviceIdentifierPreference).value as String?))
             editor.setSelection(editor.text.length)
             voiceButton.isChecked = prefs.getBoolean(PrefKeys.DEV_ID_PREFIX_VOICE, false)
             backgroundTasksButton.isChecked = prefs.getBoolean(PrefKeys.DEV_ID_PREFIX_BG_TASKS, true)
@@ -93,7 +110,8 @@ class DeviceIdentifierPreference constructor(context: Context, attrs: AttributeS
             if (positiveResult) {
                 val prefs = preference.sharedPreferences
                 prefs.edit {
-                    putString(PrefKeys.DEV_ID, editor.text.toString())
+                    val pref = preference as DeviceIdentifierPreference
+                    pref.setValue(editor.text.toString())
                     putBoolean(PrefKeys.DEV_ID_PREFIX_VOICE, voiceButton.isChecked)
                     putBoolean(PrefKeys.DEV_ID_PREFIX_BG_TASKS, backgroundTasksButton.isChecked)
                 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/ItemUpdatingPreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/ItemUpdatingPreference.kt
@@ -93,7 +93,7 @@ class ItemUpdatingPreference constructor(context: Context, attrs: AttributeSet?)
         }
     }
 
-    fun updateSummaryAndIcon(
+    private fun updateSummaryAndIcon(
         prefix: String = context.getPrefs().getPrefixForBgTasks()
     ) {
         val value = value ?: return

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/ItemUpdatingPreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/ItemUpdatingPreference.kt
@@ -35,9 +35,8 @@ import com.google.android.material.textfield.TextInputLayout
 import org.openhab.habdroid.R
 import org.openhab.habdroid.ui.setupHelpIcon
 import org.openhab.habdroid.ui.updateHelpIconAlpha
-import org.openhab.habdroid.util.PrefKeys
+import org.openhab.habdroid.util.getPrefixForBgTasks
 import org.openhab.habdroid.util.getPrefs
-import org.openhab.habdroid.util.getStringOrEmpty
 
 class ItemUpdatingPreference constructor(context: Context, attrs: AttributeSet?) : DialogPreference(context, attrs) {
     private val howtoUrl: String?
@@ -95,7 +94,7 @@ class ItemUpdatingPreference constructor(context: Context, attrs: AttributeSet?)
     }
 
     fun updateSummaryAndIcon(
-        prefix: String = context.getPrefs().getStringOrEmpty(PrefKeys.SEND_DEVICE_INFO_PREFIX)
+        prefix: String = context.getPrefs().getPrefixForBgTasks()
     ) {
         val value = value ?: return
         val summary = if (value.first) summaryOn else summaryOff

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/ItemUpdatingPreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/ItemUpdatingPreference.kt
@@ -177,7 +177,7 @@ class ItemUpdatingPreference constructor(context: Context, attrs: AttributeSet?)
         override fun afterTextChanged(s: Editable) {
             val value = s.toString()
             if (value.trim().isEmpty() || value.contains(" ") || value.contains("\n")) {
-                editorWrapper.error = context?.getString(R.string.error_sending_alarm_clock_item_empty)
+                editorWrapper.error = context?.getString(R.string.error_no_valid_item_name)
             } else {
                 editorWrapper.error = null
             }

--- a/mobile/src/main/java/org/openhab/habdroid/util/PrefExtensions.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/PrefExtensions.kt
@@ -120,6 +120,16 @@ fun SharedPreferences.getBackgroundTaskScheduleInMillis(): Long {
     return value.toInt() * 60 * 1000L
 }
 
+fun SharedPreferences.getPrefixForVoice(): String? {
+    val enabled = getBoolean(PrefKeys.DEV_ID_PREFIX_VOICE, false)
+    return if (enabled) getStringOrEmpty(PrefKeys.DEV_ID) else null
+}
+
+fun SharedPreferences.getPrefixForBgTasks(): String {
+    val enabled = getBoolean(PrefKeys.DEV_ID_PREFIX_BG_TASKS, true)
+    return if (enabled) getStringOrEmpty(PrefKeys.DEV_ID) else ""
+}
+
 fun SharedPreferences.getStringOrNull(key: String): String? {
     return getString(key, null)
 }

--- a/mobile/src/main/java/org/openhab/habdroid/util/PrefKeys.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/PrefKeys.kt
@@ -40,7 +40,6 @@ object PrefKeys {
     const val SCREEN_TIMER_OFF = "default_openhab_screentimeroff"
     const val FULLSCREEN = "default_openhab_fullscreen"
 
-    const val SEND_DEVICE_INFO_PREFIX = "sendDeviceInfoPrefix"
     const val SEND_DEVICE_INFO_SCHEDULE = "send_device_info_schedule"
     const val SEND_ALARM_CLOCK = "alarmClock"
     const val SEND_PHONE_STATE = "phoneState"
@@ -49,6 +48,9 @@ object PrefKeys {
     const val SEND_WIFI_SSID = "send_wifi_ssid"
     const val SEND_DND_MODE = "send_dnd_mode"
 
+    const val DEV_ID = "sendDeviceInfoPrefix"
+    const val DEV_ID_PREFIX_VOICE = "device_identifier_prefix_voice"
+    const val DEV_ID_PREFIX_BG_TASKS = "device_identifier_prefix_background_tasks"
     const val SCREEN_LOCK = "screen_lock"
     const val TASKER_PLUGIN_ENABLED = "taskerPlugin"
     const val NOTIFICATION_TONE = "default_openhab_alertringtone"

--- a/mobile/src/main/java/org/openhab/habdroid/util/SuggestedCommandsFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/SuggestedCommandsFactory.kt
@@ -20,7 +20,6 @@ import org.openhab.habdroid.R
 import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.model.Widget
 import org.openhab.habdroid.model.withValue
-import java.util.ArrayList
 
 class SuggestedCommandsFactory(private val context: Context, private val showUndef: Boolean) {
     fun fill(widget: Widget?, forItemUpdate: Boolean = false): SuggestedCommands {
@@ -87,7 +86,7 @@ class SuggestedCommandsFactory(private val context: Context, private val showUnd
         item.isOfTypeOrGroupType(Item.Type.Number) -> {
             // Don't suggest numbers that might be totally out of context if there's already
             // at least one command
-            if (suggestedCommands.commands.isEmpty()) {
+            if (suggestedCommands.entries.isEmpty()) {
                 addCommonNumberCommands(suggestedCommands)
             }
             item.state?.asString?.let { value -> add(suggestedCommands, value) }
@@ -142,10 +141,8 @@ class SuggestedCommandsFactory(private val context: Context, private val showUnd
     }
 
     private fun add(suggestedCommands: SuggestedCommands, command: String, label: String = command) {
-        if (command !in suggestedCommands.commands) {
-            suggestedCommands.commands.add(command)
-            suggestedCommands.labels.add(label)
-            suggestedCommands.types.add(CommandType.DEFAULT)
+        if (command !in suggestedCommands.entries.map { entry -> entry.command }) {
+            suggestedCommands.entries.add(SuggestedCommand(command, label))
         }
     }
 
@@ -172,10 +169,10 @@ class SuggestedCommandsFactory(private val context: Context, private val showUnd
         add(suggestedCommands, "DECREASE", R.string.nfc_action_decrease)
     }
 
+    data class SuggestedCommand(val command: String, val label: String)
+
     inner class SuggestedCommands {
-        var commands: MutableList<String> = ArrayList()
-        var labels: MutableList<String> = ArrayList()
-        var types: MutableList<CommandType> = ArrayList()
+        var entries: MutableList<SuggestedCommand> = mutableListOf()
         var shouldShowCustom = false
         var inputTypeFlags = InputType.TYPE_CLASS_TEXT
     }
@@ -188,8 +185,3 @@ class SuggestedCommandsFactory(private val context: Context, private val showUnd
     }
 }
 
-enum class CommandType {
-    DEFAULT,
-    DEVICE_ID,
-    CUSTOM
-}

--- a/mobile/src/main/java/org/openhab/habdroid/util/SuggestedCommandsFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/SuggestedCommandsFactory.kt
@@ -145,6 +145,7 @@ class SuggestedCommandsFactory(private val context: Context, private val showUnd
         if (command !in suggestedCommands.commands) {
             suggestedCommands.commands.add(command)
             suggestedCommands.labels.add(label)
+            suggestedCommands.types.add(CommandType.DEFAULT)
         }
     }
 
@@ -174,6 +175,7 @@ class SuggestedCommandsFactory(private val context: Context, private val showUnd
     inner class SuggestedCommands {
         var commands: MutableList<String> = ArrayList()
         var labels: MutableList<String> = ArrayList()
+        var types: MutableList<CommandType> = ArrayList()
         var shouldShowCustom = false
         var inputTypeFlags = InputType.TYPE_CLASS_TEXT
     }
@@ -184,4 +186,10 @@ class SuggestedCommandsFactory(private val context: Context, private val showUnd
         private const val INPUT_TYPE_SINGED_DECIMAL_NUMBER =
             INPUT_TYPE_DECIMAL_NUMBER or InputType.TYPE_NUMBER_FLAG_SIGNED
     }
+}
+
+enum class CommandType {
+    DEFAULT,
+    DEVICE_ID,
+    CUSTOM
 }

--- a/mobile/src/main/java/org/openhab/habdroid/util/Util.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Util.kt
@@ -54,6 +54,6 @@ object Util {
             (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic")) ||
             "google_sdk" == Build.PRODUCT
         Log.d(TAG, "Device is emulator: $isEmulator")
-        return isEmulator
+        return true
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/util/Util.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Util.kt
@@ -54,6 +54,6 @@ object Util {
             (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic")) ||
             "google_sdk" == Build.PRODUCT
         Log.d(TAG, "Device is emulator: $isEmulator")
-        return true
+        return isEmulator
     }
 }

--- a/mobile/src/main/res/drawable/ic_tag_text_outline_grey_24dp.xml
+++ b/mobile/src/main/res/drawable/ic_tag_text_outline_grey_24dp.xml
@@ -1,0 +1,22 @@
+<!--
+    Copyright (c) 2014, Austin Andrews (http://materialdesignicons.com/),
+    with Reserved Font Name Material Design Icons.
+    Copyright (c) 2014, Google (http://www.google.com/design/)
+    uses the license at https://github.com/google/material-design-icons/blob/master/LICENSE
+
+    This Font Software is licensed under the SIL Open Font License, Version 1.1.
+    This license is copied below, and is also available with a FAQ at:
+    http://scripts.sil.org/OFL
+
+    Author: https://twitter.com/Templarian
+-->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#757575"
+        android:pathData="M21.4,11.6L12.4,2.6C12,2.2 11.5,2 11,2H4C2.9,2 2,2.9 2,4V11C2,11.5 2.2,12 2.6,12.4L11.6,21.4C12,21.8 12.5,22 13,22C13.5,22 14,21.8 14.4,21.4L21.4,14.4C21.8,14 22,13.5 22,13C22,12.5 21.8,12 21.4,11.6M13,20L4,11V4H11L20,13M6.5,5C7.3,5 8,5.7 8,6.5S7.3,8 6.5,8 5,7.3 5,6.5 5.7,5 6.5,5M10.1,8.9L11.5,7.5L17,13L15.6,14.4L10.1,8.9M7.6,11.4L9,10L13,14L11.6,15.4L7.6,11.4Z"/>
+</vector>

--- a/mobile/src/main/res/layout/pref_dialog_device_identifier.xml
+++ b/mobile/src/main/res/layout/pref_dialog_device_identifier.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:clipToPadding="false"
+    android:padding="?attr/dialogPreferredPadding">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/input_wrapper"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@android:id/edit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:singleLine="true" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/voice_switch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/device_identifier_prefix_voice"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/input_wrapper" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/background_tasks_switch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/device_identifier_bg_tasks"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/voice_switch" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/hint"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/device_identifier_hint"
+        android:drawableStart="@drawable/ic_info_outline_grey_24dp"
+        android:drawablePadding="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/background_tasks_switch" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -261,6 +261,14 @@
     <string name="send_device_info_schedule_6_hours">6 hours</string>
     <string name="send_device_info_schedule_12_hours">12 hours</string>
 
+    <!-- Device identifier -->
+    <string name="device_identifier_title">Device identifier</string>
+    <string name="device_identifier_prefix_voice"><![CDATA[Prefix voice commands with \'<Device identifier>|\']]></string>
+    <string name="device_identifier_bg_tasks">Prefix the Item names of \"Send device information to server\" with this identifier</string>
+    <string name="device_identifier_hint">This device identifier can be any string and should be unique for all devices accessing your openHAB server. Besides the two use cases above, you can also use it as state on NFC tags, so you know which device read the tag.</string>
+    <string name="device_identifier_suggested_command_nfc_tag">Device identifier of scanning device (\"%s\" for this device)</string>
+    <string name="device_identifier_summary_not_set">Data sent to the server and voice commands aren\'t prefixed with a device identifier</string>
+
     <!-- Notification list strings -->
     <string name="notification_list_empty">No notifications were sent so far</string>
     <string name="notification_list_error">An error occurred while loading notifications</string>
@@ -484,9 +492,4 @@
     <string name="widget_type_video">Video</string>
     <string name="widget_type_mapview">Map</string>
     <string name="widget_type_chart">Chart</string>
-    <string name="device_identifier_title">Device identifier</string>
-    <string name="device_identifier_prefix_voice"><![CDATA[Prefix voice commands with \'<Device identifier>|\']]></string>
-    <string name="device_identifier_bg_tasks">Prefix the Item names of \"Send device information to server\" with this identifier</string>
-    <string name="device_identifier_hint">This device identifier can be any string and should be unique for all devices accessing your openHAB server. Besides the two use cases above, you can also use it as state on NFC tags, so you know which device read the tag.</string>
-    <string name="device_identifier_suggested_command_nfc_tag">Device identifier of scanning device (\"%s\" for this device)</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -197,10 +197,8 @@
     <string name="send_device_info_category_event_based_explanation">These Items are updated on corresponding events, e.g. an incoming phone call</string>
     <string name="send_device_info_category_schedule_based_title">Schedule based</string>
     <string name="send_device_info_category_schedule_based_explanation">The shorter the chosen interval is, the larger is the potential impact on the battery life of your device. Additionally, your device might not follow the chosen interval exactly, but delay the updates to reduce power consumption across apps.</string>
-    <string name="send_device_info_category_general">General</string>
-    <string name="send_device_info_item_prefix">Item name prefix</string>
-    <string name="send_device_info_item_prefix_summary">The Item names of the following features are prefixed with \'%s\'</string>
-    <string name="send_device_info_item_prefix_summary_not_set">No prefix is set for the Item names of the following features</string>
+    <string name="send_device_info_item_prefix_summary">The Item names on this page are prefixed with the device identifier \'%s\'</string>
+    <string name="send_device_info_item_prefix_summary_not_set">No prefix is set for the Item names on this page. You can prefix them with the device identifier, which can be set on the main settings page.</string>
     <string name="settings_item_update_pref_howto_summary">Tap here to get hints on how to set up this feature server-side</string>
     <string name="settings_alarm_clock">Alarm time</string>
     <string name="settings_alarm_clock_summary_on">Sends alarm time to Item \'%1$s\'</string>
@@ -486,4 +484,9 @@
     <string name="widget_type_video">Video</string>
     <string name="widget_type_mapview">Map</string>
     <string name="widget_type_chart">Chart</string>
+    <string name="device_identifier_title">Device identifier</string>
+    <string name="device_identifier_prefix_voice"><![CDATA[Prefix voice commands with \'<Device identifier>|\']]></string>
+    <string name="device_identifier_bg_tasks">Prefix the Item names of \"Send device information to server\" with this identifier</string>
+    <string name="device_identifier_hint">This device identifier can be any string and should be unique for all devices accessing your openHAB server. Besides the two use cases above, you can also use it as state on NFC tags, so you know which device read the tag.</string>
+    <string name="device_identifier_suggested_command_nfc_tag">Device identifier of scanning device (\"%s\" for this device)</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -250,7 +250,7 @@
     <string name="item_update_http_error_label">%1$s update failed: %2$s</string>
     <string name="item_update_connection_error">Item \'%1$s\' update failed (No connection)</string>
     <string name="item_update_connection_error_label">%1$s update failed (No connection)</string>
-    <string name="error_sending_alarm_clock_item_empty">Please enter a valid Item name</string>
+    <string name="error_no_valid_item_name">Please enter a valid Item name</string>
     <string name="retry">Retry</string>
     <string name="ignore">Ignore</string>
     <string name="send_device_info_schedule">Schedule</string>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -89,6 +89,10 @@
             android:title="@string/settings_openhab_fullscreen" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_misc_title">
+        <org.openhab.habdroid.ui.preference.DeviceIdentifierPreference
+            android:defaultValue="@string/empty_string"
+            android:key="sendDeviceInfoPrefix"
+            android:title="@string/device_identifier_title" />
         <Preference
             android:key="send_device_info"
             android:dependency="default_openhab_demomode"

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -92,6 +92,7 @@
         <org.openhab.habdroid.ui.preference.DeviceIdentifierPreference
             android:defaultValue="@string/empty_string"
             android:key="sendDeviceInfoPrefix"
+            android:icon="@drawable/ic_tag_text_outline_grey_24dp"
             android:title="@string/device_identifier_title" />
         <Preference
             android:key="send_device_info"

--- a/mobile/src/main/res/xml/preferences_device_information.xml
+++ b/mobile/src/main/res/xml/preferences_device_information.xml
@@ -3,14 +3,11 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/send_device_info_to_server">
-    <PreferenceCategory
-        android:title="@string/send_device_info_category_general">
-        <org.openhab.habdroid.ui.preference.CustomInputTypePreference
-            android:defaultValue="@string/empty_string"
-            android:inputType="textNoSuggestions"
-            android:key="sendDeviceInfoPrefix"
-            android:title="@string/send_device_info_item_prefix" />
-    </PreferenceCategory>
+    <Preference
+        android:key="device_identifier_prefix_background_tasks"
+        android:enabled="false"
+        android:selectable="false"
+        android:icon="@drawable/ic_info_outline_grey_24dp" />
     <PreferenceCategory
         android:title="@string/send_device_info_category_event_based_title">
         <Preference


### PR DESCRIPTION
Rename the existing prefix of "Send device info" to "Device identifier"
and make it available for NFC tags and voice command.

Closes #1692
Closes #1951

For NFC tags a new query parameter is added (`d=true`) if the device
identifier should be send instead of the state on the tag. Older clients
will send "UNSUPPORTED" instead.