### PR TITLE
Fix myopenhab access for oh 3

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/ServerProperties.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ServerProperties.kt
@@ -103,7 +103,7 @@ data class ServerProperties(val flags: Int, val sitemaps: List<Sitemap>) : Parce
         ) {
             handle.job = handle.scope.launch {
                 try {
-                    val result = client.get("rest").asText()
+                    val result = client.get("rest/").asText()
                     try {
                         val resultJson = JSONObject(result.response)
                         // If this succeeded, we're talking to OH2


### PR DESCRIPTION
Fixes #2145

The connection is still working for openHAB 2.5. I'm using
"https://myopenhab.org" as remote address.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>