### PR TITLE
Load widgets after activity has been restored

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
@@ -184,6 +184,8 @@ abstract class ContentController protected constructor(private val activity: Mai
         }
         temporaryPage = fm.getFragment(state, STATE_KEY_TEMPORARY_PAGE)
         noConnectionFragment = fm.getFragment(state, STATE_KEY_ERROR_FRAGMENT)
+
+        updateConnectionState()
     }
 
     /**

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/PageConnectionHolderFragment.kt
@@ -297,7 +297,7 @@ class PageConnectionHolderFragment : Fragment(), CoroutineScope {
         }
 
         private fun handleResponse(response: String, headers: Headers) {
-            val id = headers.get("X-Atmosphere-tracking-id")
+            val id = headers["X-Atmosphere-tracking-id"]
             if (id != null) {
                 atmosphereTrackingId = id
             }


### PR DESCRIPTION
Fixes #2220

`PageConnectionHolderFragment`'s `connections` was null after it has
been recreated.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>