### PR TITLE
Fix crash "FragmentManager has been destroyed"

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
@@ -38,6 +38,9 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import androidx.fragment.app.commitNow
+import java.util.ArrayList
+import java.util.HashSet
+import java.util.Stack
 import org.openhab.habdroid.R
 import org.openhab.habdroid.core.connection.Connection
 import org.openhab.habdroid.core.connection.ConnectionFactory
@@ -54,9 +57,6 @@ import org.openhab.habdroid.util.RemoteLog
 import org.openhab.habdroid.util.getHumanReadableErrorMessage
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.isDebugModeEnabled
-import java.util.ArrayList
-import java.util.HashSet
-import java.util.Stack
 
 /**
  * Controller class for the content area of [MainActivity]
@@ -454,6 +454,9 @@ abstract class ContentController protected constructor(private val activity: Mai
     internal abstract fun executeStateUpdate(reason: FragmentUpdateReason, allowStateLoss: Boolean)
 
     private fun updateFragmentState(reason: FragmentUpdateReason) {
+        if (fm.isDestroyed) {
+            return
+        }
         // Allow state loss if activity is still started, as we'll get
         // another onSaveInstanceState() callback on activity stop
         executeStateUpdate(reason, activity.isStarted)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentControllerOnePane.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentControllerOnePane.kt
@@ -24,6 +24,10 @@ class ContentControllerOnePane(activity: MainActivity) : ContentController(activ
     override val fragmentForTitle get() = if (pageStack.empty()) sitemapFragment else pageStack.peek().second
 
     override fun executeStateUpdate(reason: FragmentUpdateReason, allowStateLoss: Boolean) {
+        if (fm.isDestroyed) {
+            return
+        }
+
         val fragment = when {
             overridingFragment != null -> overridingFragment
             !pageStack.isEmpty() -> pageStack.peek().second

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentControllerOnePane.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentControllerOnePane.kt
@@ -24,10 +24,6 @@ class ContentControllerOnePane(activity: MainActivity) : ContentController(activ
     override val fragmentForTitle get() = if (pageStack.empty()) sitemapFragment else pageStack.peek().second
 
     override fun executeStateUpdate(reason: FragmentUpdateReason, allowStateLoss: Boolean) {
-        if (fm.isDestroyed) {
-            return
-        }
-
         val fragment = when {
             overridingFragment != null -> overridingFragment
             !pageStack.isEmpty() -> pageStack.peek().second


### PR DESCRIPTION
````
Fatal Exception: java.lang.IllegalStateException: FragmentManager has been destroyed
       at androidx.fragment.app.FragmentManager.enqueueAction(FragmentManager.java:1737)
       at androidx.fragment.app.BackStackRecord.commitInternal(BackStackRecord.java:321)
       at androidx.fragment.app.BackStackRecord.commit(BackStackRecord.java:286)
       at org.openhab.habdroid.ui.activity.ContentControllerOnePane.executeStateUpdate$mobile_fullStableRelease(ContentControllerOnePane.kt:50)
       at org.openhab.habdroid.ui.activity.ContentController.updateFragmentState(ContentController.kt:459)
       at org.openhab.habdroid.ui.activity.ContentController.clearServerCommunicationFailure(ContentController.kt:314)
       at org.openhab.habdroid.ui.MainActivity.retryServerPropertyQuery(MainActivity.kt:525)
       at org.openhab.habdroid.ui.MainActivity$handlePropertyFetchFailure$2.invoke(MainActivity.kt:1039)
       at org.openhab.habdroid.ui.MainActivity$handlePropertyFetchFailure$2.invoke(MainActivity.kt:116)
       at org.openhab.habdroid.ui.MainActivity$scheduleRetry$1.invokeSuspend(MainActivity.kt:479)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTaskKt.resume(DispatchedTask.kt:175)
       at kotlinx.coroutines.DispatchedTaskKt.dispatch(DispatchedTask.kt:111)
       at kotlinx.coroutines.CancellableContinuationImpl.dispatchResume(CancellableContinuationImpl.kt:308)
       at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl(CancellableContinuationImpl.kt:318)
       at kotlinx.coroutines.CancellableContinuationImpl.resumeUndispatched(CancellableContinuationImpl.kt:400)
       at kotlinx.coroutines.android.HandlerContext$scheduleResumeAfterDelay$$inlined$Runnable$1.run(Runnable.kt:19)
       at android.os.Handler.handleCallback(Handler.java:873)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:193)
       at android.app.ActivityThread.main(ActivityThread.java:6718)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:491)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>