### PR TITLE
Don't show authenticated connections as insecure

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/ServerConfiguration.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ServerConfiguration.kt
@@ -33,7 +33,8 @@ data class ServerPath(
     val userName: String?,
     val password: String?
 ) : Parcelable {
-    fun hasAuthentication() = !userName.isNullOrEmpty() && !password.isNullOrEmpty()
+    // If the user name is longer than 50 chars, assume it's an API token and therefore no password is required.
+    fun hasAuthentication() = !userName.isNullOrEmpty() && (!password.isNullOrEmpty() || userName.length > 50)
 
     companion object {
         internal fun load(


### PR DESCRIPTION
If the user name is longer than 50 chars, assume it's an API token and therefore no password is required.
The keys I generated where usually 82 chars long, but they might be shorter and 50 is longer than the most mail addresses.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>