### PR TITLE
Fix base64 images overridden by URL images

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.kt
@@ -103,6 +103,7 @@ class WidgetImageView constructor(context: Context, attrs: AttributeSet?) : AppC
     }
 
     fun setBase64EncodedImage(base64: String) {
+        prepareForNonHttpImage()
         val data = Base64.decode(base64, Base64.DEFAULT)
         val bitmap = BitmapFactory.decodeByteArray(data, 0, data.size)
 


### PR DESCRIPTION
If `WidgetImageView` is used for a URL image with refresh and then
recycled for a base64 image without refresh, so previous refresh isn't
stopped.

Fixes #2539

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>