### PR TITLE
Improve beta pref background when disabled

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/BetaPreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/BetaPreference.kt
@@ -34,11 +34,21 @@ class BetaPreference constructor(context: Context, attrs: AttributeSet) : Prefer
         if (holder != null) {
             betaTag = holder.itemView.findViewById(R.id.beta_tag)
             betaTag?.isGone = !showBetaTag
+            updateDisabledState()
         }
+    }
+
+    override fun notifyDependencyChange(disableDependents: Boolean) {
+        super.notifyDependencyChange(disableDependents)
+        updateDisabledState()
     }
 
     fun setBetaTagVisibility(show: Boolean) {
         showBetaTag = show
         betaTag?.isGone = !showBetaTag
+    }
+
+    private fun updateDisabledState() {
+        betaTag?.background?.alpha = if (shouldDisableDependents()) 50 else 255
     }
 }

--- a/mobile/src/main/res/drawable/rounded_corner_box.xml
+++ b/mobile/src/main/res/drawable/rounded_corner_box.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle" >
-    <!-- View border color and width -->
     <stroke
         android:width="1dp"
-        android:color="@color/pref_icon_grey" >
+        android:color="@color/pref_icon_grey">
     </stroke>
 
-    <!-- The radius makes the corners rounded -->
     <corners
-        android:radius="2dp"   >
+        android:radius="2dp">
     </corners>
-
 </shape>


### PR DESCRIPTION
Now the border of the "beta" text changes when enabled/disabled.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>