### PR TITLE
Always show full chart scalling summary

### DIFF
--- a/mobile/src/main/res/layout/chart_scaling_pref.xml
+++ b/mobile/src/main/res/layout/chart_scaling_pref.xml
@@ -18,6 +18,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?android:attr/listPreferredItemHeight"
@@ -47,7 +48,7 @@
     </LinearLayout>
 
     <RelativeLayout
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="6dip"
         android:layout_marginBottom="6dip"
@@ -61,7 +62,8 @@
             android:singleLine="true"
             android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
             android:ellipsize="marquee"
-            android:fadingEdge="horizontal" />
+            android:fadingEdge="horizontal"
+            tools:text="@string/settings_chart_scaling" />
 
         <!-- Using UnPressableLinearLayout as a workaround to disable the pressed state propagation
         to the children of this container layout. Otherwise, the animated pressed state will also
@@ -96,18 +98,19 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="end|center_vertical"
                 android:textAppearance="?android:attr/textAppearanceSmall"
-                android:textColor="?android:attr/textColorSecondary" />
+                android:textColor="?android:attr/textColorSecondary"
+                tools:text="@string/settings_chart_scaling_value_m" />
 
         </androidx.preference.UnPressableLinearLayout>
 
-        <TextView android:id="@android:id/summary"
+        <TextView
+            android:id="@android:id/summary"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignStart="@android:id/title"
             android:layout_below="@id/seekbar_wrapper"
             android:textAppearance="?android:attr/textAppearanceSmall"
-            android:textColor="?android:attr/textColorSecondary"
-            android:maxLines="4" />
+            android:textColor="?android:attr/textColorSecondary" />
 
     </RelativeLayout>
 


### PR DESCRIPTION
I noticed that the summary is truncated on small displays when the font is set to large.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>