### PR TITLE
Fix crash in Video item

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -87,6 +87,7 @@ import java.util.Calendar
 import java.util.HashMap
 import java.util.Locale
 import java.util.Random
+import java.util.concurrent.CancellationException
 import java.util.concurrent.Executor
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -967,7 +968,11 @@ class WidgetAdapter(
                     mediaPlayer.setMediaItem(mediaItem)
                     val prepareFuture = mediaPlayer.prepare()
                     prepareFuture.addListener(Runnable {
-                        val code = prepareFuture.get().resultCode
+                        val code = try {
+                            prepareFuture.get().resultCode
+                        } catch (e: CancellationException) {
+                            Log.d(TAG, "Task was canceled")
+                        }
                         Log.d(TAG, "Media player returned $code")
                         loadingIndicator.isVisible = false
                         if (code >= 0) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -51,6 +51,7 @@ import androidx.core.view.children
 import androidx.core.view.get
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import androidx.media2.common.BaseResult
 import androidx.media2.common.MediaMetadata
 import androidx.media2.common.UriMediaItem
 import androidx.media2.player.MediaPlayer
@@ -972,6 +973,7 @@ class WidgetAdapter(
                             prepareFuture.get().resultCode
                         } catch (e: CancellationException) {
                             Log.d(TAG, "Task was canceled")
+                            BaseResult.RESULT_ERROR_UNKNOWN
                         }
                         Log.d(TAG, "Media player returned $code")
                         loadingIndicator.isVisible = false


### PR DESCRIPTION
````
Fatal Exception: java.util.concurrent.CancellationException: Task was cancelled.
       at androidx.media2.player.futures.AbstractResolvableFuture.cancellationExceptionWithCause(AbstractResolvableFuture.java:1193)
       at androidx.media2.player.futures.AbstractResolvableFuture.getDoneValue(AbstractResolvableFuture.java:515)
       at androidx.media2.player.futures.AbstractResolvableFuture.get(AbstractResolvableFuture.java:476)
       at org.openhab.habdroid.ui.WidgetAdapter$VideoViewHolder$bindAfterDataSaverCheck$1.run(WidgetAdapter.kt:970)
       at android.os.Handler.handleCallback(Handler.java:883)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>