### PR TITLE
Video widget: Data saver improvements

### DIFF
--- a/mobile/src/foss/java/org/openhab/habdroid/ui/MapViewHelper.kt
+++ b/mobile/src/foss/java/org/openhab/habdroid/ui/MapViewHelper.kt
@@ -98,7 +98,6 @@ object MapViewHelper {
         }
 
         override fun start() {
-            super.start()
             if (!started) {
                 mapView.onResume()
                 started = true
@@ -106,7 +105,6 @@ object MapViewHelper {
         }
 
         override fun stop() {
-            super.stop()
             if (started) {
                 mapView.onPause()
                 started = false

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -984,6 +984,8 @@ class WidgetAdapter(
                     })
                 }
             }
+
+            start()
         }
 
         override fun start() {

--- a/mobile/src/main/res/layout/widgetlist_videoitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_videoitem.xml
@@ -11,7 +11,9 @@
         android:layout_height="wrap_content"
         style="?attr/indeterminateProgressStyle"
         android:padding="8dp"
-        android:layout_gravity="center" />
+        android:layout_gravity="center"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
     <org.openhab.habdroid.ui.widget.AutoHeightVideoView
         android:id="@+id/widget_content"


### PR DESCRIPTION
* Hide loading indicator if data saver hint is shown
* Start video after clicking on "Load anyway"

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>