### PR TITLE
Fix creation of webview shortcuts

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
@@ -50,7 +50,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.openhab.habdroid.R
@@ -206,22 +205,18 @@ abstract class AbstractWebViewFragment : Fragment(), ConnectionFactory.UpdateLis
         val context = context ?: return
         askForShortcutTitle(context, shortcutInfo) {
             val success = ShortcutManagerCompat.requestPinShortcut(context, it, null)
-            launch {
-                withContext(Dispatchers.Main) {
-                    if (success) {
-                        (activity as? MainActivity)?.showSnackbar(
-                            MainActivity.SNACKBAR_TAG_SHORTCUT_INFO,
-                            R.string.home_shortcut_success_pinning,
-                            Snackbar.LENGTH_SHORT
-                        )
-                    } else {
-                        (activity as? MainActivity)?.showSnackbar(
-                            MainActivity.SNACKBAR_TAG_SHORTCUT_INFO,
-                            R.string.home_shortcut_error_pinning,
-                            Snackbar.LENGTH_LONG
-                        )
-                    }
-                }
+            if (success) {
+                (activity as? MainActivity)?.showSnackbar(
+                    MainActivity.SNACKBAR_TAG_SHORTCUT_INFO,
+                    R.string.home_shortcut_success_pinning,
+                    Snackbar.LENGTH_SHORT
+                )
+            } else {
+                (activity as? MainActivity)?.showSnackbar(
+                    MainActivity.SNACKBAR_TAG_SHORTCUT_INFO,
+                    R.string.home_shortcut_error_pinning,
+                    Snackbar.LENGTH_LONG
+                )
             }
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
@@ -95,10 +95,8 @@ abstract class AbstractWebViewFragment : Fragment(), ConnectionFactory.UpdateLis
                 .putExtra(MainActivity.EXTRA_SERVER_ID, context.getPrefs().getActiveServerId())
                 .setAction(shortcutAction)
 
-            launch {
-                webView?.url?.toHttpUrlOrNull()?.let {
-                    intent.putExtra(MainActivity.EXTRA_SUBPAGE, it.toRelativeUrl())
-                }
+            webView?.url?.toHttpUrlOrNull()?.let {
+                intent.putExtra(MainActivity.EXTRA_SUBPAGE, it.toRelativeUrl())
             }
 
             return ShortcutInfoCompat.Builder(context, "$shortcutAction-${System.currentTimeMillis()}")
@@ -405,7 +403,9 @@ abstract class AbstractWebViewFragment : Fragment(), ConnectionFactory.UpdateLis
         @JavascriptInterface
         fun pinToHome() {
             Log.d(TAG, "pinToHome()")
-            fragment.pinShortcut()
+            fragment.launch {
+                fragment.pinShortcut()
+            }
         }
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
@@ -19,6 +19,8 @@ import android.content.Intent
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.text.InputType
 import android.text.SpannableStringBuilder
 import android.util.Log
@@ -91,8 +93,10 @@ abstract class AbstractWebViewFragment : Fragment(), ConnectionFactory.UpdateLis
                 .putExtra(MainActivity.EXTRA_SERVER_ID, context.getPrefs().getActiveServerId())
                 .setAction(shortcutAction)
 
-            webView?.url?.toHttpUrlOrNull()?.let {
-                intent.putExtra(MainActivity.EXTRA_SUBPAGE, it.toRelativeUrl())
+            Handler(Looper.getMainLooper()).post {
+                webView?.url?.toHttpUrlOrNull()?.let {
+                    intent.putExtra(MainActivity.EXTRA_SUBPAGE, it.toRelativeUrl())
+                }
             }
 
             return ShortcutInfoCompat.Builder(context, "$shortcutAction-${System.currentTimeMillis()}")


### PR DESCRIPTION
Fixes #2506

````
W/WebView: java.lang.Throwable: A WebView method was called on thread 'JavaBridge'. All WebView methods must be called on the same thread. (Expected Looper Looper (main, tid 2) {44709f2} called on Looper (JavaBridge, tid 6438) {7566e81}, FYI main Looper is Looper (main, tid 2) {44709f2})
        at android.webkit.WebView.checkThread(WebView.java:2575)
        at android.webkit.WebView.getUrl(WebView.java:1251)
        at org.openhab.habdroid.ui.activity.AbstractWebViewFragment.getShortcutInfo(AbstractWebViewFragment.kt:96)
        at org.openhab.habdroid.ui.activity.AbstractWebViewFragment.pinShortcut(AbstractWebViewFragment.kt:206)
        at org.openhab.habdroid.ui.activity.AbstractWebViewFragment.access$pinShortcut(AbstractWebViewFragment.kt:70)
        at org.openhab.habdroid.ui.activity.AbstractWebViewFragment$OHAppInterfaceWithPin.pinToHome(AbstractWebViewFragment.kt:405)
        at android.os.MessageQueue.nativePollOnce(Native Method)
        at android.os.MessageQueue.next(MessageQueue.java:336)
        at android.os.Looper.loop(Looper.java:174)
        at android.os.HandlerThread.run(HandlerThread.java:67)
2021-03-31 22:54:09.694 4816-4988/org.openhab.habdroid D/StrictMode: StrictMode policy violation: android.os.strictmode.WebViewMethodCalledOnWrongThreadViolation
        at android.webkit.WebView.checkThread(WebView.java:2575)
        at android.webkit.WebView.getUrl(WebView.java:1251)
        at org.openhab.habdroid.ui.activity.AbstractWebViewFragment.getShortcutInfo(AbstractWebViewFragment.kt:96)
        at org.openhab.habdroid.ui.activity.AbstractWebViewFragment.pinShortcut(AbstractWebViewFragment.kt:206)
        at org.openhab.habdroid.ui.activity.AbstractWebViewFragment.access$pinShortcut(AbstractWebViewFragment.kt:70)
        at org.openhab.habdroid.ui.activity.AbstractWebViewFragment$OHAppInterfaceWithPin.pinToHome(AbstractWebViewFragment.kt:405)
        at android.os.MessageQueue.nativePollOnce(Native Method)
        at android.os.MessageQueue.next(MessageQueue.java:336)
        at android.os.Looper.loop(Looper.java:174)
        at android.os.HandlerThread.run(HandlerThread.java:67)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>