### PR TITLE
Improve launch theme

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
         android:resizeableActivity="true"
         android:supportsPictureInPicture="false"
         android:supportsRtl="true"
-        android:theme="@style/openHAB.DayNight.orange">
+        android:theme="@style/openHAB.Launch">
         <activity
             android:name=".ui.PreferencesActivity"
             android:label="@string/app_preferences_name">

--- a/mobile/src/main/res/values-night/themes.xml
+++ b/mobile/src/main/res/values-night/themes.xml
@@ -8,4 +8,8 @@
         <item name="chartTheme">dark</item>
         <item name="valueColors">@array/valueColorsDarkBackground</item>
     </style>
+
+    <style name="openHAB.Launch" parent="openHAB.Base">
+        <item name="colorPrimaryDark">@android:color/background_dark</item>
+    </style>
 </resources>

--- a/mobile/src/main/res/values/themes.xml
+++ b/mobile/src/main/res/values/themes.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <style name="openHAB.Base" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
         <item name="windowActionBarOverlay">false</item>
         <item name="android:windowBackground">?android:colorBackground</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
     </style>
 
     <style name="openHAB.DayNight" parent="openHAB.Base">
@@ -14,6 +15,11 @@
 
         <item name="chartTheme">white</item>
         <item name="valueColors">@array/valueColorsBrightBackground</item>
+    </style>
+
+    <style name="openHAB.Launch" parent="openHAB.Base">
+        <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
+        <item name="colorPrimaryDark">@android:color/background_light</item>
     </style>
 
     <style name="openHAB.DayNight.orange" parent="openHAB.DayNight">


### PR DESCRIPTION
When the app is launched, the status bar is now white or black, based on
the day/night theme. After the MainActivity is loaded, the status bar
color is changed according to the configured theme.
Previously it was always orange during startup.
This change only applies to Android 10.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>