### PR TITLE
Fix lint regarding DND mode and min sdk

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -32,6 +32,7 @@ import android.os.Parcelable
 import android.speech.RecognizerIntent
 import android.telephony.TelephonyManager
 import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.core.content.edit
 import androidx.core.location.LocationManagerCompat
 import androidx.core.os.bundleOf
@@ -632,6 +633,7 @@ class BackgroundTasksManager : BroadcastReceiver() {
                 }
                 ItemUpdateWorker.ValueWithInfo(ssidToSend)
             }
+            @RequiresApi(Build.VERSION_CODES.M)
             VALUE_GETTER_MAP[PrefKeys.SEND_DND_MODE] = { context ->
                 val nm = context.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
                 val mode = when (nm.currentInterruptionFilter) {


### PR DESCRIPTION
This code isn't executed for Android < M, because the pref is hidden.