### PR TITLE
Fix crash on Android L when changing prefix

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -663,7 +663,8 @@ class PreferencesActivity : AbstractBaseActivity() {
                 updatePrefixSummary(prefixPref, prefix)
 
                 BackgroundTasksManager.KNOWN_KEYS.forEach {
-                    (getPreference(it) as ItemUpdatingPreference).updateSummaryAndIcon(prefix)
+                    val pref = findPreference(it) as ItemUpdatingPreference?
+                    pref?.updateSummaryAndIcon(prefix)
                 }
                 true
             }


### PR DESCRIPTION
The DND mode pref isn't shown there

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>