### PR TITLE
Allow empty strings as tile state

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/tiles/AbstractTileService.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/tiles/AbstractTileService.kt
@@ -266,7 +266,6 @@ data class TileData(
 ) : Parcelable {
     fun isValid(): Boolean {
         return item.isNotEmpty() &&
-            state.isNotEmpty() &&
             label.isNotEmpty() &&
             tileLabel.isNotEmpty() &&
             mappedState.isNotEmpty() &&


### PR DESCRIPTION
An empty string is even a suggested command for StringItems.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>