### PR TITLE
Fix UninitializedPropertyAccessException in CustomInputTypePreference

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/CustomInputTypePreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/CustomInputTypePreference.kt
@@ -32,8 +32,8 @@ import org.openhab.habdroid.ui.CustomDialogPreference
 open class CustomInputTypePreference constructor(context: Context, attrs: AttributeSet) :
     EditTextPreference(context, attrs), CustomDialogPreference {
     private val inputType: Int
-    private var autofillHints: Array<String>? = null
-    private lateinit var whitespaceBehavior: WhitespaceBehavior
+    private var autofillHints: Array<String>?
+    private var whitespaceBehavior: WhitespaceBehavior
     private var defValue: Any? = null
 
     init {
@@ -42,8 +42,10 @@ open class CustomInputTypePreference constructor(context: Context, attrs: Attrib
             inputType = getInt(0, 0)
             autofillHints = getString(1)?.split(',')?.toTypedArray()
             val whitespaceBehaviorId = getInt(2, 0)
-            if (whitespaceBehaviorId < WhitespaceBehavior.values().size) {
-                whitespaceBehavior = WhitespaceBehavior.values()[whitespaceBehaviorId]
+            whitespaceBehavior = if (whitespaceBehaviorId < WhitespaceBehavior.values().size) {
+                WhitespaceBehavior.values()[whitespaceBehaviorId]
+            } else {
+                WhitespaceBehavior.IGNORE
             }
             recycle()
         }
@@ -82,7 +84,7 @@ open class CustomInputTypePreference constructor(context: Context, attrs: Attrib
     class PrefFragment : EditTextPreferenceDialogFragmentCompat(), TextWatcher {
         private lateinit var wrapper: TextInputLayout
         private lateinit var editor: EditText
-        private lateinit var whitespaceBehavior: WhitespaceBehavior
+        private var whitespaceBehavior: WhitespaceBehavior? = null
 
         override fun onBindDialogView(view: View?) {
             super.onBindDialogView(view)
@@ -108,8 +110,10 @@ open class CustomInputTypePreference constructor(context: Context, attrs: Attrib
                 }
             }
             val whitespaceBehaviorId = arguments?.getInt(KEY_WHITESPACE_BEHAVIOR, 0) ?: 0
-            if (whitespaceBehaviorId < WhitespaceBehavior.values().size) {
-                whitespaceBehavior = WhitespaceBehavior.values()[whitespaceBehaviorId]
+            whitespaceBehavior = if (whitespaceBehaviorId < WhitespaceBehavior.values().size) {
+                WhitespaceBehavior.values()[whitespaceBehaviorId]
+            } else {
+                WhitespaceBehavior.IGNORE
             }
         }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/CustomInputTypePreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/CustomInputTypePreference.kt
@@ -32,8 +32,8 @@ import org.openhab.habdroid.ui.CustomDialogPreference
 open class CustomInputTypePreference constructor(context: Context, attrs: AttributeSet) :
     EditTextPreference(context, attrs), CustomDialogPreference {
     private val inputType: Int
-    private var autofillHints: Array<String>?
-    private var whitespaceBehavior: WhitespaceBehavior
+    private val autofillHints: Array<String>?
+    private val whitespaceBehavior: WhitespaceBehavior
     private var defValue: Any? = null
 
     init {


### PR DESCRIPTION
````
Fatal Exception: kotlin.UninitializedPropertyAccessException: lateinit property whitespaceBehavior has not been initialized
       at org.openhab.habdroid.ui.preference.CustomInputTypePreference$PrefFragment.afterTextChanged(CustomInputTypePreference.kt:130)
       at android.widget.TextView.sendAfterTextChanged(TextView.java:11664)
       at android.widget.TextView.setText(TextView.java:6851)
       at android.widget.TextView.setText(TextView.java:6642)
       at android.widget.EditText.setText(EditText.java:140)
       at android.widget.TextView.setText(TextView.java:6594)
       at android.widget.TextView.setTransformationMethod(TextView.java:2870)
       at android.widget.TextView.setInputType(TextView.java:7100)
       at org.openhab.habdroid.ui.preference.CustomInputTypePreference$PrefFragment.onBindDialogView(CustomInputTypePreference.kt:96)
       at androidx.preference.PreferenceDialogFragmentCompat.onCreateDialog(PreferenceDialogFragmentCompat.java:148)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>