### PR TITLE
Fix device id preference

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/DeviceIdentifierPreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/DeviceIdentifierPreference.kt
@@ -43,7 +43,7 @@ class DeviceIdentifierPreference constructor(context: Context, attrs: AttributeS
     }
 
     override fun onSetInitialValue(defaultValue: Any?) {
-        value = defaultValue as String?
+        value = getPersistedString(null) ?: defaultValue as String?
         updateSummary()
     }
 


### PR DESCRIPTION
Load the set value to correctly initialize the preference.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>