### PR TITLE
Fix app:theme deprecation

### DIFF
--- a/mobile/src/main/res/layout/activity_about.xml
+++ b/mobile/src/main/res/layout/activity_about.xml
@@ -13,7 +13,7 @@
         android:background="?attr/colorPrimary"
         android:elevation="8dp"
         app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
 
     <FrameLayout
         android:id="@+id/activity_content"

--- a/mobile/src/main/res/layout/activity_chart.xml
+++ b/mobile/src/main/res/layout/activity_chart.xml
@@ -15,7 +15,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/activity_content"

--- a/mobile/src/main/res/layout/activity_item_picker.xml
+++ b/mobile/src/main/res/layout/activity_item_picker.xml
@@ -17,7 +17,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
 
     <LinearLayout
         android:id="@+id/additional_config_parent"

--- a/mobile/src/main/res/layout/activity_log.xml
+++ b/mobile/src/main/res/layout/activity_log.xml
@@ -16,7 +16,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/shareFab"

--- a/mobile/src/main/res/layout/activity_main.xml
+++ b/mobile/src/main/res/layout/activity_main.xml
@@ -12,7 +12,7 @@
         android:background="?attr/colorPrimary"
         android:elevation="8dp"
         app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
         <androidx.core.widget.ContentLoadingProgressBar
             android:id="@+id/toolbar_progress_bar"

--- a/mobile/src/main/res/layout/activity_prefs.xml
+++ b/mobile/src/main/res/layout/activity_prefs.xml
@@ -13,7 +13,7 @@
         android:background="?attr/colorPrimary"
         android:elevation="8dp"
         app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
 
     <FrameLayout
         android:id="@+id/activity_content"

--- a/mobile/src/main/res/layout/activity_writetag.xml
+++ b/mobile/src/main/res/layout/activity_writetag.xml
@@ -15,7 +15,7 @@
         android:background="?attr/colorPrimary"
         android:elevation="8dp"
         app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
 
     <FrameLayout
         android:id="@+id/activity_content"


### PR DESCRIPTION
Fixes `AppCompatViewInflater: app:theme is now deprecated. Please move to using android:theme instead.`

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>