### PR TITLE
Remove FIXME in code

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
@@ -553,8 +553,12 @@ abstract class ContentController protected constructor(private val activity: Mai
         companion object {
             fun newInstance(message: CharSequence): CommunicationFailureFragment {
                 val f = CommunicationFailureFragment()
-                f.arguments = buildArgs(message, R.string.try_again_button,
-                    R.drawable.ic_openhab_appicon_340dp /* FIXME */, false)
+                f.arguments = buildArgs(
+                    message,
+                    R.string.try_again_button,
+                    R.drawable.ic_openhab_appicon_340dp,
+                    false
+                )
                 return f
             }
         }


### PR DESCRIPTION
IMO all TODOs and FIXME should be tracked as GitHub issue, so the TODO
tab in AS can be used for WIP PRs.
The icon here is fine for me, so I just remove the FIXME.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>