### PR TITLE
Fix crash when reading invalid NFC tag

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -264,7 +264,7 @@ class BackgroundTasksManager : BroadcastReceiver() {
         }
 
         fun enqueueNfcUpdateIfNeeded(context: Context, tag: NfcTag?) {
-            if (tag != null && tag.sitemap == null && tag.item != null && tag.state != null) {
+            if (tag?.item != null && tag.state != null && tag.sitemap == null) {
                 val value = if (tag.deviceId) {
                     val deviceId = context.getPrefs().getStringOrEmpty(PrefKeys.DEV_ID)
                     ItemUpdateWorker.ValueWithInfo(deviceId, deviceId)

--- a/mobile/src/main/java/org/openhab/habdroid/model/NfcTag.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/NfcTag.kt
@@ -36,7 +36,7 @@ data class NfcTag(
 }
 
 fun Uri.toTagData(): NfcTag? {
-    if (scheme != NfcTag.SCHEME) {
+    if (isOpaque || scheme != NfcTag.SCHEME) {
         return null
     }
     val item = if (NfcTag.DEPRECATED_QUERY_PARAMETER_ITEM_NAME in queryParameterNames)


### PR DESCRIPTION
````
Fatal Exception: java.lang.RuntimeException: Unable to start activity ComponentInfo{org.openhab.habdroid/org.openhab.habdroid.background.NfcReceiveActivity}: java.lang.UnsupportedOperationException: This isn't a hierarchical URI.
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3448)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3595)
       at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:83)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2147)
       at android.os.Handler.dispatchMessage(Handler.java:107)
       at android.os.Looper.loop(Looper.java:237)
       at android.app.ActivityThread.main(ActivityThread.java:7814)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1068)
Caused by java.lang.UnsupportedOperationException: This isn't a hierarchical URI.
       at android.net.Uri.getQueryParameterNames(Uri.java:1605)
       at org.openhab.habdroid.model.NfcTagKt.toTagData(NfcTag.kt:40)
       at org.openhab.habdroid.background.NfcReceiveActivity.onCreate(NfcReceiveActivity.kt:33)
       at android.app.Activity.performCreate(Activity.java:7955)
       at android.app.Activity.performCreate(Activity.java:7944)
       at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1307)
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3423)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3595)
       at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:83)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2147)
       at android.os.Handler.dispatchMessage(Handler.java:107)
       at android.os.Looper.loop(Looper.java:237)
       at android.app.ActivityThread.main(ActivityThread.java:7814)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1068)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>