### PR TITLE
Use a progress bar in WebViews

### DIFF
--- a/mobile/src/main/res/layout/fragment_webview.xml
+++ b/mobile/src/main/res/layout/fragment_webview.xml
@@ -12,6 +12,15 @@
         android:layout_height="match_parent"
         tools:visibility="gone" />
 
+    <ProgressBar
+        android:id="@+id/progress"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/widgetlist_item_side_margin"
+        android:paddingEnd="@dimen/widgetlist_item_side_margin"
+        android:layout_gravity="top|center_horizontal" />
+
     <LinearLayout
         android:id="@android:id/empty"
         android:layout_width="match_parent"
@@ -49,11 +58,4 @@
             android:text="@string/try_again_button" />
 
     </LinearLayout>
-
-    <ProgressBar
-        android:id="@+id/progress"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center" />
-
 </FrameLayout>


### PR DESCRIPTION
The current progress indicator is shown in the middle of the screen. It
may draw on top of Webview content, because the indicator is hidden at
100% loading progress. However some content may be displayed before,
e.g. at 70%.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>