### PR TITLE
Hide dev id as state option if it would produce errors

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
@@ -164,7 +164,7 @@ abstract class AbstractItemPickerActivity : AbstractBaseActivity(), SwipeRefresh
             .map { entry -> CommandEntry(entry.command, entry.label) }
             .toMutableList()
 
-        addAdditionalCommands(entries)
+        addAdditionalCommands(suggestedCommands, entries)
 
         val labels = entries.map { entry -> entry.label }.toMutableList()
         if (suggestedCommands.shouldShowCustom) {
@@ -201,7 +201,10 @@ abstract class AbstractItemPickerActivity : AbstractBaseActivity(), SwipeRefresh
             .show()
     }
 
-    protected open fun addAdditionalCommands(entries: MutableList<CommandEntry>) {
+    protected open fun addAdditionalCommands(
+        suggestedCommands: SuggestedCommandsFactory.SuggestedCommands,
+        entries: MutableList<CommandEntry>
+    ) {
         // no-op
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/NfcItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/NfcItemPickerActivity.kt
@@ -19,6 +19,7 @@ import androidx.core.content.edit
 import org.openhab.habdroid.R
 import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.util.PrefKeys
+import org.openhab.habdroid.util.SuggestedCommandsFactory
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getStringOrEmpty
 import org.openhab.habdroid.util.wasNfcInfoHintShown
@@ -50,19 +51,22 @@ class NfcItemPickerActivity(
         }
     }
 
-    override fun addAdditionalCommands(entries: MutableList<CommandEntry>) {
+    override fun addAdditionalCommands(
+        suggestedCommands: SuggestedCommandsFactory.SuggestedCommands,
+        entries: MutableList<CommandEntry>
+    ) {
         val deviceId = getPrefs().getStringOrEmpty(PrefKeys.DEV_ID)
-        if (deviceId.isNotEmpty()) {
+        if (deviceId.isNotEmpty() && suggestedCommands.shouldShowCustom) {
             entries.add(CommandEntry(
                 deviceId,
                 getString(R.string.device_identifier_suggested_command_nfc_tag, deviceId),
-                "IsDeviceId"
+                "isDeviceId"
             ))
         }
     }
 
     override fun finish(item: Item, state: String, mappedState: String, tag: Any?) {
-        val deviceId = tag == "IsDeviceId"
+        val deviceId = tag == "isDeviceId"
         startActivity(WriteTagActivity.createItemUpdateIntent(
             this, item.name, state, mappedState, item.label, deviceId))
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/TaskerItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/TaskerItemPickerActivity.kt
@@ -24,6 +24,7 @@ import com.google.android.material.button.MaterialButton
 import org.openhab.habdroid.R
 import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.util.PrefKeys
+import org.openhab.habdroid.util.SuggestedCommandsFactory
 import org.openhab.habdroid.util.TaskerIntent
 import org.openhab.habdroid.util.TaskerPlugin
 import org.openhab.habdroid.util.getPrefs
@@ -78,7 +79,10 @@ class TaskerItemPickerActivity(
         }
     }
 
-    override fun addAdditionalCommands(entries: MutableList<CommandEntry>) {
+    override fun addAdditionalCommands(
+        suggestedCommands: SuggestedCommandsFactory.SuggestedCommands,
+        entries: MutableList<CommandEntry>
+    ) {
         relevantVars?.forEach {
             entries.add(CommandEntry(it, getString(R.string.item_picker_tasker_variable, it)))
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -239,7 +239,8 @@ class WidgetListFragment : Fragment(), WidgetAdapter.ItemClickListener,
                     val nfcMenu = menu.addSubMenu(Menu.NONE, CONTEXT_MENU_ID_WRITE_ITEM_TAG, Menu.NONE,
                         R.string.nfc_action_write_command_tag)
                     nfcMenu.setHeaderTitle(R.string.item_picker_dialog_title)
-                    populateStatesMenu(nfcMenu, context, suggestedCommands, true) { state, mappedState, itemId ->
+                    populateStatesMenu(nfcMenu, context, suggestedCommands, suggestedCommands.shouldShowCustom) {
+                            state, mappedState, itemId ->
                         startActivity(WriteTagActivity.createItemUpdateIntent(
                             context,
                             widget.item?.name ?: return@populateStatesMenu,
@@ -289,7 +290,8 @@ class WidgetListFragment : Fragment(), WidgetAdapter.ItemClickListener,
                 val nfcMenu = menu.addSubMenu(Menu.NONE, CONTEXT_MENU_ID_WRITE_ITEM_TAG, Menu.NONE,
                     R.string.nfc_action_write_command_tag)
                 nfcMenu.setHeaderTitle(R.string.item_picker_dialog_title)
-                populateStatesMenu(nfcMenu, context, suggestedCommands, true) { state, mappedState, itemId ->
+                populateStatesMenu(nfcMenu, context, suggestedCommands, suggestedCommands.shouldShowCustom) {
+                        state, mappedState, itemId ->
                     startActivity(WriteTagActivity.createItemUpdateIntent(
                         context,
                         widget.item?.name ?: return@populateStatesMenu,


### PR DESCRIPTION
E.g. when sending a string to a switch Item.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>