### PR TITLE
Increase server selector hitbox

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -874,9 +874,9 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         }
 
         drawerModeSelectorContainer = drawerView.inflateHeaderView(R.layout.drawer_header)
+        drawerModeSelectorContainer.setOnClickListener { updateDrawerMode(!inServerSelectionMode) }
         drawerModeToggle = drawerModeSelectorContainer.findViewById(R.id.drawer_mode_switcher)
         drawerServerNameView = drawerModeSelectorContainer.findViewById(R.id.server_name)
-        drawerModeToggle.setOnClickListener { updateDrawerMode(!inServerSelectionMode) }
     }
 
     private fun updateDrawerServerEntries() {


### PR DESCRIPTION
Increase the hitbox from the arrow only to the complete header, like it's done for switches in the settings.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>