### PR TITLE
Upgrade to the Firebase Crashlytics SDK

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -11,16 +11,13 @@ buildscript {
     ext.exoplayer_version = '2.11.8'
 
     repositories {
-        maven {
-            url "https://maven.fabric.io/public"
-        }
         mavenCentral()
         google()
         jcenter()
     }
     dependencies {
         classpath "com.google.gms:google-services:4.3.3"
-        classpath "io.fabric.tools:gradle:1.31.2"
+        classpath "com.google.firebase:firebase-crashlytics-gradle:2.2.0"
         classpath 'de.mobilej.unmock:UnMockPlugin:0.7.6'
         classpath "com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:$about_libraries_version"
     }
@@ -32,7 +29,8 @@ apply plugin: "kotlin-android-extensions"
 apply plugin: 'de.mobilej.unmock'
 apply plugin: "com.mikepenz.aboutlibraries.plugin"
 if (!isFoss) {
-    apply plugin: "io.fabric"
+    apply plugin: "com.google.gms.google-services"
+    apply plugin: "com.google.firebase.crashlytics"
 }
 
 android {
@@ -48,6 +46,7 @@ android {
         versionName "2.14.6-beta"
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField "long", "TIMESTAMP", System.currentTimeMillis() + "L"
     }
     buildTypes {
         release {
@@ -164,6 +163,8 @@ dependencies {
 
     // FCM
     fullImplementation "com.google.firebase:firebase-messaging:20.2.4"
+    // Crash reporting
+    fullImplementation "com.google.firebase:firebase-crashlytics:17.2.1"
 
     // About screen
     implementation "com.github.daniel-stoneuk:material-about-library:2.4.2"
@@ -171,12 +172,6 @@ dependencies {
     implementation "com.mikepenz:aboutlibraries-core:$about_libraries_version"
     implementation "com.mikepenz:aboutlibraries:$about_libraries_version"
     implementation "com.github.GrenderG:Toasty:1.4.2"
-
-    // Crash reporting
-    fullImplementation("com.crashlytics.sdk.android:crashlytics:2.10.1@aar") {
-        transitive = true
-    }
-
     testImplementation "org.mockito:mockito-core:3.5.9"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testImplementation "junit:junit:4.13"
@@ -199,8 +194,4 @@ dependencies {
         exclude group: "com.android.support", module: "support-annotations"
     }
     androidTestImplementation "androidx.test.ext:junit:1.1.2"
-}
-
-if (!isFoss) {
-    apply plugin: "com.google.gms.google-services"
 }

--- a/mobile/google-services.json
+++ b/mobile/google-services.json
@@ -33,11 +33,7 @@
         }
       ],
       "services": {
-        "analytics_service": {
-          "status": 1
-        },
         "appinvite_service": {
-          "status": 2,
           "other_platform_oauth_client": [
             {
               "client_id": "849058498762-bc6nbdk0aercq1e5utj1so77e390cr5j.apps.googleusercontent.com",
@@ -52,9 +48,6 @@
               }
             }
           ]
-        },
-        "ads_service": {
-          "status": 2
         }
       }
     },
@@ -85,11 +78,7 @@
         }
       ],
       "services": {
-        "analytics_service": {
-          "status": 1
-        },
         "appinvite_service": {
-          "status": 2,
           "other_platform_oauth_client": [
             {
               "client_id": "849058498762-bc6nbdk0aercq1e5utj1so77e390cr5j.apps.googleusercontent.com",
@@ -104,9 +93,6 @@
               }
             }
           ]
-        },
-        "ads_service": {
-          "status": 2
         }
       }
     }

--- a/mobile/src/foss/java/org/openhab/habdroid/util/RemoteLog.kt
+++ b/mobile/src/foss/java/org/openhab/habdroid/util/RemoteLog.kt
@@ -13,12 +13,10 @@
 
 package org.openhab.habdroid.util
 
-import android.content.Context
 import android.util.Log
 
 object RemoteLog {
-    // context is used in full flavor
-    fun initialize(@Suppress("UNUSED_PARAMETER") context: Context) {
+    fun initialize() {
         // no-op
     }
 

--- a/mobile/src/full/AndroidManifest.xml
+++ b/mobile/src/full/AndroidManifest.xml
@@ -28,5 +28,9 @@
         <meta-data
             android:name="com.google.android.geo.API_KEY"
             android:value="${maps_api_key}" />
+
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="false" />
     </application>
 </manifest>

--- a/mobile/src/full/java/org/openhab/habdroid/util/RemoteLog.kt
+++ b/mobile/src/full/java/org/openhab/habdroid/util/RemoteLog.kt
@@ -13,29 +13,31 @@
 
 package org.openhab.habdroid.util
 
-import android.content.Context
 import android.util.Log
-import com.crashlytics.android.Crashlytics
-import io.fabric.sdk.android.Fabric
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import org.openhab.habdroid.BuildConfig
 
 object RemoteLog {
-    fun initialize(context: Context) {
-        Fabric.with(context, Crashlytics())
+    private val TAG = RemoteLog::class.java.simpleName
+
+    fun initialize() {
+        val outdatedBuildMillis = BuildConfig.TIMESTAMP + (6L * 30 * 24 * 60 * 60 * 1000) // 6 months after build
+        val isOutdated = outdatedBuildMillis < System.currentTimeMillis()
+        Log.d(TAG, "Crashlytics status: isDebug ${BuildConfig.DEBUG}, isOutdated $isOutdated")
+        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(!BuildConfig.DEBUG && !isOutdated)
     }
 
     fun d(tag: String, message: String, remoteOnly: Boolean = false) {
-        if (remoteOnly) {
-            Crashlytics.log("[$tag] $message")
-        } else {
-            Crashlytics.log(Log.DEBUG, tag, message)
+        FirebaseCrashlytics.getInstance().log("D/$tag: $message")
+        if (!remoteOnly) {
+            Log.d(tag, message)
         }
     }
 
     fun e(tag: String, message: String, remoteOnly: Boolean = false) {
-        if (remoteOnly) {
-            Crashlytics.log("[$tag] $message")
-        } else {
-            Crashlytics.log(Log.ERROR, tag, message)
+        FirebaseCrashlytics.getInstance().log("E/$tag: $message")
+        if (!remoteOnly) {
+            Log.e(tag, message)
         }
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHabApplication.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHabApplication.kt
@@ -74,10 +74,10 @@ class OpenHabApplication : MultiDexApplication() {
 
     override fun onCreate() {
         super.onCreate()
+        RemoteLog.initialize()
         AppCompatDelegate.setDefaultNightMode(getPrefs().getDayNightMode(this))
         ConnectionFactory.initialize(this)
         BackgroundTasksManager.initialize(this)
-        RemoteLog.initialize(this)
 
         dataSaverChangeListener?.let { listener ->
             registerReceiver(listener, IntentFilter(ConnectivityManager.ACTION_RESTRICT_BACKGROUND_CHANGED))


### PR DESCRIPTION
Fixes #2179

Disable crash reporting for builds older than 6 months and debug builds.
Fixes #564

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>