### PR TITLE
Increase memory allocated by JVM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Setup Gradle
-        run: mkdir ~/.gradle/ && echo "mapsApiKey=AIzaSyA2t2893e9wccs9EnlnauJRgtqFNYQSp-o" >> ~/.gradle/gradle.properties && echo "org.gradle.daemon=true" >> ~/.gradle/gradle.properties
+        run: mkdir ~/.gradle/ && echo -e "org.gradle.jvmargs=-Xmx6144M\nmapsApiKey=AIzaSyA2t2893e9wccs9EnlnauJRgtqFNYQSp-o\norg.gradle.daemon=true" >> ~/.gradle/gradle.properties
       - name: Build (full, beta)
         run: ./gradlew :mobile:assembleFullBeta
       - name: Unit Tests (full, beta)


### PR DESCRIPTION
Recently gradle throws OOM exceptions quite often.
The default runner has 7GB ram: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>