### PR TITLE
Update links after branch rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please report [Android specific issues here](https://github.com/openhab/openhab-
 
 ## Build Environment
 
-For instructions on setting up your development environment, please see [README](https://github.com/openhab/openhab-android/blob/master/README.md).
+For instructions on setting up your development environment, please see [README](https://github.com/openhab/openhab-android/blob/main/README.md).
 
 ## Contribution guidelines
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
     <a href="https://github.com/openhab/openhab-android/actions?query=workflow%3A%22Build+App%22"><img alt="GitHub Action" src="https://github.com/openhab/openhab-android/workflows/Build%20App/badge.svg"></a>
-    <a href="https://travis-ci.com/openhab/openhab-android"><img alt="Travis CI Status" src="https://travis-ci.com/openhab/openhab-android.svg?branch=master"></a>
+    <a href="https://travis-ci.com/openhab/openhab-android"><img alt="Travis CI Status" src="https://travis-ci.com/openhab/openhab-android.svg?branch=main"></a>
     <a href="https://crowdin.com/project/openhab-android"><img alt="Crowdin" src="https://d322cqt584bo4o.cloudfront.net/openhab-android/localized.svg"></a>
     <a href="https://www.bountysource.com/teams/openhab/issues?tracker_ids=968858"><img alt="Bountysource" src="https://www.bountysource.com/badge/tracker?tracker_id=968858"></a>
     <br>

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,7 +1,7 @@
 ---
 layout: documentation
 title: Android App
-source: https://github.com/openhab/openhab-android/blob/master/docs/USAGE.md
+source: https://github.com/openhab/openhab-android/blob/main/docs/USAGE.md
 ---
 
 {% include base.html %}

--- a/mobile/src/beta/res/values/strings.xml
+++ b/mobile/src/beta/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <!-- Attention translators! Do NOT submit localized strings through GitHub Pull Request. -->
-    <!-- See: https://github.com/openhab/openhab-android/blob/master/README.md#localization -->
+    <!-- See: https://github.com/openhab/openhab-android/blob/main/README.md#localization -->
 
     <!-- Name used for beta builds -->
     <string name="app_name">openHAB Beta</string>

--- a/mobile/src/full/res/values/strings.xml
+++ b/mobile/src/full/res/values/strings.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+    <!-- Attention translators! Do NOT submit localized strings through GitHub Pull Request. -->
+    <!-- See: https://github.com/openhab/openhab-android/blob/main/README.md#localization -->
+
     <string name="info_openhab_gcm_in_progress">Notification registration is in progress</string>
     <string name="info_openhab_gcm_failed">Notification registration failed</string>
     <string name="info_openhab_gcm_failed_play_services">Notification registration failed due to a Google Play Services issue: %s</string>

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AboutActivity.kt
@@ -131,7 +131,7 @@ class AboutActivity : AbstractBaseActivity(), FragmentManager.OnBackStackChanged
                 .text(R.string.about_license_title)
                 .subText(R.string.about_license)
                 .icon(R.drawable.ic_account_balance_grey_24dp)
-                .setOnClickAction(makeClickRedirect(context, "$URL_TO_GITHUB/blob/master/LICENSE"))
+                .setOnClickAction(makeClickRedirect(context, "$URL_TO_GITHUB/blob/main/LICENSE"))
                 .build())
             appCard.addItem(MaterialAboutActionItem.Builder()
                 .text(R.string.title_activity_libraries)

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <!-- Attention translators! Do NOT submit localized strings through GitHub Pull Request. -->
-    <!-- See: https://github.com/openhab/openhab-android/blob/master/README.md#localization -->
+    <!-- See: https://github.com/openhab/openhab-android/blob/main/README.md#localization -->
 
     <!-- General app strings -->
     <string name="openhab" translatable="false">openHAB</string>


### PR DESCRIPTION
The default branch has been renamed to main in most openHAB repos.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>