### PR TITLE
Correctly reset FCM registration failure.

### DIFF
--- a/mobile/src/full/java/org/openhab/habdroid/core/FcmRegistrationService.kt
+++ b/mobile/src/full/java/org/openhab/habdroid/core/FcmRegistrationService.kt
@@ -67,6 +67,8 @@ class FcmRegistrationService : JobIntentService() {
             ACTION_REGISTER -> {
                 try {
                     runBlocking { registerFcm(connection) }
+                    CloudMessagingHelper.registrationFailureReason = null
+                    CloudMessagingHelper.registrationDone = true
                 } catch (e: HttpClient.HttpException) {
                     CloudMessagingHelper.registrationFailureReason = e
                     CloudMessagingHelper.registrationDone = true
@@ -82,8 +84,6 @@ class FcmRegistrationService : JobIntentService() {
                     }
                     Log.e(TAG, "FCM registration failed", e)
                 }
-
-                CloudMessagingHelper.registrationDone = true
             }
             ACTION_HIDE_NOTIFICATION -> {
                 val id = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)


### PR DESCRIPTION
Once FCM registration was successful, we aren't interested in previous
exceptions anymore. When keeping them, we continue reporting failure
even though registration was successful.
