### PR TITLE
Use child classes of WebViewFragment for each UI

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/WebViewUi.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/WebViewUi.kt
@@ -13,42 +13,27 @@
 
 package org.openhab.habdroid.model
 
-import androidx.annotation.DrawableRes
-import androidx.annotation.StringRes
-import org.openhab.habdroid.R
 import org.openhab.habdroid.ui.MainActivity
+import org.openhab.habdroid.ui.activity.HabpanelWebViewFragment
+import org.openhab.habdroid.ui.activity.Oh3UiWebViewFragment
+import org.openhab.habdroid.ui.activity.AbstractWebViewFragment
 
 data class WebViewUi(
-    @StringRes val titleRes: Int,
-    @StringRes val multiServerTitleRes: Int,
-    @StringRes val errorRes: Int,
-    val urlToLoad: String,
-    val urlForError: String,
     val serverFlag: Int,
     val shortcutAction: String,
-    @DrawableRes val shortcutIconRes: Int
+    val fragment: Class<out AbstractWebViewFragment>
 ) {
     companion object {
         val HABPANEL = WebViewUi(
-            R.string.mainmenu_openhab_habpanel,
-            R.string.mainmenu_openhab_habpanel_on_server,
-            R.string.habpanel_error,
-            "/habpanel/index.html",
-            "/rest/events",
             ServerProperties.SERVER_FLAG_HABPANEL_INSTALLED,
             MainActivity.ACTION_HABPANEL_SELECTED,
-            R.mipmap.ic_shortcut_habpanel
+            HabpanelWebViewFragment::class.java
         )
 
         val OH3_UI = WebViewUi(
-            R.string.mainmenu_openhab_oh3_ui,
-            R.string.mainmenu_openhab_oh3_ui_on_server,
-            R.string.oh3_ui_error,
-            "/",
-            "/",
             ServerProperties.SERVER_FLAG_OH3_UI,
             MainActivity.ACTION_OH3_UI_SELECTED,
-            R.mipmap.ic_shortcut_oh3_ui
+            Oh3UiWebViewFragment::class.java
         )
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
@@ -70,17 +70,22 @@ abstract class AbstractWebViewFragment : Fragment(), ConnectionFactory.UpdateLis
     abstract val shortcutInfo: ShortcutInfoCompat
     abstract val errorMessageRes: Int
 
-    fun init(activity: MainActivity, callback: ParentCallback, isStackRoot: Boolean) {
+    fun init(callback: ParentCallback) {
         this.callback = callback
-        this.isStackRoot = isStackRoot
+    }
 
-        val prefs = activity.getPrefs()
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        val prefs = context.getPrefs()
         val activeServerId = prefs.getActiveServerId()
-        title = if (prefs.getConfiguredServerIds().size <= 1 || activity.connection is DemoConnection) {
-            activity.getString(titleRes)
+        title = if (
+            prefs.getConfiguredServerIds().size <= 1 ||
+            ConnectionFactory.activeUsableConnection?.connection is DemoConnection
+        ) {
+            context.getString(titleRes)
         } else {
-            val activeServerName = ServerConfiguration.load(prefs, activity.getSecretPrefs(), activeServerId)?.name
-            activity.getString(multiServerTitleRes, activeServerName)
+            val activeServerName = ServerConfiguration.load(prefs, context.getSecretPrefs(), activeServerId)?.name
+            context.getString(multiServerTitleRes, activeServerName)
         }
     }
 
@@ -97,6 +102,8 @@ abstract class AbstractWebViewFragment : Fragment(), ConnectionFactory.UpdateLis
         actionBar = (activity as? MainActivity)?.supportActionBar
 
         webView = view.findViewById(R.id.webview)
+
+        isStackRoot = requireArguments().getBoolean(KEY_IS_STACK_ROOT)
 
         val retryButton = view.findViewById<Button>(R.id.retry_button)
         retryButton.setOnClickListener { loadWebsite() }
@@ -318,6 +325,7 @@ abstract class AbstractWebViewFragment : Fragment(), ConnectionFactory.UpdateLis
         private val TAG = AbstractWebViewFragment::class.java.simpleName
 
         private const val KEY_CURRENT_URL = "url"
+        const val KEY_IS_STACK_ROOT = "is_stack_root"
     }
 
     interface ParentCallback {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
@@ -70,10 +70,6 @@ abstract class AbstractWebViewFragment : Fragment(), ConnectionFactory.UpdateLis
     abstract val shortcutInfo: ShortcutInfoCompat
     abstract val errorMessageRes: Int
 
-    fun init(callback: ParentCallback) {
-        this.callback = callback
-    }
-
     override fun onAttach(context: Context) {
         super.onAttach(context)
         val prefs = context.getPrefs()
@@ -157,6 +153,10 @@ abstract class AbstractWebViewFragment : Fragment(), ConnectionFactory.UpdateLis
             }
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    fun setCallback(callback: ParentCallback) {
+        this.callback = callback
     }
 
     private fun pinShortcut() = GlobalScope.launch {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
@@ -179,6 +179,7 @@ abstract class ContentController protected constructor(private val activity: Mai
             pageStack.add(Pair(page, f ?: makePageFragment(page)))
         }
         temporaryPage = fm.getFragment(state, STATE_KEY_TEMPORARY_PAGE)
+        (temporaryPage as? AbstractWebViewFragment)?.setCallback(this)
         noConnectionFragment = fm.getFragment(state, STATE_KEY_ERROR_FRAGMENT)
     }
 
@@ -259,9 +260,7 @@ abstract class ContentController protected constructor(private val activity: Mai
     fun showWebViewUi(ui: WebViewUi, isStackRoot: Boolean) {
         val webViewFragment = ui.fragment.newInstance()
         webViewFragment.arguments = bundleOf(KEY_IS_STACK_ROOT to isStackRoot)
-        webViewFragment.init(
-            this
-        )
+        webViewFragment.setCallback(this)
         showTemporaryPage(webViewFragment)
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
@@ -54,6 +54,7 @@ import org.openhab.habdroid.ui.MainActivity
 import org.openhab.habdroid.ui.PreferencesActivity
 import org.openhab.habdroid.ui.WidgetListFragment
 import org.openhab.habdroid.util.CrashReportingHelper
+import org.openhab.habdroid.ui.activity.AbstractWebViewFragment.Companion.KEY_IS_STACK_ROOT
 import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.getHumanReadableErrorMessage
@@ -257,10 +258,9 @@ abstract class ContentController protected constructor(private val activity: Mai
 
     fun showWebViewUi(ui: WebViewUi, isStackRoot: Boolean) {
         val webViewFragment = ui.fragment.newInstance()
+        webViewFragment.arguments = bundleOf(KEY_IS_STACK_ROOT to isStackRoot)
         webViewFragment.init(
-            activity,
-            this,
-            isStackRoot
+            this
         )
         showTemporaryPage(webViewFragment)
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/HabpanelWebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/HabpanelWebViewFragment.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.habdroid.ui.activity
+
+import android.content.Intent
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.graphics.drawable.IconCompat
+import org.openhab.habdroid.R
+import org.openhab.habdroid.model.WebViewUi
+import org.openhab.habdroid.ui.MainActivity
+import org.openhab.habdroid.util.getActiveServerId
+import org.openhab.habdroid.util.getPrefs
+
+class HabpanelWebViewFragment : AbstractWebViewFragment() {
+    override val titleRes = R.string.mainmenu_openhab_habpanel
+    override val multiServerTitleRes = R.string.mainmenu_openhab_habpanel_on_server
+    override val errorMessageRes = R.string.habpanel_error
+    override val urlToLoad = "/habpanel/index.html"
+    override val urlForError = "/rest/events"
+
+    override val shortcutInfo: ShortcutInfoCompat
+        get() {
+            val context = requireContext()
+            val intent = Intent(context, MainActivity::class.java)
+                .putExtra(MainActivity.EXTRA_SERVER_ID, context.getPrefs().getActiveServerId())
+                .setAction(WebViewUi.HABPANEL.shortcutAction)
+
+            return ShortcutInfoCompat.Builder(context, WebViewUi.HABPANEL.shortcutAction)
+                .setShortLabel(title!!)
+                .setIcon(IconCompat.createWithResource(context, R.mipmap.ic_shortcut_habpanel))
+                .setIntent(intent)
+                .build()
+        }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/Oh3UiWebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/Oh3UiWebViewFragment.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.habdroid.ui.activity
+
+import android.content.Intent
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.graphics.drawable.IconCompat
+import okhttp3.HttpUrl
+import org.openhab.habdroid.R
+import org.openhab.habdroid.model.WebViewUi
+import org.openhab.habdroid.ui.MainActivity
+import org.openhab.habdroid.util.getActiveServerId
+import org.openhab.habdroid.util.getPrefs
+
+class Oh3UiWebViewFragment : AbstractWebViewFragment() {
+    override val titleRes = R.string.mainmenu_openhab_oh3_ui
+    override val multiServerTitleRes = R.string.mainmenu_openhab_oh3_ui_on_server
+    override val errorMessageRes = R.string.oh3_ui_error
+    override val urlToLoad = "/"
+    override val urlForError = "/"
+
+    override val shortcutInfo: ShortcutInfoCompat
+        get() {
+            val context = requireContext()
+            val intent = Intent(context, MainActivity::class.java)
+                .putExtra(MainActivity.EXTRA_SERVER_ID, context.getPrefs().getActiveServerId())
+                .setAction(WebViewUi.OH3_UI.shortcutAction)
+
+            return ShortcutInfoCompat.Builder(context, WebViewUi.OH3_UI.shortcutAction)
+                .setShortLabel(title!!)
+                .setIcon(IconCompat.createWithResource(context, R.mipmap.ic_shortcut_oh3_ui))
+                .setIntent(intent)
+                .build()
+        }
+
+    override fun modifyUrl(orig: HttpUrl): HttpUrl {
+        if (orig.host == "myopenhab.org") {
+            return orig.newBuilder()
+                .host("home.myopenhab.org")
+                .build()
+        }
+        return orig
+    }
+}


### PR DESCRIPTION
IMO this makes it easier to
1. pass arguments to the fragment, like `callback`
2. implement #2289 and #2337

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>