### PR TITLE
Fix crash in event listener

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/BroadcastEventListenerService.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BroadcastEventListenerService.kt
@@ -64,8 +64,8 @@ class BroadcastEventListenerService : Service() {
                 getPrefs().isItemUpdatePrefEnabled(PrefKeys.SEND_DND_MODE) -> {
                 getString(R.string.send_device_info_foreground_service_running_summary_dnd)
             }
-            Build.VERSION.SDK_INT < Build.VERSION_CODES.O -> return
-            titlesOfItems.isEmpty() -> return
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.O -> null
+            titlesOfItems.isEmpty() -> null
             titlesOfItems.size == 1 -> {
                 getString(R.string.send_device_info_foreground_service_running_summary_one, titlesOfItems[0])
             }


### PR DESCRIPTION
````
Fatal Exception: android.app.RemoteServiceException: Context.startForegroundService() did not then call Service.startForeground(): ServiceRecord{7c9a704 u0 org.openhab.habdroid.beta/org.openhab.habdroid.background.BroadcastEventListenerService}
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2010)
       at android.os.Handler.dispatchMessage(Handler.java:107)
       at android.os.Looper.loop(Looper.java:214)
       at android.app.ActivityThread.main(ActivityThread.java:7643)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:516)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>