### PR TITLE
Support battery saver

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/NotificationHelper.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/NotificationHelper.kt
@@ -33,10 +33,10 @@ import org.openhab.habdroid.model.CloudNotification
 import org.openhab.habdroid.ui.MainActivity
 import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.ImageConversionPolicy
+import org.openhab.habdroid.util.determineDataUsagePolicy
 import org.openhab.habdroid.util.getNotificationTone
 import org.openhab.habdroid.util.getNotificationVibrationPattern
 import org.openhab.habdroid.util.getPrefs
-import org.openhab.habdroid.util.isDataSaverActive
 
 class NotificationHelper constructor(private val context: Context) {
     private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -124,7 +124,7 @@ class NotificationHelper constructor(private val context: Context) {
 
         if (message.icon != null) {
             val connection = ConnectionFactory.cloudConnectionOrNull
-            if (connection != null && !context.isDataSaverActive()) {
+            if (connection != null && context.determineDataUsagePolicy().canDoLargeTransfers) {
                 try {
                     val targetSize = context.resources.getDimensionPixelSize(R.dimen.notificationlist_icon_size)
                     iconBitmap = connection.httpClient

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ChartActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ChartActivity.kt
@@ -29,10 +29,9 @@ import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.model.Widget
 import org.openhab.habdroid.ui.widget.WidgetImageView
 import org.openhab.habdroid.util.ScreenLockMode
+import org.openhab.habdroid.util.determineDataUsagePolicy
 import org.openhab.habdroid.util.getPrefs
-import org.openhab.habdroid.util.isDataSaverActive
 import org.openhab.habdroid.util.orDefaultIfEmpty
-import java.util.Random
 
 class ChartActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListener {
     private lateinit var swipeLayout: SwipeRefreshLayout
@@ -73,7 +72,7 @@ class ChartActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListen
     override fun onResume() {
         super.onResume()
         loadChartImage(false)
-        if (!isDataSaverActive()) {
+        if (determineDataUsagePolicy().canDoRefreshes) {
             chart.startRefreshingIfNeeded()
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationAdapter.kt
@@ -25,7 +25,7 @@ import org.openhab.habdroid.R
 import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.model.CloudNotification
 import org.openhab.habdroid.ui.widget.WidgetImageView
-import org.openhab.habdroid.util.isDataSaverActive
+import org.openhab.habdroid.util.determineDataUsagePolicy
 import java.util.ArrayList
 
 class CloudNotificationAdapter(context: Context, private val loadMoreListener: () -> Unit) :
@@ -111,7 +111,8 @@ class CloudNotificationAdapter(context: Context, private val loadMoreListener: (
             if (notification.icon != null && conn != null) {
                 iconView.setImageUrl(
                     conn,
-                    notification.icon.toUrl(itemView.context, !itemView.context.isDataSaverActive()),
+                    notification.icon.toUrl(itemView.context,
+                        itemView.context.determineDataUsagePolicy().canDoLargeTransfers),
                     timeoutMillis = 2000
                 )
             } else {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationAdapter.kt
@@ -21,12 +21,12 @@ import android.widget.TextView
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
+import java.util.ArrayList
 import org.openhab.habdroid.R
 import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.model.CloudNotification
 import org.openhab.habdroid.ui.widget.WidgetImageView
 import org.openhab.habdroid.util.determineDataUsagePolicy
-import java.util.ArrayList
 
 class CloudNotificationAdapter(context: Context, private val loadMoreListener: () -> Unit) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
@@ -111,8 +111,10 @@ class CloudNotificationAdapter(context: Context, private val loadMoreListener: (
             if (notification.icon != null && conn != null) {
                 iconView.setImageUrl(
                     conn,
-                    notification.icon.toUrl(itemView.context,
-                        itemView.context.determineDataUsagePolicy().loadIconsWithState),
+                    notification.icon.toUrl(
+                        itemView.context,
+                        itemView.context.determineDataUsagePolicy().loadIconsWithState
+                    ),
                     timeoutMillis = 2000
                 )
             } else {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationAdapter.kt
@@ -112,7 +112,7 @@ class CloudNotificationAdapter(context: Context, private val loadMoreListener: (
                 iconView.setImageUrl(
                     conn,
                     notification.icon.toUrl(itemView.context,
-                        itemView.context.determineDataUsagePolicy().canDoLargeTransfers),
+                        itemView.context.determineDataUsagePolicy().loadIconsWithState),
                     timeoutMillis = 2000
                 )
             } else {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ItemPickerAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ItemPickerAdapter.kt
@@ -123,7 +123,7 @@ class ItemPickerAdapter(context: Context, private val itemClickListener: ItemCli
             if (icon != null && connection != null) {
                 iconView.setImageUrl(
                     connection,
-                    icon.toUrl(itemView.context, itemView.context.determineDataUsagePolicy().canDoLargeTransfers),
+                    icon.toUrl(itemView.context, itemView.context.determineDataUsagePolicy().loadIconsWithState),
                     timeoutMillis = 2000
                 )
             } else {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ItemPickerAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ItemPickerAdapter.kt
@@ -24,7 +24,7 @@ import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.model.toOH2IconResource
 import org.openhab.habdroid.ui.widget.WidgetImageView
-import org.openhab.habdroid.util.isDataSaverActive
+import org.openhab.habdroid.util.determineDataUsagePolicy
 import java.util.ArrayList
 import java.util.Comparator
 import java.util.Locale
@@ -123,7 +123,7 @@ class ItemPickerAdapter(context: Context, private val itemClickListener: ItemCli
             if (icon != null && connection != null) {
                 iconView.setImageUrl(
                     connection,
-                    icon.toUrl(itemView.context, !itemView.context.isDataSaverActive()),
+                    icon.toUrl(itemView.context, itemView.context.determineDataUsagePolicy().canDoLargeTransfers),
                     timeoutMillis = 2000
                 )
             } else {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/LogActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/LogActivity.kt
@@ -25,6 +25,8 @@ import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import java.io.BufferedReader
+import java.io.InputStreamReader
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -37,8 +39,6 @@ import org.openhab.habdroid.util.getLocalUrl
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getRemoteUrl
 import org.openhab.habdroid.util.showToast
-import java.io.BufferedReader
-import java.io.InputStreamReader
 
 class LogActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListener {
     private lateinit var logTextView: TextView

--- a/mobile/src/main/java/org/openhab/habdroid/ui/LogActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/LogActivity.kt
@@ -30,7 +30,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.openhab.habdroid.R
+import org.openhab.habdroid.core.OpenHabApplication
 import org.openhab.habdroid.util.ToastType
+import org.openhab.habdroid.util.determineDataUsagePolicy
 import org.openhab.habdroid.util.getLocalUrl
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getRemoteUrl
@@ -205,7 +207,10 @@ class LogActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListener
             "Product: ${Build.PRODUCT}\n" +
             "OS: ${Build.VERSION.RELEASE}\n" +
             "Display: ${displayMetrics.widthPixels}x${displayMetrics.heightPixels}, " +
-                "${displayMetrics.density} density\n"
+                "${displayMetrics.density} density\n" +
+            "Data usage policy: ${determineDataUsagePolicy()}, " +
+                "data saver: ${(applicationContext as OpenHabApplication).systemDataSaverStatus}, " +
+                "battery saver: ${(applicationContext as OpenHabApplication).batterySaverActive}\n"
     }
 
     private fun redactHost(text: String, url: String?, replacement: String): String {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -777,8 +777,9 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         }
         launch {
             try {
-                item.icon = conn.httpClient.get(sitemap.icon.toUrl(this@MainActivity,
-                    determineDataUsagePolicy().loadIconsWithState))
+                item.icon = conn.httpClient.get(
+                    sitemap.icon.toUrl(this@MainActivity, determineDataUsagePolicy().loadIconsWithState)
+                )
                     .asBitmap(defaultIcon!!.intrinsicWidth, ImageConversionPolicy.ForceTargetSize)
                     .response
                     .toDrawable(resources)
@@ -957,7 +958,8 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
 
     fun showDataSaverHintSnackbarIfNeeded() {
         if (prefs.getBoolean(PrefKeys.DATA_SAVER_EXPLAINED, false) ||
-            determineDataUsagePolicy().loadIconsWithState) {
+            determineDataUsagePolicy().loadIconsWithState
+        ) {
             return
         }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -100,12 +100,12 @@ import org.openhab.habdroid.util.RemoteLog
 import org.openhab.habdroid.util.ScreenLockMode
 import org.openhab.habdroid.util.Util
 import org.openhab.habdroid.util.areSitemapsShownInDrawer
+import org.openhab.habdroid.util.determineDataUsagePolicy
 import org.openhab.habdroid.util.getDefaultSitemap
 import org.openhab.habdroid.util.getHumanReadableErrorMessage
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getStringOrNull
 import org.openhab.habdroid.util.hasPermissions
-import org.openhab.habdroid.util.isDataSaverActive
 import org.openhab.habdroid.util.isDebugModeEnabled
 import org.openhab.habdroid.util.isEventListenerEnabled
 import org.openhab.habdroid.util.isResolvable
@@ -777,7 +777,8 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         }
         launch {
             try {
-                item.icon = conn.httpClient.get(sitemap.icon.toUrl(this@MainActivity, !isDataSaverActive()))
+                item.icon = conn.httpClient.get(sitemap.icon.toUrl(this@MainActivity,
+                    determineDataUsagePolicy().canDoLargeTransfers))
                     .asBitmap(defaultIcon!!.intrinsicWidth, ImageConversionPolicy.ForceTargetSize)
                     .response
                     .toDrawable(resources)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -778,7 +778,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         launch {
             try {
                 item.icon = conn.httpClient.get(sitemap.icon.toUrl(this@MainActivity,
-                    determineDataUsagePolicy().canDoLargeTransfers))
+                    determineDataUsagePolicy().loadIconsWithState))
                     .asBitmap(defaultIcon!!.intrinsicWidth, ImageConversionPolicy.ForceTargetSize)
                     .response
                     .toDrawable(resources)
@@ -956,7 +956,8 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
     }
 
     fun showDataSaverHintSnackbarIfNeeded() {
-        if (prefs.getBoolean(PrefKeys.DATA_SAVER_EXPLAINED, false) || !isDataSaverActive()) {
+        if (prefs.getBoolean(PrefKeys.DATA_SAVER_EXPLAINED, false) ||
+            determineDataUsagePolicy().loadIconsWithState) {
             return
         }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -988,7 +988,8 @@ class WidgetAdapter(
         }
 
         override fun onStart() {
-            if (exoPlayer.playbackState != Player.STATE_IDLE) {
+            if (itemView.context.determineDataUsagePolicy().autoPlayVideos &&
+                exoPlayer.playbackState != Player.STATE_IDLE) {
                 exoPlayer.playWhenReady = true
             }
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -97,9 +97,9 @@ import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.MjpegStreamer
 import org.openhab.habdroid.util.beautify
 import org.openhab.habdroid.util.determineDataUsagePolicy
+import org.openhab.habdroid.util.getImageWidgetScalingType
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.orDefaultIfEmpty
-import org.openhab.habdroid.util.getImageWidgetScalingType
 
 /**
  * This class provides openHAB widgets adapter for list view.
@@ -990,7 +990,8 @@ class WidgetAdapter(
 
         override fun onStart() {
             if (itemView.context.determineDataUsagePolicy().autoPlayVideos &&
-                exoPlayer.playbackState != Player.STATE_IDLE) {
+                exoPlayer.playbackState != Player.STATE_IDLE
+            ) {
                 exoPlayer.playWhenReady = true
             }
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -1450,7 +1450,7 @@ fun WidgetImageView.loadWidgetIcon(connection: Connection, widget: Widget, mappe
     }
     setImageUrl(
         connection,
-        widget.icon.toUrl(context, context.determineDataUsagePolicy().canDoLargeTransfers)
+        widget.icon.toUrl(context, context.determineDataUsagePolicy().loadIconsWithState)
     )
     val color = mapper.mapColor(widget.iconColor)
     if (color != null) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -388,7 +388,8 @@ class WidgetAdapter(
         }
 
         private fun showDataSaverPlaceholderIfNeeded(widget: Widget, canBindWithoutData: Boolean): Boolean {
-            val dataSaverActive = !itemView.context.determineDataUsagePolicy().canDoLargeTransfers && !canBindWithoutData
+            val dataSaverActive = !itemView.context.determineDataUsagePolicy().canDoLargeTransfers &&
+                !canBindWithoutData
 
             dataSaverView.isVisible = dataSaverActive
             widgetContentView.isVisible = !dataSaverView.isVisible

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -58,6 +58,7 @@ import org.openhab.habdroid.ui.homescreenwidget.ItemUpdateWidget
 import org.openhab.habdroid.ui.widget.ContextMenuAwareRecyclerView
 import org.openhab.habdroid.ui.widget.RecyclerViewSwipeRefreshLayout
 import org.openhab.habdroid.util.CacheManager
+import org.openhab.habdroid.util.DataUsagePolicy
 import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.ImageConversionPolicy
 import org.openhab.habdroid.util.PrefKeys
@@ -76,7 +77,7 @@ import org.openhab.habdroid.util.showToast
  */
 
 class WidgetListFragment : Fragment(), WidgetAdapter.ItemClickListener,
-    OpenHabApplication.OnDataSaverActiveStateChangedListener {
+    OpenHabApplication.OnDataUsagePolicyChangedListener {
     @VisibleForTesting lateinit var recyclerView: RecyclerView
     private lateinit var refreshLayout: RecyclerViewSwipeRefreshLayout
     private lateinit var emptyPageView: View
@@ -167,15 +168,15 @@ class WidgetListFragment : Fragment(), WidgetAdapter.ItemClickListener,
         startOrStopVisibleViewHolders(false)
     }
 
-    override fun onSystemDataSaverActiveStateChanged(active: Boolean) {
+    override fun onDataUsagePolicyChanged(newPolicy: DataUsagePolicy) {
         val firstVisibleItemPosition = layoutManager.findFirstVisibleItemPosition()
         val lastVisibleItemPosition = layoutManager.findLastVisibleItemPosition()
         for (i in firstVisibleItemPosition..lastVisibleItemPosition) {
             val holder = recyclerView.findViewHolderForAdapterPosition(i)
             if (holder is WidgetAdapter.HeavyDataViewHolder) {
-                holder.handleDataSaverChange(active)
+                holder.handleDataUsagePolicyChange(newPolicy)
             } else if (holder is WidgetAdapter.AbstractMapViewHolder) {
-                holder.handleDataSaverChange()
+                holder.handleDataUsagePolicyChange()
             }
         }
         (activity as MainActivity?)?.showDataSaverHintSnackbarIfNeeded()

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -352,12 +352,18 @@ fun Context.openInAppStore(app: String) {
     }
 }
 
-data class DataUsagePolicy(val canDoLargeTransfers: Boolean, val autoPlayVideos: Boolean, val canDoRefreshes: Boolean)
+data class DataUsagePolicy(
+    val canDoLargeTransfers: Boolean,
+    val loadIconsWithState: Boolean,
+    val autoPlayVideos: Boolean,
+    val canDoRefreshes: Boolean
+)
 
 fun Context.determineDataUsagePolicy(): DataUsagePolicy {
     val isBatterySaverActive = (applicationContext as OpenHabApplication).batterySaverActive
     fun getDataUsagePolicyForBatterySaver() = DataUsagePolicy(
         canDoLargeTransfers = true,
+        loadIconsWithState = true,
         autoPlayVideos = false,
         canDoRefreshes = false
     )
@@ -367,12 +373,13 @@ fun Context.determineDataUsagePolicy(): DataUsagePolicy {
         return if (isBatterySaverActive) {
             getDataUsagePolicyForBatterySaver()
         } else {
-            DataUsagePolicy(!dataSaverPref, !dataSaverPref, !dataSaverPref)
+            DataUsagePolicy(!dataSaverPref, !dataSaverPref, !dataSaverPref, !dataSaverPref)
         }
     }
     return when ((applicationContext as OpenHabApplication).systemDataSaverStatus) {
         ConnectivityManager.RESTRICT_BACKGROUND_STATUS_ENABLED -> DataUsagePolicy(
             canDoLargeTransfers = false,
+            loadIconsWithState = false,
             autoPlayVideos = false,
             canDoRefreshes = false
         )
@@ -382,6 +389,7 @@ fun Context.determineDataUsagePolicy(): DataUsagePolicy {
             } else {
                 DataUsagePolicy(
                     canDoLargeTransfers = true,
+                    loadIconsWithState = true,
                     autoPlayVideos = false,
                     canDoRefreshes = true
                 )
@@ -393,6 +401,7 @@ fun Context.determineDataUsagePolicy(): DataUsagePolicy {
             } else {
                 DataUsagePolicy(
                     canDoLargeTransfers = true,
+                    loadIconsWithState = true,
                     autoPlayVideos = true,
                     canDoRefreshes = true
                 )

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -370,7 +370,7 @@ fun Context.determineDataUsagePolicy(): DataUsagePolicy {
             DataUsagePolicy(!dataSaverPref, !dataSaverPref, !dataSaverPref)
         }
     }
-    return when((applicationContext as OpenHabApplication).systemDataSaverStatus) {
+    return when ((applicationContext as OpenHabApplication).systemDataSaverStatus) {
         ConnectivityManager.RESTRICT_BACKGROUND_STATUS_ENABLED -> DataUsagePolicy(
             canDoLargeTransfers = false,
             autoPlayVideos = false,

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -516,7 +516,7 @@
     <string name="data_saver_off">The system wide data saver setting is followed when loading data-using sitemap elements</string>
     <string name="data_saver_off_pre_n">All sitemap elements are loaded, disregarding their data usage</string>
     <string name="data_saver_load">Load anyway</string>
-    <string name="data_saver_hint">%s was not loaded to save data and battery</string>
+    <string name="data_saver_hint">%s was not loaded to save data</string>
     <string name="data_saver_snackbar">Icons aren\'t based on Item states, because data saver is turned on</string>
     <string name="widget_type_image">Image</string>
     <string name="widget_type_webview">WebView</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -516,7 +516,7 @@
     <string name="data_saver_off">The system wide data saver setting is followed when loading data-using sitemap elements</string>
     <string name="data_saver_off_pre_n">All sitemap elements are loaded, disregarding their data usage</string>
     <string name="data_saver_load">Load anyway</string>
-    <string name="data_saver_hint">%s was not loaded to save data</string>
+    <string name="data_saver_hint">%s was not loaded to save data and battery</string>
     <string name="data_saver_snackbar">Icons aren\'t based on Item states, because data saver is turned on</string>
     <string name="widget_type_image">Image</string>
     <string name="widget_type_webview">WebView</string>


### PR DESCRIPTION
Fixes #1898

Also avoid auto playing videos when data saver is on and the app is whitelisted.

> Conversely, to work well with Data Saver, apps should not: [...] Treat whitelisting as a license to use more bandwidth

https://source.android.com/devices/tech/connect/data-saver?hl=en