### PR TITLE
Fix IllegalArgumentException when adding shortcut

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -1359,7 +1359,11 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
                 .setIcon(Icon.createWithResource(this, icon))
                 .setIntent(intent)
                 .build()
-            shortcutManager?.addDynamicShortcuts(listOf(shortcut))
+            try {
+                shortcutManager?.addDynamicShortcuts(listOf(shortcut))
+            } catch (e: IllegalArgumentException) {
+                Log.e(TAG, "Failed to add shortcut $id", e)
+            }
         } else {
             shortcutManager?.disableShortcuts(listOf(id), getString(disableMessage))
         }


### PR DESCRIPTION
````
Fatal Exception: java.lang.IllegalArgumentException: Max number of dynamic shortcuts exceeded
       at android.os.Parcel.createExceptionOrNull(Parcel.java:2377)
       at android.os.Parcel.createException(Parcel.java:2357)
       at android.os.Parcel.readException(Parcel.java:2340)
       at android.os.Parcel.readException(Parcel.java:2282)
       at android.content.pm.IShortcutService$Stub$Proxy.addDynamicShortcuts(IShortcutService.java:703)
       at android.content.pm.ShortcutManager.addDynamicShortcuts(ShortcutManager.java:232)
       at org.openhab.habdroid.ui.MainActivity.manageShortcut(MainActivity.kt:1365)
       at org.openhab.habdroid.ui.MainActivity.manageHabPanelShortcut(MainActivity.kt:1328)
       at org.openhab.habdroid.ui.MainActivity.updateDrawerItemVisibility(MainActivity.kt:968)
       at org.openhab.habdroid.ui.MainActivity.updateSitemapDrawerEntries(MainActivity.kt:936)
       at org.openhab.habdroid.ui.MainActivity.access$updateSitemapDrawerEntries(MainActivity.kt:132)
       at org.openhab.habdroid.ui.MainActivity$queryServerProperties$successCb$1.invoke(MainActivity.kt:687)
       at org.openhab.habdroid.ui.MainActivity$queryServerProperties$successCb$1.invoke(MainActivity.kt:132)
       at org.openhab.habdroid.model.ServerProperties$Companion$fetchSitemaps$1.invokeSuspend(ServerProperties.kt:177)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>