### PR TITLE
closes #2209 Trim username and password fields 

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/CustomInputTypePreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/CustomInputTypePreference.kt
@@ -70,7 +70,7 @@ open class CustomInputTypePreference constructor(context: Context, attrs: Attrib
     }
 
     class PrefFragment : EditTextPreferenceDialogFragmentCompat(), TextWatcher {
-        private var wrapper: TextInputLayout? = null
+        private lateinit var wrapper: TextInputLayout
         private lateinit var editor: EditText
 
         override fun onBindDialogView(view: View?) {
@@ -85,7 +85,7 @@ open class CustomInputTypePreference constructor(context: Context, attrs: Attrib
                 editor.inputType = type
             }
             arguments?.getCharSequence(KEY_TITLE)?.let { title ->
-                wrapper?.hint = title
+                wrapper.hint = title
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 val hints = arguments?.getStringArray(KEY_AUTOFILL_HINTS)
@@ -96,6 +96,11 @@ open class CustomInputTypePreference constructor(context: Context, attrs: Attrib
                     editor.setAutofillHints(*hints)
                 }
             }
+        }
+
+        override fun onStart() {
+            super.onStart()
+            afterTextChanged(editor.text)
         }
 
         override fun beforeTextChanged(charSequence: CharSequence, start: Int, before: Int, count: Int) {
@@ -112,8 +117,8 @@ open class CustomInputTypePreference constructor(context: Context, attrs: Attrib
             val isLastCharWhitespace = value.lastOrNull()?.isWhitespace() ?: false
             val isFirstCharWhitespace = value.firstOrNull()?.isWhitespace() ?: false
 
-            val res = editor.resources
-            wrapper?.error = when {
+            val res = wrapper.resources
+            wrapper.error = when {
                 isFirstCharWhitespace -> res.getString(R.string.error_first_char_is_whitespace)
                 isLastCharWhitespace -> res.getString(R.string.error_last_char_is_whitespace)
                 else -> null

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -140,6 +140,8 @@
     <string name="error_invalid_url">Please enter a valid URL in a \'http(s)://host(:port)/\' form</string>
     <string name="error_invalid_https_url">Please enter a valid URL in a \'https://host(:port)/\' form</string>
     <string name="error_port_seems_invalid">The port you have entered seems invalid for the selected protocol</string>
+    <string name="error_first_char_is_whitespace">The first character is a whitespace, which is probably unwanted</string>
+    <string name="error_last_char_is_whitespace">The last character is a whitespace, which is probably unwanted</string>
     <string name="error_connection_failed">Connection to host failed</string>
     <string name="error_unable_to_resolve_hostname">Unable to resolve hostname</string>
     <string name="error_unknown">An unknown error occurred: %s</string>


### PR DESCRIPTION
Closes #2209

Add warning in all CustomInputTypePreference if there is a whitespace at the end of input.

<img width="388" alt="image" src="https://user-images.githubusercontent.com/11671046/95667035-bcf6f800-0b60-11eb-99c9-9402b9a9f195.png">

I've had the warning il all CustomInputTypePreference as you suggested. If you want it only for password i will make the change !
