### PR TITLE
Make sure that tile subtitle is updated

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -108,7 +108,7 @@ class BackgroundTasksManager : BroadcastReceiver() {
                 KNOWN_KEYS.forEach { key -> scheduleWorker(context, key) }
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                     for (tileId in 1..AbstractTileService.TILE_COUNT) {
-                        AbstractTileService.updateTile(context, tileId)
+                        AbstractTileService.requestTileUpdate(context, tileId)
                     }
                 }
                 EventListenerService.startOrStopService(context)

--- a/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/NotificationUpdateObserver.kt
@@ -29,6 +29,7 @@ import androidx.work.WorkInfo
 import java.util.ArrayList
 import java.util.HashMap
 import org.openhab.habdroid.R
+import org.openhab.habdroid.background.tiles.AbstractTileService
 import org.openhab.habdroid.ui.MainActivity
 import org.openhab.habdroid.util.getHumanReadableErrorMessage
 import org.openhab.habdroid.util.getNotificationTone
@@ -70,8 +71,9 @@ internal class NotificationUpdateObserver(context: Context) : Observer<List<Work
                             else -> {}
                         }
                     }
-                    // Stop evaluating tags and advance to next info
-                    break
+                } else if (tag.startsWith(BackgroundTasksManager.WORKER_TAG_PREFIX_TILE_ID)) {
+                    val tileId = tag.substringAfter(BackgroundTasksManager.WORKER_TAG_PREFIX_TILE_ID).toInt()
+                    AbstractTileService.requestTileUpdate(context, tileId)
                 }
             }
         }

--- a/mobile/src/main/java/org/openhab/habdroid/background/tiles/AbstractTileService.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/tiles/AbstractTileService.kt
@@ -83,6 +83,8 @@ abstract class AbstractTileService : TileService() {
             infoLiveData.observe(lifeCycleOwner) {
                 updateTileSubtitle()
             }
+
+            updateTileSubtitle()
         }
     }
 
@@ -126,6 +128,7 @@ abstract class AbstractTileService : TileService() {
     }
 
     private fun updateTile(tile: Tile) {
+        Log.d(TAG, "updateTile()")
         val data = getPrefs().getTileData(ID)
 
         tile.apply {
@@ -138,6 +141,8 @@ abstract class AbstractTileService : TileService() {
 
     @RequiresApi(Build.VERSION_CODES.Q)
     private fun updateTileSubtitle() {
+        Log.d(TAG, "updateTileSubtitle()")
+
         val lastInfo = WorkManager
             .getInstance(applicationContext)
             .getWorkInfosByTag(BackgroundTasksManager.WORKER_TAG_PREFIX_TILE_ID + ID)
@@ -232,7 +237,7 @@ abstract class AbstractTileService : TileService() {
             else -> R.drawable.ic_openhab_appicon_24dp
         }
 
-        fun updateTile(context: Context, id: Int) {
+        fun requestTileUpdate(context: Context, id: Int) {
             val data = context.getPrefs().getTileData(id)
             val tileService = ComponentName(
                 context,

--- a/mobile/src/main/java/org/openhab/habdroid/core/UpdateBroadcastReceiver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/UpdateBroadcastReceiver.kt
@@ -180,7 +180,7 @@ class UpdateBroadcastReceiver : BroadcastReceiver() {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             for (tileId in 1..AbstractTileService.TILE_COUNT) {
-                AbstractTileService.updateTile(context, tileId)
+                AbstractTileService.requestTileUpdate(context, tileId)
             }
         }
         EventListenerService.startOrStopService(context)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -1453,7 +1453,7 @@ class PreferencesActivity : AbstractBaseActivity() {
             prefs.edit {
                 putTileData(tileId, currentData)
             }
-            AbstractTileService.updateTile(context, tileId)
+            AbstractTileService.requestTileUpdate(context, tileId)
             parentActivity.invalidateOptionsMenu()
             parentFragmentManager.popBackStack() // close ourself
         }


### PR DESCRIPTION
If the item update cannot be sent directly after the click on the tile, the tile service is most likely killed, before the update was successful/failed. Therefore the subtitle shows "Waiting..." until the user clicks on the tile again.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>