### PR TITLE
Fix fragement manager IllegalStateException

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -135,8 +135,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         private set
     private var propsUpdateHandle: ServerProperties.Companion.UpdateHandle? = null
     private var retryJob: Job? = null
-    var isStarted: Boolean = false
-        private set
+    private var isStarted: Boolean = false
     private var shortcutManager: ShortcutManager? = null
     private val backgroundTasksManager = BackgroundTasksManager()
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
@@ -451,15 +451,13 @@ abstract class ContentController protected constructor(private val activity: Mai
         activity.showSnackbar(R.string.error_sse_failed, tag = MainActivity.TAG_SNACKBAR_SSE_ERROR)
     }
 
-    internal abstract fun executeStateUpdate(reason: FragmentUpdateReason, allowStateLoss: Boolean)
+    internal abstract fun executeStateUpdate(reason: FragmentUpdateReason)
 
     private fun updateFragmentState(reason: FragmentUpdateReason) {
         if (fm.isDestroyed) {
             return
         }
-        // Allow state loss if activity is still started, as we'll get
-        // another onSaveInstanceState() callback on activity stop
-        executeStateUpdate(reason, activity.isStarted)
+        executeStateUpdate(reason)
         collectWidgetFragments().forEach { f -> f.closeAllDialogs() }
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentControllerOnePane.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentControllerOnePane.kt
@@ -23,14 +23,14 @@ import org.openhab.habdroid.ui.MainActivity
 class ContentControllerOnePane(activity: MainActivity) : ContentController(activity) {
     override val fragmentForTitle get() = if (pageStack.empty()) sitemapFragment else pageStack.peek().second
 
-    override fun executeStateUpdate(reason: FragmentUpdateReason, allowStateLoss: Boolean) {
+    override fun executeStateUpdate(reason: FragmentUpdateReason) {
         val fragment = when {
             overridingFragment != null -> overridingFragment
             !pageStack.isEmpty() -> pageStack.peek().second
             else -> sitemapFragment
         }
 
-        fm.commit(allowStateLoss) {
+        fm.commit(!fm.isStateSaved) {
             setCustomAnimations(determineEnterAnim(reason), determineExitAnim(reason))
             replace(R.id.content, fragment ?: defaultProgressFragment)
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentControllerTwoPane.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentControllerTwoPane.kt
@@ -37,7 +37,7 @@ class ContentControllerTwoPane(activity: MainActivity) : ContentController(activ
         rightContentView.isVisible = fm.findFragmentById(R.id.content_right) != null
     }
 
-    override fun executeStateUpdate(reason: FragmentUpdateReason, allowStateLoss: Boolean) {
+    override fun executeStateUpdate(reason: FragmentUpdateReason) {
         var leftFragment = overridingFragment
         val rightFragment: WidgetListFragment?
         val rightPair: Pair<LinkedPage, WidgetListFragment>?
@@ -62,7 +62,7 @@ class ContentControllerTwoPane(activity: MainActivity) : ContentController(activ
         val currentLeftFragment = fm.findFragmentById(R.id.content_left)
         val currentRightFragment = fm.findFragmentById(R.id.content_right)
 
-        fm.commitNow(allowStateLoss) {
+        fm.commitNow(!fm.isStateSaved) {
             if (currentLeftFragment != null && currentLeftFragment !== leftFragment) {
                 remove(currentLeftFragment)
             }
@@ -71,7 +71,7 @@ class ContentControllerTwoPane(activity: MainActivity) : ContentController(activ
             }
         }
 
-        fm.commit(allowStateLoss) {
+        fm.commit(!fm.isStateSaved) {
             setCustomAnimations(R.anim.slide_in_left, R.anim.slide_out_right)
             if (leftFragment != null) {
                 setCustomAnimations(determineEnterAnim(reason), determineExitAnim(reason))


### PR DESCRIPTION
Instead of taking the saved state from the activity, use it from the
fragment manager itself.

From the Java docs of `isStateSaved()`:

> Any operations that would change saved state should not be performed if this method returns true. For example, [...] any FragmentTransaction using {@link FragmentTransaction#commit()} instead of {@link FragmentTransaction#commitAllowingStateLoss()} will change the state and will result in an error.

Fixes #1650

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>