### PR TITLE
Fix voice widget not available

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -31,6 +31,9 @@
     <queries>
         <package android:name="net.dinglisch.android.taskerm" />
         <package android:name="com.twofortyfouram.locale" />
+        <intent>
+            <action android:name="android.speech.RecognitionService" />
+        </intent>
     </queries>
 
     <application


### PR DESCRIPTION
`SpeechRecognizer.isRecognitionAvailable()` internally uses a query
which has to be added to the manifest to work on Android 11.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>