### PR TITLE
Display correct sitemap name in drawer

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -850,9 +850,9 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
             } else if (result != null && (configuredSitemap.isEmpty() || configuredSitemap != result.name)) {
                 // update result
                 updateDefaultSitemap(result, connection)
-                updateSitemapAndHabPanelDrawerItems()
             }
         }
+        updateSitemapAndHabPanelDrawerItems()
 
         return result
     }


### PR DESCRIPTION
When connecting the first time to a new server or after clearing the default sitemap,
a sitemap is automatically selected, if it's the only one.
`updateDefaultSitemap()` was called, but before saving the default
sitemap to prefs, `updateSitemapAndHabPanelDrawerItems()` was called and
changed the drawer state to "no default sitemap selected".

Fix this by moving `updateSitemapAndHabPanelDrawerItems()` out of
`prefs.edit{}`.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>