### PR TITLE
Auto select server based on Wi-Fi SSID

### DIFF
--- a/.idea/dictionaries/openhab.xml
+++ b/.idea/dictionaries/openhab.xml
@@ -41,6 +41,7 @@
       <w>setpoint</w>
       <w>sitemap</w>
       <w>snackbar</w>
+      <w>ssid</w>
       <w>subpages</w>
       <w>tasker</w>
       <w>twofortyfouram</w>

--- a/mobile/src/main/java/org/openhab/habdroid/core/UpdateBroadcastReceiver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/UpdateBroadcastReceiver.kt
@@ -152,7 +152,8 @@ class UpdateBroadcastReceiver : BroadcastReceiver() {
                         localPath,
                         remotePath,
                         prefs.getStringOrNull("default_openhab_sslclientcert"),
-                        defaultSitemap
+                        defaultSitemap,
+                        null
                     )
                     config.saveToPrefs(prefs, secretPrefs)
                     prefs.edit {

--- a/mobile/src/main/java/org/openhab/habdroid/model/ServerConfiguration.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ServerConfiguration.kt
@@ -62,7 +62,8 @@ data class ServerConfiguration(
     val localPath: ServerPath?,
     val remotePath: ServerPath?,
     val sslClientCert: String?,
-    val defaultSitemap: DefaultSitemap?
+    val defaultSitemap: DefaultSitemap?,
+    val wifiSsid: String?
 ) : Parcelable {
     fun saveToPrefs(prefs: SharedPreferences, secretPrefs: SharedPreferences) {
         val serverIdSet = prefs.getConfiguredServerIds()
@@ -72,6 +73,7 @@ data class ServerConfiguration(
             putString(PrefKeys.buildServerKey(id, PrefKeys.LOCAL_URL_PREFIX), localPath?.url)
             putString(PrefKeys.buildServerKey(id, PrefKeys.REMOTE_URL_PREFIX), remotePath?.url)
             putString(PrefKeys.buildServerKey(id, PrefKeys.SSL_CLIENT_CERT_PREFIX), sslClientCert)
+            putString(PrefKeys.buildServerKey(id, PrefKeys.WIFI_SSID_PREFIX), wifiSsid)
             if (!serverIdSet.contains(id)) {
                 serverIdSet.add(id)
                 putConfiguredServerIds(serverIdSet)
@@ -100,6 +102,7 @@ data class ServerConfiguration(
             remove(PrefKeys.buildServerKey(id, PrefKeys.SSL_CLIENT_CERT_PREFIX))
             remove(PrefKeys.buildServerKey(id, PrefKeys.DEFAULT_SITEMAP_NAME_PREFIX))
             remove(PrefKeys.buildServerKey(id, PrefKeys.DEFAULT_SITEMAP_LABEL_PREFIX))
+            remove(PrefKeys.buildServerKey(id, PrefKeys.WIFI_SSID_PREFIX))
             putConfiguredServerIds(serverIdSet)
             if (prefs.getActiveServerId() == id) {
                 putActiveServerId(if (serverIdSet.isNotEmpty()) serverIdSet.first() else 0)
@@ -139,7 +142,16 @@ data class ServerConfiguration(
                 return null
             }
             val clientCert = prefs.getStringOrNull(PrefKeys.buildServerKey(id, PrefKeys.SSL_CLIENT_CERT_PREFIX))
-            return ServerConfiguration(id, serverName, localPath, remotePath, clientCert, getDefaultSitemap(prefs, id))
+            val wifiSsid = prefs.getStringOrNull(PrefKeys.buildServerKey(id, PrefKeys.WIFI_SSID_PREFIX))
+            return ServerConfiguration(
+                id,
+                serverName,
+                localPath,
+                remotePath,
+                clientCert,
+                getDefaultSitemap(prefs, id),
+                wifiSsid
+            )
         }
 
         fun saveDefaultSitemap(prefs: SharedPreferences, id: Int, defaultSitemap: DefaultSitemap?) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -534,7 +534,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
             else -> null
         }
 
-        val serverHaveWifiSet = prefs
+        val anyServerHasSetWifi = prefs
             .getConfiguredServerIds()
             .map { id -> ServerConfiguration.load(prefs, getSecretPrefs(), id) }
             .any { config -> config?.wifiSsid?.isNotEmpty() == true }
@@ -545,7 +545,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         val wifiSsid = if (wifiInfo.networkId == -1) null else wifiInfo.ssid.removeSurrounding("\"")
         val requiredPermission = getPermissionForSsidRead()
         when {
-            !serverHaveWifiSet -> {
+            !anyServerHasSetWifi -> {
                 Log.d(TAG, "Cannot auto select server: No server with configured wifi")
                 return
             }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -582,7 +582,8 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         val serverForCurrentWifi = prefs
             .getConfiguredServerIds()
             .map { id -> ServerConfiguration.load(prefs, getSecretPrefs(), id) }
-            .firstOrNull { config -> config?.wifiSsid == wifiSsid } ?: return
+            .firstOrNull { config -> config?.wifiSsid == wifiSsid }
+            ?: return
 
         val prevActiveServer = prefs.getActiveServerId()
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -309,7 +309,7 @@ class PreferencesActivity : AbstractBaseActivity() {
                     getString(R.string.settings_server_default_name, nextServerId)
                 }
                 val f = ServerEditorFragment.newInstance(
-                    ServerConfiguration(nextServerId, nextName, null, null, null, null)
+                    ServerConfiguration(nextServerId, nextName, null, null, null, null, null)
                 )
                 parentActivity.openSubScreen(f)
                 true
@@ -763,7 +763,8 @@ class PreferencesActivity : AbstractBaseActivity() {
                     config.localPath,
                     config.remotePath,
                     config.sslClientCert,
-                    config.defaultSitemap
+                    config.defaultSitemap,
+                    config.wifiSsid
                 )
                 parentActivity.invalidateOptionsMenu()
                 true
@@ -807,7 +808,8 @@ class PreferencesActivity : AbstractBaseActivity() {
                     config.localPath,
                     config.remotePath,
                     newValue as String?,
-                    config.defaultSitemap
+                    config.defaultSitemap,
+                    config.wifiSsid
                 )
                 true
             }
@@ -829,6 +831,7 @@ class PreferencesActivity : AbstractBaseActivity() {
 
             if (prefs.getConfiguredServerIds().isEmpty()) {
                 preferenceScreen.removePreferenceRecursively(PrefKeys.PRIMARY_SERVER_PREF)
+                preferenceScreen.removePreferenceRecursively("wifi_ssid")
             } else {
                 val primaryServerPref = getPreference(PrefKeys.PRIMARY_SERVER_PREF)
                 updatePrimaryServerPrefState(primaryServerPref, config.id == prefs.getPrimaryServerId())
@@ -841,6 +844,21 @@ class PreferencesActivity : AbstractBaseActivity() {
                         markAsPrimary = true
                     }
                     updatePrimaryServerPrefState(primaryServerPref, true)
+                    true
+                }
+
+                val wifiSsidPref = getPreference("wifi_ssid") as EditTextPreference
+                wifiSsidPref.text = config.wifiSsid
+                wifiSsidPref.setOnPreferenceChangeListener { _, newValue ->
+                    config = ServerConfiguration(
+                        config.id,
+                        config.name,
+                        config.localPath,
+                        config.remotePath,
+                        config.sslClientCert,
+                        config.defaultSitemap,
+                        newValue as String?
+                    )
                     true
                 }
             }
@@ -868,7 +886,8 @@ class PreferencesActivity : AbstractBaseActivity() {
                     path,
                     config.remotePath,
                     config.sslClientCert,
-                    config.defaultSitemap
+                    config.defaultSitemap,
+                    config.wifiSsid
                 )
             } else {
                 ServerConfiguration(
@@ -877,7 +896,8 @@ class PreferencesActivity : AbstractBaseActivity() {
                     config.localPath,
                     path,
                     config.sslClientCert,
-                    config.defaultSitemap
+                    config.defaultSitemap,
+                    config.wifiSsid
                 )
             }
             parentActivity.invalidateOptionsMenu()

--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -849,6 +849,14 @@ class PreferencesActivity : AbstractBaseActivity() {
 
                 val wifiSsidPref = getPreference("wifi_ssid") as EditTextPreference
                 wifiSsidPref.text = config.wifiSsid
+                wifiSsidPref.summaryProvider = Preference.SummaryProvider<EditTextPreference> { preference ->
+                    val value = preference.text
+                    if (value.isNullOrEmpty()) {
+                        getString(R.string.settings_multi_server_wifi_ssid_summary_unset)
+                    } else {
+                        getString(R.string.settings_multi_server_wifi_ssid_summary_set, value)
+                    }
+                }
                 wifiSsidPref.setOnPreferenceChangeListener { _, newValue ->
                     config = ServerConfiguration(
                         config.id,

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -21,6 +21,7 @@ import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
+import android.location.LocationManager
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.Uri
@@ -435,6 +436,13 @@ fun Context.resolveThemedColor(@AttrRes colorAttr: Int, @ColorInt fallbackColor:
     }
 }
 
+fun Context.getCurrentWifiSsid() : String? {
+    val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+    return wifiManager.connectionInfo.let {info ->
+        if (info.networkId == -1) null else info.ssid.removeSurrounding("\"")
+    }
+}
+
 fun Socket.bindToNetworkIfPossible(network: Network?) {
     try {
         network?.bindSocket(this)
@@ -456,9 +464,7 @@ fun ServiceInfo.addToPrefs(context: Context) {
     val port = port.toString()
     Log.d(Util.TAG, "Service resolved: $address port: $port")
 
-    val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
-    val wifiInfo = wifiManager.connectionInfo
-    val wifiSsid = if (wifiInfo.networkId == -1) null else wifiInfo.ssid.removeSurrounding("\"")
+    val wifiSsid = context.getCurrentWifiSsid()
 
     val config = ServerConfiguration(
         context.getPrefs().getNextAvailableServerId(),

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -464,8 +464,6 @@ fun ServiceInfo.addToPrefs(context: Context) {
     val port = port.toString()
     Log.d(Util.TAG, "Service resolved: $address port: $port")
 
-    val wifiSsid = context.getCurrentWifiSsid()
-
     val config = ServerConfiguration(
         context.getPrefs().getNextAvailableServerId(),
         context.getString(R.string.openhab),
@@ -473,7 +471,7 @@ fun ServiceInfo.addToPrefs(context: Context) {
         null,
         null,
         null,
-        wifiSsid
+        null
     )
     config.saveToPrefs(context.getPrefs(), context.getSecretPrefs())
 }

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -21,7 +21,6 @@ import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
-import android.location.LocationManager
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.Uri
@@ -436,9 +435,9 @@ fun Context.resolveThemedColor(@AttrRes colorAttr: Int, @ColorInt fallbackColor:
     }
 }
 
-fun Context.getCurrentWifiSsid() : String? {
+fun Context.getCurrentWifiSsid(): String? {
     val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
-    return wifiManager.connectionInfo.let {info ->
+    return wifiManager.connectionInfo.let { info ->
         if (info.networkId == -1) null else info.ssid.removeSurrounding("\"")
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -24,6 +24,7 @@ import android.graphics.Canvas
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.Uri
+import android.net.wifi.WifiManager
 import android.os.Build
 import android.util.DisplayMetrics
 import android.util.Log
@@ -455,13 +456,18 @@ fun ServiceInfo.addToPrefs(context: Context) {
     val port = port.toString()
     Log.d(Util.TAG, "Service resolved: $address port: $port")
 
+    val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+    val wifiInfo = wifiManager.connectionInfo
+    val wifiSsid = if (wifiInfo.networkId == -1) null else wifiInfo.ssid.removeSurrounding("\"")
+
     val config = ServerConfiguration(
         context.getPrefs().getNextAvailableServerId(),
         context.getString(R.string.openhab),
         ServerPath("https://$address:$port", null, null),
         null,
         null,
-        null
+        null,
+        wifiSsid
     )
     config.saveToPrefs(context.getPrefs(), context.getSecretPrefs())
 }

--- a/mobile/src/main/java/org/openhab/habdroid/util/PrefKeys.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/PrefKeys.kt
@@ -32,6 +32,7 @@ object PrefKeys {
     const val SSL_CLIENT_CERT_PREFIX = "sslclientcert_"
     const val DEFAULT_SITEMAP_NAME_PREFIX = "default_sitemap_name_"
     const val DEFAULT_SITEMAP_LABEL_PREFIX = "default_sitemap_label_"
+    const val WIFI_SSID_PREFIX = "wifi_ssid_"
     const val CLEAR_DEFAULT_SITEMAP = "clear_default_sitemap"
     fun buildServerKey(id: Int, prefix: String) = "$prefix$id"
 

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -116,6 +116,10 @@
     <string name="settings_server_primary_url" translatable="false">https://www.openhab.org/docs/apps/android.html#multi-server-support</string>
     <string name="settings_server_default_name">openHAB %d</string>
     <string name="click_here_for_more_information">Touch here for more information</string>
+    <string name="settings_multi_server_wifi_ssid_summary">The app will select this server if it\'s connected to this Wi-Fi name</string>
+    <string name="settings_multi_server_wifi_ssid_switched">Switched to server "%s" based on Wi-Fi</string>
+    <string name="settings_multi_server_wifi_ssid_missing_permissions">Unable to read Wi-Fi name: Missing permissions</string>
+    <string name="settings_multi_server_wifi_ssid_location_off">Unable to read Wi-Fi name: Location is off</string>
 
     <!-- App messages strings -->
     <string name="title_voice_widget">Voice commands</string>
@@ -424,6 +428,7 @@
     <string name="set">Set</string>
     <string name="cancel">Cancel</string>
     <string name="close">Close</string>
+    <string name="undo">Undo</string>
     <string name="try_again_button">Try again</string>
     <string name="enable_wifi_button">Turn on Wi-Fi</string>
     <string name="go_to_settings_button">Go to settings</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -116,7 +116,8 @@
     <string name="settings_server_primary_url" translatable="false">https://www.openhab.org/docs/apps/android.html#multi-server-support</string>
     <string name="settings_server_default_name">openHAB %d</string>
     <string name="click_here_for_more_information">Touch here for more information</string>
-    <string name="settings_multi_server_wifi_ssid_summary">The app will select this server if it\'s connected to this Wi-Fi name</string>
+    <string name="settings_multi_server_wifi_ssid_summary_set">The app will select this server when connected to Wi-Fi \'%s\'</string>
+    <string name="settings_multi_server_wifi_ssid_summary_unset">The app will not automatically select this server based on connected Wi-Fi network</string>
     <string name="settings_multi_server_wifi_ssid_switched">Switched to server "%s" based on Wi-Fi</string>
     <string name="settings_multi_server_wifi_ssid_missing_permissions">Unable to read Wi-Fi name: Missing permissions</string>
     <string name="settings_multi_server_wifi_ssid_location_off">Unable to read Wi-Fi name: Location is off</string>

--- a/mobile/src/main/res/xml/preferences_server.xml
+++ b/mobile/src/main/res/xml/preferences_server.xml
@@ -37,6 +37,11 @@
         android:persistent="false"
         android:summary="@string/settings_openhab_none"
         android:title="@string/settings_openhab_sslclientcert" />
+    <EditTextPreference
+        android:key="wifi_ssid"
+        android:persistent="false"
+        android:summary="@string/settings_multi_server_wifi_ssid_summary"
+        android:title="@string/settings_wifi_ssid" />
     <Preference
         android:clickable="true"
         android:key="clear_default_sitemap"

--- a/mobile/src/main/res/xml/preferences_server.xml
+++ b/mobile/src/main/res/xml/preferences_server.xml
@@ -37,10 +37,12 @@
         android:persistent="false"
         android:summary="@string/settings_openhab_none"
         android:title="@string/settings_openhab_sslclientcert" />
-    <EditTextPreference
+    <org.openhab.habdroid.ui.preference.CustomInputTypePreference
         android:key="wifi_ssid"
         android:persistent="false"
         android:summary="@string/settings_multi_server_wifi_ssid_summary"
+        app:whitespaceBehavior="trim"
+        android:inputType="text"
         android:title="@string/settings_wifi_ssid" />
     <Preference
         android:clickable="true"

--- a/mobile/src/main/res/xml/preferences_server.xml
+++ b/mobile/src/main/res/xml/preferences_server.xml
@@ -40,7 +40,6 @@
     <org.openhab.habdroid.ui.preference.CustomInputTypePreference
         android:key="wifi_ssid"
         android:persistent="false"
-        android:summary="@string/settings_multi_server_wifi_ssid_summary"
         app:whitespaceBehavior="trim"
         android:inputType="text"
         android:title="@string/settings_wifi_ssid" />


### PR DESCRIPTION
An optional Wi-Fi SSID can be configured for each server. If the app is
started and connected to one of these Wi-Fis, it switches to the
corresponding server.

Later this preference could be used force connecting to a remote url,
see #146.

Closes #2229

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>