### PR TITLE
Make sure tile prefs is always closed after saving

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -1454,8 +1454,13 @@ class PreferencesActivity : AbstractBaseActivity() {
                 putTileData(tileId, currentData)
             }
             AbstractTileService.requestTileUpdate(context, tileId)
-            parentActivity.invalidateOptionsMenu()
-            parentFragmentManager.popBackStack() // close ourself
+
+            if (parentFragmentManager.backStackEntryCount > 0) {
+                parentActivity.invalidateOptionsMenu()
+                parentFragmentManager.popBackStack() // close ourself
+            } else {
+                parentActivity.onBackPressed()
+            }
         }
 
         override fun onLeaveAndDiscard() {


### PR DESCRIPTION
When entering the tile prefs via long pressing the tile, it didn't close
on save.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>