### PR TITLE
Fix snackbar related crashes

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractBaseActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractBaseActivity.kt
@@ -166,8 +166,8 @@ abstract class AbstractBaseActivity : AppCompatActivity(), CoroutineScope {
                 Log.d(TAG, "No next snackbar to show")
                 return
             }
-            val nextSnackbar = snackbarQueue.removeAt(0)
-            nextSnackbar.show()
+            val nextSnackbar = snackbarQueue.removeFirstOrNull()
+            nextSnackbar?.show()
             lastSnackbar = nextSnackbar
         }
 


### PR DESCRIPTION
````
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.google.android.material.snackbar.Snackbar.show()' on a null object reference
       at org.openhab.habdroid.ui.AbstractBaseActivity$showSnackbar$1.invoke(AbstractBaseActivity.kt:170)
       at org.openhab.habdroid.ui.AbstractBaseActivity.showSnackbar(AbstractBaseActivity.kt:197)
       at org.openhab.habdroid.ui.AbstractBaseActivity.showSnackbar$default(AbstractBaseActivity.kt:162)
       at org.openhab.habdroid.ui.MainActivity.showPushNotificationWarningIfNeeded(MainActivity.kt:1072)
       at org.openhab.habdroid.ui.MainActivity$showPushNotificationWarningIfNeeded$1.invokeSuspend(:11)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
````

````
Fatal Exception: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
       at java.util.ArrayList.remove(ArrayList.java:503)
       at org.openhab.habdroid.ui.AbstractBaseActivity$showSnackbar$1.invoke(AbstractBaseActivity.kt:169)
       at org.openhab.habdroid.ui.AbstractBaseActivity.showSnackbar(AbstractBaseActivity.kt:197)
       at org.openhab.habdroid.ui.AbstractBaseActivity.showSnackbar$default(AbstractBaseActivity.kt:162)
       at org.openhab.habdroid.ui.MainActivity.showPushNotificationWarningIfNeeded(MainActivity.kt:1072)
       at org.openhab.habdroid.ui.MainActivity$showPushNotificationWarningIfNeeded$1.invokeSuspend(:11)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
       at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>