### PR TITLE
Only lock swipe on drawer

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -99,6 +99,7 @@ import org.openhab.habdroid.ui.activity.ContentController
 import org.openhab.habdroid.ui.homescreenwidget.VoiceWidget
 import org.openhab.habdroid.ui.homescreenwidget.VoiceWidgetWithIcon
 import org.openhab.habdroid.ui.preference.toItemUpdatePrefValue
+import org.openhab.habdroid.ui.widget.LockableDrawerLayout
 import org.openhab.habdroid.util.AsyncServiceResolver
 import org.openhab.habdroid.util.CrashReportingHelper
 import org.openhab.habdroid.util.HttpClient
@@ -131,7 +132,7 @@ import org.openhab.habdroid.util.updateDefaultSitemap
 class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
     private lateinit var prefs: SharedPreferences
     private var serviceResolveJob: Job? = null
-    private lateinit var drawerLayout: DrawerLayout
+    private lateinit var drawerLayout: LockableDrawerLayout
     private lateinit var drawerToggle: ActionBarDrawerToggle
     private lateinit var drawerMenu: Menu
     private lateinit var drawerModeSelectorContainer: View
@@ -1234,9 +1235,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
     }
 
     fun setDrawerLocked(locked: Boolean) {
-        drawerLayout.setDrawerLockMode(
-            if (locked) DrawerLayout.LOCK_MODE_LOCKED_CLOSED else DrawerLayout.LOCK_MODE_UNLOCKED
-        )
+        drawerLayout.isSwipeDisabled = locked
     }
 
     private fun handlePropertyFetchFailure(request: Request, statusCode: Int, error: Throwable) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/LockableDrawerLayout.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/LockableDrawerLayout.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.habdroid.ui.widget
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import androidx.drawerlayout.widget.DrawerLayout
+
+class LockableDrawerLayout constructor(context: Context, attrs: AttributeSet?) : DrawerLayout(context, attrs) {
+    var isSwipeDisabled = false
+
+    override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+        if (isSwipeDisabled) {
+            return false
+        }
+        return super.onInterceptTouchEvent(ev)
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onTouchEvent(ev: MotionEvent): Boolean {
+        if (isSwipeDisabled) {
+            return false
+        }
+        return super.onTouchEvent(ev)
+    }
+}

--- a/mobile/src/main/res/layout/activity_main.xml
+++ b/mobile/src/main/res/layout/activity_main.xml
@@ -25,7 +25,7 @@
             android:indeterminateTintMode="src_in" />
     </androidx.appcompat.widget.Toolbar>
 
-    <androidx.drawerlayout.widget.DrawerLayout
+    <org.openhab.habdroid.ui.widget.LockableDrawerLayout
         android:id="@+id/activity_content"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -42,5 +42,5 @@
             android:layout_gravity="start"
             android:background="?android:colorBackground" />
 
-    </androidx.drawerlayout.widget.DrawerLayout>
+    </org.openhab.habdroid.ui.widget.LockableDrawerLayout>
 </LinearLayout>


### PR DESCRIPTION
When the app is opened by a shortcut to e.g. HABPanel, and it doesn't go
fullscreen, the drawer button is disabled as well.
With this commit only disable swipe-to-open, but keep the drawer button
active.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>