### PR TITLE
Scale down image used in widgets

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/ViewExtensions.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ViewExtensions.kt
@@ -16,12 +16,12 @@ package org.openhab.habdroid.ui
 import android.content.Intent
 import android.os.Build
 import android.os.Message
-import android.util.TypedValue
 import android.view.View
 import android.webkit.WebChromeClient
 import android.webkit.WebView
 import android.webkit.WebViewDatabase
 import android.widget.ImageView
+import android.widget.RemoteViews
 import androidx.annotation.AttrRes
 import androidx.appcompat.widget.TooltipCompat
 import androidx.core.graphics.drawable.DrawableCompat
@@ -97,5 +97,14 @@ fun View.playPressAnimationAndCallBack(postAnimationCallback: () -> Unit) {
         isPressed = true
         isPressed = false
         postAnimationCallback()
+    }
+}
+
+fun RemoteViews.duplicate(): RemoteViews {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        RemoteViews(this)
+    } else {
+        @Suppress("DEPRECATION")
+        clone()
     }
 }


### PR DESCRIPTION
I checked a few devices and each one had its own bitmap size limits,
so I implemented this dynamic approach.

Fixes #2053

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>