### PR TITLE
Fix crash when FcmMessageListenerService is started.

### DIFF
--- a/mobile/src/full/java/org/openhab/habdroid/core/FcmMessageListenerService.kt
+++ b/mobile/src/full/java/org/openhab/habdroid/core/FcmMessageListenerService.kt
@@ -20,7 +20,12 @@ import org.openhab.habdroid.model.CloudNotification
 import org.openhab.habdroid.model.toOH2IconResource
 
 class FcmMessageListenerService : FirebaseMessagingService() {
-    private val notifHelper = NotificationHelper(this)
+    private lateinit var notifHelper: NotificationHelper
+
+    override fun onCreate() {
+        super.onCreate()
+        notifHelper = NotificationHelper(this)
+    }
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)


### PR DESCRIPTION
NotificationHelper needs a fully initialized context, which in the case
of a Service means attach() was called, which in turn happens between
constructor and onCreate() invocation.

Closes #2044
