### PR TITLE
Improve notification status strings

### DIFF
--- a/mobile/src/full/res/values/strings.xml
+++ b/mobile/src/full/res/values/strings.xml
@@ -3,6 +3,6 @@
     <string name="info_openhab_gcm_in_progress">Device registration is in progress</string>
     <string name="info_openhab_gcm_failed">Push notification registration failed</string>
     <string name="info_openhab_gcm_failed_play_services">Push notification registration failed due to a Google Play Services issue: %s</string>
-    <string name="info_openhab_gcm_connected">Device successfully registered with Firebase Cloud Messaging</string>
+    <string name="info_openhab_gcm_connected">Notifications are enabled</string>
     <string name="open_in_maps">Open in Google Maps</string>
 </resources>

--- a/mobile/src/full/res/values/strings.xml
+++ b/mobile/src/full/res/values/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="info_openhab_gcm_in_progress">Device registration is in progress</string>
-    <string name="info_openhab_gcm_failed">Push notification registration failed</string>
-    <string name="info_openhab_gcm_failed_play_services">Push notification registration failed due to a Google Play Services issue: %s</string>
-    <string name="info_openhab_gcm_connected">Notifications are enabled</string>
+    <string name="info_openhab_gcm_in_progress">Notification registration is in progress</string>
+    <string name="info_openhab_gcm_failed">Notification registration failed</string>
+    <string name="info_openhab_gcm_failed_play_services">Notification registration failed due to a Google Play Services issue: %s</string>
+    <string name="info_openhab_gcm_connected">Notification registration completed successfully</string>
     <string name="open_in_maps">Open in Google Maps</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -289,9 +289,9 @@
         <item quantity="one">%d new notification</item>
         <item quantity="other">%d new notifications</item>
     </plurals>
-    <string name="push_notification_status_no_remote_configured">Unavailable, remote server isn\'t configured</string>
-    <string name="push_notification_status_http_error">Unavailable, error connecting to remote server: %s</string>
-    <string name="push_notification_status_remote_no_cloud">Unavailable, remote server isn\'t an openHAB cloud instance</string>
+    <string name="push_notification_status_no_remote_configured">Notifications are unavailable: Remote server isn\'t configured</string>
+    <string name="push_notification_status_http_error">Notifications are unavailable: Error connecting to remote server: %s</string>
+    <string name="push_notification_status_remote_no_cloud">Notifications are unavailable: Remote server isn\'t an openHAB cloud instance</string>
     <string name="push_notification_status">Status</string>
     <string name="push_notification_hint">The notifications are polled on a regular schedule, which is the same than for \"Send device information to server\"</string>
     <plurals name="item_update_error_title">


### PR DESCRIPTION
* Put "notification" in every string, so it isn't out of context when
  shown as Snackbar in MainActivity
* Remove FCM from the success string, because it's quite technical

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>