### PR TITLE
Specify WorkManager foreground service type in Manifest

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -198,6 +198,14 @@
                 <data android:scheme="openhab" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:directBootAware="false"
+            android:enabled="@bool/enable_system_foreground_service_default"
+            android:exported="false"
+            android:foregroundServiceType="dataSync"
+            tools:targetApi="n" />
     </application>
 
 </manifest>


### PR DESCRIPTION
Fixes https://issuetracker.google.com/issues/147873061

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>