### PR TITLE
Fix divider not showing when there're invible widgets

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -1340,11 +1340,6 @@ class WidgetAdapter(
                         return true
                     }
                 }
-                if (adapter.getItemViewType(position) == TYPE_INVISIBLE &&
-                    adapter.getItemViewType(position + 1) == TYPE_INVISIBLE
-                ) {
-                    return true
-                }
             }
 
             return false

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -1331,15 +1331,19 @@ class WidgetAdapter(
 
             // hide dividers before and after frame widgets
             val adapter = parent.adapter
-            val noDividerTypes = intArrayOf(TYPE_FRAME, TYPE_INVISIBLE)
             if (adapter != null) {
-                if (adapter.getItemViewType(position) in noDividerTypes) {
+                if (adapter.getItemViewType(position) == TYPE_FRAME) {
                     return true
                 }
                 if (position < adapter.itemCount - 1) {
-                    if (adapter.getItemViewType(position + 1) in noDividerTypes) {
+                    if (adapter.getItemViewType(position + 1) in intArrayOf(TYPE_FRAME, TYPE_INVISIBLE)) {
                         return true
                     }
+                }
+                if (adapter.getItemViewType(position) == TYPE_INVISIBLE &&
+                    adapter.getItemViewType(position + 1) == TYPE_INVISIBLE
+                ) {
+                    return true
                 }
             }
 


### PR DESCRIPTION
https://community.openhab.org/t/not-always-lines-under-items-on-sitemap-openhab-app/103961