### PR TITLE
Revert "Bump security-crypto from 1.0.0-rc01 to 1.0.0-rc02"

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -145,7 +145,7 @@ dependencies {
     fullImplementation "androidx.work:work-gcm:$work_manager_version"
     implementation "androidx.media2:media2-widget:$androidx_media_version"
     implementation "androidx.media2:media2-player:$androidx_media_version"
-    implementation "androidx.security:security-crypto:1.0.0-rc02"
+    implementation "androidx.security:security-crypto:1.0.0-rc01"
     implementation "org.jmdns:jmdns:3.5.5"
     implementation "com.squareup.okhttp3:okhttp:$ok_http_version"
     implementation "com.squareup.okhttp3:logging-interceptor:$ok_http_version"


### PR DESCRIPTION
Reverts openhab/openhab-android#2017

I see a new crash since security-crypto has been bumped to 1.0.0-rc02:

````
Fatal Exception: java.lang.SecurityException: Could not decrypt value. decryption failed
       at androidx.security.crypto.EncryptedSharedPreferences.getDecryptedObject(EncryptedSharedPreferences.java:546)
       at androidx.security.crypto.EncryptedSharedPreferences.getString(EncryptedSharedPreferences.java:377)
       at org.openhab.habdroid.util.PrefExtensionsKt.getStringOrNull(PrefExtensions.kt:124)
       at org.openhab.habdroid.core.connection.ConnectionFactory.makeConnection(ConnectionFactory.kt:302)
       at org.openhab.habdroid.core.connection.ConnectionFactory.updateConnections(ConnectionFactory.kt:173)
       at org.openhab.habdroid.core.connection.ConnectionFactory$Companion$initialize$1.invokeSuspend(ConnectionFactory.kt:428)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
       at android.os.Handler.handleCallback(Handler.java:809)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:166)
       at android.app.ActivityThread.main(ActivityThread.java:7383)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:469)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:963)
Caused by java.security.GeneralSecurityException: decryption failed
       at com.google.crypto.tink.aead.AeadWrapper$WrappedAead.decrypt(AeadWrapper.java:83)
       at androidx.security.crypto.EncryptedSharedPreferences.getDecryptedObject(EncryptedSharedPreferences.java:499)
       at androidx.security.crypto.EncryptedSharedPreferences.getString(EncryptedSharedPreferences.java:377)
       at org.openhab.habdroid.util.PrefExtensionsKt.getStringOrNull(PrefExtensions.kt:124)
       at org.openhab.habdroid.core.connection.ConnectionFactory.makeConnection(ConnectionFactory.kt:302)
       at org.openhab.habdroid.core.connection.ConnectionFactory.updateConnections(ConnectionFactory.kt:173)
       at org.openhab.habdroid.core.connection.ConnectionFactory$Companion$initialize$1.invokeSuspend(ConnectionFactory.kt:428)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
       at android.os.Handler.handleCallback(Handler.java:809)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:166)
       at android.app.ActivityThread.main(ActivityThread.java:7383)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:469)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:963)
````