### PR TITLE
Fix TOGGLE on color items

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
@@ -145,6 +145,8 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : Worker(cont
         return if (item.isOfTypeOrGroupType(Item.Type.Rollershutter) || item.isOfTypeOrGroupType(Item.Type.Dimmer)) {
             // If shutter is (partially) closed, open it, else close it
             if (item.state?.asNumber?.value == 0F) "100" else "0"
+        } else if (item.isOfTypeOrGroupType(Item.Type.Color)) {
+            if (item.state?.asBrightness == 0) "100" else "0"
         } else if (item.isOfTypeOrGroupType(Item.Type.Contact)) {
             if (item.state?.asString == "OPEN") "CLOSED" else "OPEN"
         } else if (item.isOfTypeOrGroupType(Item.Type.Player)) {


### PR DESCRIPTION
Without this commit the following commands where send, when a toggle
action was used on a turned off color bulb:
1. ON (Light was turned on)
2. ON (Nothing happened)
3. OFF (Light was turned off)

Now it sends:
1. 100
2. 0

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>