### PR TITLE
Trim Item and Widget labels

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
@@ -74,7 +74,7 @@ data class Item internal constructor(
             val parsedItem = jsonObject.toItem()
             // Events don't contain the link property, so preserve that if previously present
             val link = item?.link ?: parsedItem.link
-            return Item(parsedItem.name, parsedItem.label, parsedItem.category, parsedItem.type,
+            return Item(parsedItem.name, parsedItem.label?.trim(), parsedItem.category, parsedItem.type,
                 parsedItem.groupType, link, parsedItem.readOnly, parsedItem.members,
                 parsedItem.options, parsedItem.state)
         }
@@ -102,7 +102,7 @@ fun Node.toItem(): Item? {
         state = null
     }
 
-    return Item(finalName, finalName, null, type, groupType, link, false,
+    return Item(finalName, finalName.trim(), null, type, groupType, link, false,
         emptyList(), null, state.toParsedState())
 }
 
@@ -131,7 +131,7 @@ fun JSONObject.toItem(): Item {
 
     val numberPattern = stateDescription?.optString("pattern")
     return Item(name,
-        optString("label", name),
+        optString("label", name).trim(),
         optStringOrNull("category"),
         getString("type").toItemType(),
         optString("groupType").toItemType(),

--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -59,8 +59,8 @@ data class Widget(
     val height: Int,
     val visibility: Boolean
 ) : Parcelable {
-    val label get() = rawLabel.split("[", "]")[0]
-    val stateFromLabel: String? get() = rawLabel.split("[", "]").getOrNull(1)
+    val label get() = rawLabel.split("[", "]")[0].trim()
+    val stateFromLabel: String? get() = rawLabel.split("[", "]").getOrNull(1)?.trim()
 
     val mappingsOrItemOptions get() =
         if (mappings.isEmpty() && item?.options != null) item.options else mappings

--- a/mobile/src/test/java/org/openhab/habdroid/model/WidgetTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/model/WidgetTest.kt
@@ -141,7 +141,7 @@ class WidgetTest {
     fun testGetLabel() {
         assertEquals("Group1", sut1[0].label)
         assertEquals("Group1", sut2[0].label)
-        assertEquals("Dimmer ", sut3[1].label)
+        assertEquals("Dimmer", sut3[1].label)
     }
 
     @Test


### PR DESCRIPTION
There are several places where trailing whitespaces don't look nice, e.g. in NFC success toasts.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>