### PR TITLE
Add long press action to copy item name

### DIFF
--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -137,6 +137,8 @@
     <string name="app_shortcut_disabled_notifications">Your remote server isn\'t available</string>
     <string name="app_shortcut_disabled_voice_recognition">Your device doesn\'t have a voice recognition app installed</string>
     <string name="no_position_set">No position set</string>
+    <string name="show_and_copy_item_name">Show and copy Item name</string>
+    <string name="copied_item_name">Copied \"%s\"</string>
 
     <!-- Error messages -->
     <string name="error_empty_sitemap_list">openHAB returned empty Sitemap list</string>


### PR DESCRIPTION
Sometimes it's useful to quickly get the name of an Item, e.g. when configuring quick tiles or Tasker. This new long press action also allows some code cleanup, because "Create widget" now never appears as the only action.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>