### PR TITLE
Avoid duplicate CI runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - l10n_main
+      - dependabot/*
   pull_request:
     branches-ignore:
       - l10n_main

--- a/.github/workflows/validate-strings.yml
+++ b/.github/workflows/validate-strings.yml
@@ -1,5 +1,11 @@
 name: Validate Strings
-on: [push, pull_request]
+
+on:
+  push:
+    branches-ignore:
+      - l10n_main
+      - dependabot/*
+  pull_request:
 
 jobs:
   validate-strings:


### PR DESCRIPTION
For the branches l10n_main and dependabot/* there's always an open PR, so the CI runs twice: For push and for pull_request.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>