### PR TITLE
Support long pressing the rollershutter buttons

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -30,6 +30,7 @@ import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
+import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.view.WindowManager
 import android.webkit.WebView
@@ -809,7 +810,7 @@ class WidgetAdapter(
             when (motionEvent.actionMasked) {
                 MotionEvent.ACTION_UP -> {
                     val pressedTime = motionEvent.eventTime - motionEvent.downTime
-                    if (pressedTime > 500 && v.tag != "STOP") {
+                    if (pressedTime > ViewConfiguration.getLongPressTimeout() && v.tag != "STOP") {
                         connection.httpClient.sendItemCommand(boundItem, "STOP")
                     }
                 }


### PR DESCRIPTION
Send STOP when the button is released after a long press.

Fixes #679

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>