### PR TITLE
Remove arguments from SwipeRefreshLayout.applyColors()

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
@@ -92,7 +92,7 @@ abstract class AbstractItemPickerActivity : AbstractBaseActivity(), SwipeRefresh
 
         swipeLayout = findViewById(R.id.swipe_refresh)
         swipeLayout.setOnRefreshListener(this)
-        swipeLayout.applyColors(R.attr.colorPrimary, R.attr.colorAccent)
+        swipeLayout.applyColors()
 
         recyclerView = findViewById(android.R.id.list)
         emptyView = findViewById(android.R.id.empty)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ChartActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ChartActivity.kt
@@ -56,7 +56,7 @@ class ChartActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListen
         chart = findViewById(R.id.chart)
         swipeLayout = findViewById(R.id.activity_content)
         swipeLayout.setOnRefreshListener(this)
-        swipeLayout.applyColors(R.attr.colorPrimary, R.attr.colorAccent)
+        swipeLayout.applyColors()
 
         density = resources.configuration.densityDpi
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationListFragment.kt
@@ -75,7 +75,7 @@ class CloudNotificationListFragment : Fragment(), View.OnClickListener, SwipeRef
 
         swipeLayout = view.findViewById(R.id.swipe_container)
         swipeLayout.setOnRefreshListener(this)
-        swipeLayout.applyColors(R.attr.colorPrimary, R.attr.colorAccent)
+        swipeLayout.applyColors()
 
         retryButton = view.findViewById(R.id.retry_button)
         retryButton.setOnClickListener(this)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/LogActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/LogActivity.kt
@@ -61,7 +61,7 @@ class LogActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListener
         scrollView = findViewById(R.id.scrollview)
         swipeLayout = findViewById(R.id.activity_content)
         swipeLayout.setOnRefreshListener(this)
-        swipeLayout.applyColors(R.attr.colorPrimary, R.attr.colorAccent)
+        swipeLayout.applyColors()
 
         fab.setOnClickListener {
             val sendIntent = Intent().apply {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ViewExtensions.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ViewExtensions.kt
@@ -21,24 +21,23 @@ import android.webkit.WebView
 import android.webkit.WebViewDatabase
 import android.widget.ImageView
 import android.widget.RemoteViews
-import androidx.annotation.AttrRes
 import androidx.appcompat.widget.TooltipCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.net.toUri
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import okhttp3.HttpUrl
+import org.openhab.habdroid.R
 import org.openhab.habdroid.core.connection.Connection
 import org.openhab.habdroid.util.openInBrowser
 import org.openhab.habdroid.util.resolveThemedColor
 
 /**
- * Sets [SwipeRefreshLayout] color scheme from
- * a list of attributes pointing to color resources
- *
- * @param colorAttrIds color attributes to create color scheme from
+ * Sets [SwipeRefreshLayout] color scheme according to colorPrimary and colorAccent
  */
-fun SwipeRefreshLayout.applyColors(@AttrRes vararg colorAttrIds: Int) {
-    val colors = colorAttrIds.map { attr -> context.resolveThemedColor(attr) }.toIntArray()
+fun SwipeRefreshLayout.applyColors() {
+    val colors = listOf(R.attr.colorPrimary, R.attr.colorAccent)
+        .map { attr -> context.resolveThemedColor(attr) }
+        .toIntArray()
     setColorSchemeColors(*colors)
 }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -134,7 +134,7 @@ class WidgetListFragment : Fragment(), WidgetAdapter.ItemClickListener,
         registerForContextMenu(recyclerView)
 
         refreshLayout = view.findViewById(R.id.swiperefresh)
-        refreshLayout.applyColors(R.attr.colorPrimary, R.attr.colorAccent)
+        refreshLayout.applyColors()
         refreshLayout.recyclerView = recyclerView
         refreshLayout.setOnRefreshListener {
             activity.showRefreshHintSnackbarIfNeeded()


### PR DESCRIPTION
They're always the same colors and probably will be in future use cases
as well.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>