### PR TITLE
Always avoid cache when loading images that have refresh set.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/ChartActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ChartActivity.kt
@@ -73,8 +73,8 @@ class ChartActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListen
     override fun onResume() {
         super.onResume()
         loadChartImage(false)
-        if (widget.refresh > 0 && !isDataSaverActive()) {
-            chart.startRefreshing(widget.refresh)
+        if (!isDataSaverActive()) {
+            chart.startRefreshingIfNeeded()
         }
     }
 
@@ -174,7 +174,7 @@ class ChartActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListen
         ) ?: return
 
         Log.d(TAG, "Load chart with url $chartUrl")
-        chart.setImageUrl(connection, chartUrl, chart.width, forceLoad = force)
+        chart.setImageUrl(connection, chartUrl, chart.width, refreshDelayInMs = widget.refresh, forceLoad = force)
     }
 
     private fun updateHasLegendButtonState(item: MenuItem) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationAdapter.kt
@@ -113,7 +113,7 @@ class CloudNotificationAdapter(context: Context, private val loadMoreListener: (
                     conn,
                     notification.icon.toUrl(itemView.context, !itemView.context.isDataSaverActive()),
                     itemView.resources.getDimensionPixelSize(R.dimen.notificationlist_icon_size),
-                    2000
+                    timeoutMillis = 2000
                 )
             } else {
                 iconView.setImageResource(R.drawable.ic_openhab_appicon_24dp)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ItemPickerAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ItemPickerAdapter.kt
@@ -126,7 +126,7 @@ class ItemPickerAdapter(context: Context, private val itemClickListener: ItemCli
                     connection,
                     icon.toUrl(itemView.context, !itemView.context.isDataSaverActive()),
                     size,
-                    2000
+                    timeoutMillis = 2000
                 )
             } else {
                 iconView.setImageResource(R.drawable.ic_openhab_appicon_24dp)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -628,7 +628,6 @@ class WidgetAdapter(
                 imageView.maxHeight = Integer.MAX_VALUE
             }
 
-            @Suppress("LiftReturnOrAssignment")
             if (value != null && value.matches("data:image/.*;base64,.*".toRegex())) {
                 val dataString = value.substring(value.indexOf(",") + 1)
                 val data = Base64.decode(dataString, Base64.DEFAULT)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -611,7 +611,6 @@ class WidgetAdapter(
         connection: Connection
     ) : HeavyDataViewHolder(inflater, parent, R.layout.widgetlist_imageitem, connection) {
         private val imageView = widgetContentView as WidgetImageView
-        private var refreshRate: Int = 0
 
         override fun canBindWithoutDataTransfer(widget: Widget): Boolean {
             return widget.url == null ||
@@ -635,19 +634,16 @@ class WidgetAdapter(
                 val data = Base64.decode(dataString, Base64.DEFAULT)
                 val bitmap = BitmapFactory.decodeByteArray(data, 0, data.size)
                 imageView.setImageBitmap(bitmap)
-                refreshRate = 0
             } else if (widget.url != null) {
-                imageView.setImageUrl(connection, widget.url, parent.width)
-                refreshRate = widget.refresh
+                imageView.setImageUrl(connection, widget.url, parent.width, refreshDelayInMs = widget.refresh)
             } else {
                 imageView.setImageDrawable(null)
-                refreshRate = 0
             }
         }
 
         override fun onStart() {
-            if (refreshRate > 0 && !itemView.context.isDataSaverActive()) {
-                imageView.startRefreshing(refreshRate)
+            if (!itemView.context.isDataSaverActive()) {
+                imageView.startRefreshingIfNeeded()
             } else {
                 imageView.cancelRefresh()
             }
@@ -906,7 +902,6 @@ class WidgetAdapter(
     ) : HeavyDataViewHolder(inflater, parent, R.layout.widgetlist_chartitem, connection), View.OnClickListener {
         private val chart = widgetContentView as WidgetImageView
         private val prefs: SharedPreferences
-        private var refreshRate = 0
         private val density: Int
 
         init {
@@ -924,20 +919,18 @@ class WidgetAdapter(
             if (item == null) {
                 Log.e(TAG, "Chart item is null")
                 chart.setImageDrawable(null)
-                refreshRate = 0
                 return
             }
 
             val chartUrl =
                 widget.toChartUrl(prefs, parent.width, chartTheme = chartTheme, density = density) ?: return
             Log.d(TAG, "Chart url = $chartUrl")
-            chart.setImageUrl(connection, chartUrl, parent.width, forceLoad = true)
-            refreshRate = widget.refresh
+            chart.setImageUrl(connection, chartUrl, parent.width, refreshDelayInMs = widget.refresh, forceLoad = true)
         }
 
         override fun onStart() {
-            if (refreshRate > 0 && !itemView.context.isDataSaverActive()) {
-                chart.startRefreshing(refreshRate)
+            if (!itemView.context.isDataSaverActive()) {
+                chart.startRefreshingIfNeeded()
             } else {
                 chart.cancelRefresh()
             }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.kt
@@ -66,12 +66,15 @@ class WidgetImageView constructor(context: Context, attrs: AttributeSet?) : AppC
         connection: Connection,
         url: String,
         size: Int?,
+        refreshDelayInMs: Int = 0,
         timeoutMillis: Long = HttpClient.DEFAULT_TIMEOUT_MS,
         forceLoad: Boolean = false
     ) {
         val actualSize = size ?: defaultSvgSize
         val client = connection.httpClient
         val actualUrl = client.buildUrl(url)
+
+        refreshInterval = refreshDelayInMs.toLong()
 
         if (actualUrl == lastRequest?.url) {
             if (lastRequest?.isActive() == true) {
@@ -100,25 +103,19 @@ class WidgetImageView constructor(context: Context, attrs: AttributeSet?) : AppC
     }
 
     override fun setImageResource(resId: Int) {
-        cancelCurrentLoad()
-        lastRequest = null
-        removeProgressDrawable()
+        prepareForNonHttpImage()
         super.setImageResource(resId)
     }
 
     override fun setImageDrawable(drawable: Drawable?) {
         if (!internalLoad) {
-            cancelCurrentLoad()
-            lastRequest = null
-            removeProgressDrawable()
+            prepareForNonHttpImage()
         }
         super.setImageDrawable(drawable)
     }
 
     override fun setImageBitmap(bm: Bitmap?) {
-        cancelCurrentLoad()
-        lastRequest = null
-        removeProgressDrawable()
+        prepareForNonHttpImage()
         super.setImageBitmap(bm)
     }
 
@@ -146,7 +143,9 @@ class WidgetImageView constructor(context: Context, attrs: AttributeSet?) : AppC
         scope = CoroutineScope(Dispatchers.Main + Job())
         lastRequest?.let { request ->
             if (!request.hasCompleted()) {
-                request.execute(false)
+                // Make sure to have an up-to-date image if refresh is enabled (when avoiding cache in that case,
+                // we'll always load a stale image from cache until first refresh otherwise)
+                request.execute(refreshInterval != 0L)
             } else {
                 scheduleNextRefresh()
             }
@@ -159,10 +158,9 @@ class WidgetImageView constructor(context: Context, attrs: AttributeSet?) : AppC
         scope = null
     }
 
-    fun startRefreshing(refreshDelayInMs: Int) {
+    fun startRefreshingIfNeeded() {
         refreshJob?.cancel()
         refreshJob = null
-        refreshInterval = refreshDelayInMs.toLong()
         if (lastRequest?.isActive() != true) {
             scheduleNextRefresh()
         }
@@ -171,8 +169,15 @@ class WidgetImageView constructor(context: Context, attrs: AttributeSet?) : AppC
     fun cancelRefresh() {
         refreshJob?.cancel()
         refreshJob = null
-        refreshInterval = 0
         lastRefreshTimestamp = 0
+    }
+
+    private fun prepareForNonHttpImage() {
+        cancelCurrentLoad()
+        cancelRefresh()
+        lastRequest = null
+        refreshInterval = 0
+        removeProgressDrawable()
     }
 
     private fun setBitmapInternal(bitmap: Bitmap) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.kt
@@ -143,8 +143,8 @@ class WidgetImageView constructor(context: Context, attrs: AttributeSet?) : AppC
         scope = CoroutineScope(Dispatchers.Main + Job())
         lastRequest?.let { request ->
             if (!request.hasCompleted()) {
-                // Make sure to have an up-to-date image if refresh is enabled (when avoiding cache in that case,
-                // we'll always load a stale image from cache until first refresh otherwise)
+                // Make sure to have an up-to-date image if refresh is enabled by avoiding cache in that case
+                // (when not doing so, we'd always load a stale image from cache until first refresh)
                 request.execute(refreshInterval != 0L)
             } else {
                 scheduleNextRefresh()


### PR DESCRIPTION
We already avoided the cache for the actual refresh, but not for the
initial load triggered via onAttachedToWindow(). Since we need the
information whether refresh is enabled in that method, but the actual
sequence of calls is setImageUrl() -> onAttachedToWindow() ->
startRefreshing(), move the refresh interval setter to setImageUrl(), so
we have the interval available in onAttachedToWindow().

Closes #2066