### PR TITLE
Improve success toast for toggle on switches

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
@@ -120,7 +120,7 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
                 if (showToast) {
                     val label = inputData.getString(INPUT_DATA_LABEL).orDefaultIfEmpty(itemName)
                     applicationContext.showToast(
-                        getItemUpdateSuccessMessage(applicationContext, label, value.value, actualMappedValue),
+                        getItemUpdateSuccessMessage(applicationContext, label, valueToBeSent, actualMappedValue),
                         ToastType.SUCCESS
                     )
                 }


### PR DESCRIPTION
Before the generic message "Item has been set to ON" was used
instead of the "on" message: "Item has been turned on".
This happened only for TOGGLE on switch items.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>