### PR TITLE
Fix 'invalid notification' crashes

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/EventListenerService.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/EventListenerService.kt
@@ -64,8 +64,8 @@ class EventListenerService : Service() {
                 getPrefs().isItemUpdatePrefEnabled(PrefKeys.SEND_DND_MODE) -> {
                 getString(R.string.send_device_info_foreground_service_running_summary_dnd)
             }
-            Build.VERSION.SDK_INT < Build.VERSION_CODES.O -> null
-            titlesOfItems.isEmpty() -> null
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.O -> ""
+            titlesOfItems.isEmpty() -> ""
             titlesOfItems.size == 1 -> {
                 getString(R.string.send_device_info_foreground_service_running_summary_one, titlesOfItems[0])
             }


### PR DESCRIPTION
I see several crashes caused by invalid notifications. This should fix it.

````java
Fatal Exception: android.app.RemoteServiceException: Bad notification for startForeground: java.lang.RuntimeException: invalid channel for service notification: Notification(channel=background pri=0 contentView=null vibrate=null sound=null tick defaults=0x0 flags=0x42 color=0xffff5722 category=progress vis=PRIVATE semFlags=0x0 semPriority=0 semMissedCount=0)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2137)
       at android.os.Handler.dispatchMessage(Handler.java:107)
       at android.os.Looper.loop(Looper.java:237)
       at android.app.ActivityThread.main(ActivityThread.java:7948)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1075)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>