### PR TITLE
Fix OH3 UI on myopenHAB

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/WebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/WebViewFragment.kt
@@ -211,7 +211,13 @@ class WebViewFragment : Fragment(), ConnectionFactory.UpdateListener {
         updateViewVisibility(error = false, loading = true)
 
         val webView = webView ?: return
-        val url = conn.httpClient.buildUrl(urlToLoad)
+        var url = conn.httpClient.buildUrl(urlToLoad)
+
+        if (url.host == "myopenhab.org") {
+            url = url.newBuilder()
+                .host("home.myopenhab.org")
+                .build()
+        }
 
         webView.setUpForConnection(conn, url) { progress ->
             if (progress == 100) {


### PR DESCRIPTION
`home.myopenhab.org` sends all requests to the local openHAB server
without adding endpoints, e.g. for notifications. Thus they won't work.
`myopenhab.org` returns a custom webpage on `/`, so it won't display the
OH3 UI.

=> Use `myopenhab.org` for everything except the OH3 UI (and other UIs
in webviews).

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>