### PR TITLE
Hide SSE failure snackbar when opening HABPanel

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -1037,6 +1037,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
     }
 
     private fun openWebViewUi(ui: WebViewUi) {
+        hideSnackbar(SNACKBAR_TAG_SSE_ERROR)
         controller.showWebViewUi(ui)
         drawerToggle.isDrawerIndicatorEnabled = false
     }


### PR DESCRIPTION
SSE failures of the sitemap don't impair the refresh of HABPanel.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>