### PR TITLE
Queue snackbars instead of hiding the previous one

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -963,17 +963,14 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         }
         snackbar.view.tag = tag
         snackbar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
-             override fun onShown(transientBottomBar: Snackbar?) {
+            override fun onShown(transientBottomBar: Snackbar?) {
                 super.onShown(transientBottomBar)
                 Log.d(TAG, "Show snackbar with tag $tag")
             }
 
             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
                 super.onDismissed(transientBottomBar, event)
-                if (event != Snackbar.Callback.DISMISS_EVENT_ACTION) {
-                    showNextSnackbar()
-                }
-
+                showNextSnackbar()
             }
         })
         hideSnackbar(tag)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -125,7 +125,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
     private var progressBar: ContentLoadingProgressBar? = null
     private var sitemapSelectionDialog: AlertDialog? = null
     private var lastSnackbar: Snackbar? = null
-    private var snackbarQueue = ArrayList<Snackbar>()
+    private var snackbarQueue = mutableListOf<Snackbar>()
     var connection: Connection? = null
         private set
 
@@ -984,18 +984,15 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
             Log.d(TAG, "No next snackbar to show")
             return
         }
-        val nextSnackbar = snackbarQueue[0]
-        snackbarQueue.removeAt(0)
+        val nextSnackbar = snackbarQueue.removeAt(0)
         nextSnackbar.show()
         lastSnackbar = nextSnackbar
     }
 
     private fun hideSnackbar(tag: String) {
-        snackbarQueue.forEachIndexed { index, snackbar ->
-            if (snackbar.view.tag == tag) {
-                Log.d(TAG, "Remove snackbar with tag $tag from queue")
-                snackbarQueue.removeAt(index)
-            }
+        snackbarQueue.firstOrNull { it.view.tag == tag }?.let { snackbar ->
+            Log.d(TAG, "Remove snackbar with tag $tag from queue")
+            snackbarQueue.remove(snackbar)
         }
         if (lastSnackbar?.view?.tag == tag) {
             Log.d(TAG, "Hide snackbar with tag $tag")

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
@@ -448,7 +448,7 @@ abstract class ContentController protected constructor(private val activity: Mai
     }
 
     override fun onSseFailure() {
-        activity.showSnackbar(R.string.error_sse_failed)
+        activity.showSnackbar(R.string.error_sse_failed, tag = MainActivity.TAG_SNACKBAR_SSE_ERROR)
     }
 
     internal abstract fun executeStateUpdate(reason: FragmentUpdateReason, allowStateLoss: Boolean)


### PR DESCRIPTION
We might show multiple snackbars on launch, e.g. "Connected to local
server" and a warning that the app doesn't have the permissions for all
active background tasks.
Instead of hiding the previous snackbar when showing a new one, queue
the new one.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>