### PR TITLE
Make IconResource a data class

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
@@ -29,7 +29,7 @@ import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getStringOrNull
 
 @Parcelize
-class IconResource internal constructor(
+data class IconResource internal constructor(
     internal val icon: String,
     internal val isOh2: Boolean,
     internal val customState: String?


### PR DESCRIPTION
This adds an auto generated `toString()` function. The current one
returns e.g. `org.openhab.habdroid.model.IconResource@ae3c432`.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>