### PR TITLE
Listen for schedule based item events when in foreground

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -157,13 +157,13 @@
                 <action android:name="android.intent.action.PHONE_STATE" />
             </intent-filter>
             <intent-filter>
-                <action android:name="android.intent.action.ACTION_POWER_CONNECTED"/>
-                <action android:name="android.intent.action.ACTION_POWER_DISCONNECTED"/>
-                <action android:name="android.intent.action.BATTERY_LOW"/>
-                <action android:name="android.intent.action.BATTERY_OKAY"/>
+                <action android:name="android.intent.action.ACTION_POWER_CONNECTED" />
+                <action android:name="android.intent.action.ACTION_POWER_DISCONNECTED" />
+                <action android:name="android.intent.action.BATTERY_LOW" />
+                <action android:name="android.intent.action.BATTERY_OKAY" />
             </intent-filter>
             <intent-filter>
-                <action android:name="android.net.wifi.STATE_CHANGE"/>
+                <action android:name="android.net.wifi.STATE_CHANGE" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.LOCALE_CHANGED" />

--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -251,7 +251,7 @@ class BackgroundTasksManager : BroadcastReceiver() {
                     addAction(Intent.ACTION_BATTERY_OKAY)
                     addAction(WifiManager.NETWORK_STATE_CHANGED_ACTION)
                 }
-                // This broadcast is only send to registered receivers, so we need that in any case
+                // This broadcast is only sent to registered receivers, so we need that in any case
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     addAction(NotificationManager.ACTION_INTERRUPTION_FILTER_CHANGED)
                 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -135,6 +135,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
     var isStarted: Boolean = false
         private set
     private var shortcutManager: ShortcutManager? = null
+    private val backgroundTasksManager = BackgroundTasksManager()
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
@@ -281,18 +282,23 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
 
         updateTitle()
         showMissingPermissionsWarningIfNeeded()
+
+        registerReceiver(backgroundTasksManager, BackgroundTasksManager.getIntentFilterForForeground())
     }
 
     override fun onPause() {
         RemoteLog.d(TAG, "onPause()")
         super.onPause()
         retryJob?.cancel(CancellationException("onPause() was called"))
+
         val nfcAdapter = NfcAdapter.getDefaultAdapter(this)
         try {
             nfcAdapter?.disableForegroundDispatch(this)
         } catch (e: IllegalStateException) {
             // See #1776
         }
+
+        unregisterReceiver(backgroundTasksManager)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {


### PR DESCRIPTION
Listen for events of schedule bases items when the app is in the foreground. This applies to all Android versions.

See #2014

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>