### PR TITLE
Fix crash when log is too large to share

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/LogActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/LogActivity.kt
@@ -30,9 +30,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.openhab.habdroid.R
+import org.openhab.habdroid.util.ToastType
 import org.openhab.habdroid.util.getLocalUrl
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getRemoteUrl
+import org.openhab.habdroid.util.showToast
 import java.io.BufferedReader
 import java.io.InputStreamReader
 
@@ -64,7 +66,12 @@ class LogActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListener
                 type = "text/plain"
                 putExtra(Intent.EXTRA_TEXT, logTextView.text)
             }
-            startActivity(sendIntent)
+            try {
+                startActivity(sendIntent)
+            } catch (e: RuntimeException) {
+                Log.d(TAG, "Log too large to share", e)
+                showToast(R.string.log_too_large_to_share, ToastType.ERROR)
+            }
         }
 
         setUiState(true)

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -381,6 +381,7 @@
     <string name="log_activity_action_reload">Reload</string>
     <string name="log_activity_content_description_share">Share log</string>
     <string name="empty_log">Log is empty</string>
+    <string name="log_too_large_to_share">The log is too large to share. Please clear the log, reproduce the bug and share the log then.</string>
 
     <!-- Home screen shortcuts -->
     <string name="home_shortcut_pin_to_home">Pin to home</string>


### PR DESCRIPTION
````
Fatal Exception: java.lang.RuntimeException: Failure from system
       at android.app.Instrumentation.execStartActivity(Instrumentation.java:1719)
       at android.app.Activity.startActivityForResult(Activity.java:5252)
       at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:675)
       at android.app.Activity.startActivityForResult(Activity.java:5203)
       at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:662)
       at android.app.Activity.startActivity(Activity.java:5581)
       at android.app.Activity.startActivity(Activity.java:5549)
       at org.openhab.habdroid.ui.LogActivity$onCreate$1.onClick(LogActivity.kt:67)
       ...
Caused by android.os.TransactionTooLargeException: data parcel size 1169344 bytes
       at android.os.BinderProxy.transactNative(BinderProxy.java)
       at android.os.BinderProxy.transact(BinderProxy.java:527)
       at android.app.IActivityTaskManager$Stub$Proxy.startActivity(IActivityTaskManager.java:4324)
       at android.app.Instrumentation.execStartActivity(Instrumentation.java:1713)
       at android.app.Activity.startActivityForResult(Activity.java:5252)
       at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:675)
       at android.app.Activity.startActivityForResult(Activity.java:5203)
       at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:662)
       at android.app.Activity.startActivity(Activity.java:5581)
       at android.app.Activity.startActivity(Activity.java:5549)
       at org.openhab.habdroid.ui.LogActivity$onCreate$1.onClick(LogActivity.kt:67)
       at android.view.View.performClick(View.java:7869)
       at android.view.View.performClickInternal(View.java:7838)
       ...
````

I tried to truncate the log, but that resulted in OOMs. And even if it
works, truncating the start removes the device information and
truncating the end probably removes the log of the bug/crash.
The crash happens only once or twice a week in the stable version.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>