### PR TITLE
Remove channel group "Other"

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
@@ -26,14 +26,14 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Observer
 import androidx.work.WorkInfo
+import java.util.ArrayList
+import java.util.HashMap
 import org.openhab.habdroid.R
 import org.openhab.habdroid.ui.MainActivity
 import org.openhab.habdroid.util.getHumanReadableErrorMessage
 import org.openhab.habdroid.util.getNotificationTone
 import org.openhab.habdroid.util.getNotificationVibrationPattern
 import org.openhab.habdroid.util.getPrefs
-import java.util.ArrayList
-import java.util.HashMap
 
 internal class NotificationUpdateObserver(context: Context) : Observer<List<WorkInfo>> {
     private val context: Context = context.applicationContext
@@ -155,7 +155,6 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
         const val CHANNEL_ID_BACKGROUND_FOREGROUND_SERVICE = "backgroundBroadcastReceiver"
         const val CHANNEL_ID_MESSAGE_DEFAULT = "default"
         const val CHANNEL_GROUP_MESSAGES = "messages"
-        private const val CHANNEL_GROUP_OTHER = "other"
 
         /**
          * Creates notification channels for background tasks.
@@ -174,13 +173,6 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
                     NotificationChannelGroup(
                     CHANNEL_GROUP_MESSAGES,
                     context.getString(R.string.notification_channel_group_messages)
-                )
-            )
-
-            nm.createNotificationChannelGroup(
-                    NotificationChannelGroup(
-                    CHANNEL_GROUP_OTHER,
-                    context.getString(R.string.notification_channel_group_other)
                 )
             )
 
@@ -212,7 +204,6 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
                 setShowBadge(false)
                 enableVibration(false)
                 enableLights(false)
-                group = CHANNEL_GROUP_OTHER
                 description = context.getString(R.string.notification_channel_background_description)
                 nm.createNotificationChannel(this)
             }
@@ -227,7 +218,6 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
                 setShowBadge(false)
                 enableVibration(false)
                 enableLights(false)
-                group = CHANNEL_GROUP_OTHER
                 description = context.getString(R.string.notification_channel_background_foreground_service_description)
                 nm.createNotificationChannel(this)
             }
@@ -243,7 +233,6 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
                 enableVibration(true)
                 enableLights(true)
                 lightColor = ContextCompat.getColor(context, R.color.openhab_orange)
-                group = CHANNEL_GROUP_OTHER
                 description = context.getString(R.string.notification_channel_background_error_description)
                 nm.createNotificationChannel(this)
             }

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -253,7 +253,6 @@
     <string name="notification_channel_messages_default_severity">Default</string>
     <string name="notification_channel_messages_default_severity_description">Notifications sent by the server with no defined severity</string>
     <string name="notification_channel_group_messages">Messages</string>
-    <string name="notification_channel_group_other">Other</string>
     <string name="notification_channel_severity_value">Severity \'%1$s\'</string>
     <string name="notification_channel_severity_value_description">Notifications sent by the server with severity \'%1$s\'</string>
     <plurals name="summary_notification_text">


### PR DESCRIPTION
This channel group isn't required, because Android puts notifications under
"Other" if no group is set.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>