### PR TITLE
Increase size of video error hint

### DIFF
--- a/mobile/src/main/res/layout/widgetlist_videoitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_videoitem.xml
@@ -10,7 +10,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         style="?attr/indeterminateProgressStyle"
-        android:padding="8dp"
+        android:padding="32dp"
         android:layout_gravity="center"
         android:visibility="gone"
         tools:visibility="visible" />
@@ -30,7 +30,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:padding="16dp"
+        android:padding="32dp"
         android:orientation="vertical"
         android:visibility="gone"
         tools:visibility="visible">


### PR DESCRIPTION
With this commit the widget list is less "jumping" around when the video widget
changes between loading and error or showing.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>