### PR TITLE
Only lock drawer for webview UIs with side menu

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
@@ -82,6 +82,7 @@ abstract class AbstractWebViewFragment : Fragment(), ConnectionFactory.UpdateLis
     abstract val urlToLoad: String
     abstract val urlForError: String
     open val avoidAuthentication = false
+    abstract val lockDrawer: Boolean
     abstract val shortcutIcon: Int
     abstract val shortcutAction: String
     private val shortcutInfo: ShortcutInfoCompat
@@ -163,14 +164,18 @@ abstract class AbstractWebViewFragment : Fragment(), ConnectionFactory.UpdateLis
         super.onResume()
         webView?.onResume()
         webView?.resumeTimers()
-        (activity as MainActivity?)?.setDrawerLocked(true)
+        if (lockDrawer) {
+            (activity as MainActivity?)?.setDrawerLocked(true)
+        }
     }
 
     override fun onPause() {
         super.onPause()
         webView?.onPause()
         webView?.pauseTimers()
-        (activity as MainActivity?)?.setDrawerLocked(false)
+        if (lockDrawer) {
+            (activity as MainActivity?)?.setDrawerLocked(false)
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/FrontailWebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/FrontailWebViewFragment.kt
@@ -24,6 +24,7 @@ class FrontailWebViewFragment : AbstractWebViewFragment() {
     override val urlToLoad = "/"
     override val urlForError = "/"
     override val avoidAuthentication = true
+    override val lockDrawer = false
     override val shortcutIcon = R.mipmap.ic_shortcut_frontail
     override val shortcutAction = MainActivity.ACTION_FRONTAIL_SELECTED
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/HabpanelWebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/HabpanelWebViewFragment.kt
@@ -22,6 +22,7 @@ class HabpanelWebViewFragment : AbstractWebViewFragment() {
     override val errorMessageRes = R.string.habpanel_error
     override val urlToLoad = "/habpanel/index.html"
     override val urlForError = "/rest/events"
+    override val lockDrawer = true
     override val shortcutIcon = R.mipmap.ic_shortcut_habpanel
     override val shortcutAction = MainActivity.ACTION_HABPANEL_SELECTED
 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/Oh3UiWebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/Oh3UiWebViewFragment.kt
@@ -23,6 +23,7 @@ class Oh3UiWebViewFragment : AbstractWebViewFragment() {
     override val errorMessageRes = R.string.oh3_ui_error
     override val urlToLoad = "/"
     override val urlForError = "/"
+    override val lockDrawer = true
     override val shortcutIcon = R.mipmap.ic_shortcut_oh3_ui
     override val shortcutAction = MainActivity.ACTION_OH3_UI_SELECTED
 


### PR DESCRIPTION
Frontail doesn't have a drawer on its own, so no need to lock the app drawer here.