### PR TITLE
Catch "Exceeded maximum number of wifi locks" during discovery

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/util/AsyncServiceResolver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/AsyncServiceResolver.kt
@@ -76,7 +76,9 @@ class AsyncServiceResolver(
         try {
             multicastLock.acquire()
         } catch (e: SecurityException) {
-            Log.i(TAG, "Could not acquire multicast lock", e)
+            Log.e(TAG, "Could not acquire multicast lock", e)
+        } catch (e: UnsupportedOperationException) {
+            Log.e(TAG, "Could not acquire multicast lock", e)
         }
 
         Log.i(TAG, "Discovering service $serviceType")


### PR DESCRIPTION
````
Fatal Exception: java.lang.UnsupportedOperationException: Exceeded maximum number of wifi locks
       at android.net.wifi.WifiManager$MulticastLock.acquire(WifiManager.java:3370)
       at org.openhab.habdroid.util.AsyncServiceResolver.resolve(AsyncServiceResolver.kt:77)
       at org.openhab.habdroid.ui.MainActivity$onActiveConnectionChanged$1.invokeSuspend(MainActivity.kt:476)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>