### PR TITLE
SendDeviceInfoSettingsFragment: Unregister shared prefs listener

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -1155,6 +1155,11 @@ class PreferencesActivity : AbstractBaseActivity() {
             }
         }
 
+        override fun onDetach() {
+            prefs.unregisterOnSharedPreferenceChangeListener(this)
+            super.onDetach()
+        }
+
         override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
             if (key in BackgroundTasksManager.KNOWN_PERIODIC_KEYS) {
                 EventListenerService.startOrStopService(requireContext())


### PR DESCRIPTION
Otherwise causes:
````
Fatal Exception: java.lang.IllegalStateException: Fragment SendDeviceInfoSettingsFragment not attached to a context.
       at androidx.fragment.app.Fragment.requireContext(Fragment.java:805)
       at org.openhab.habdroid.ui.PreferencesActivity$SendDeviceInfoSettingsFragment.onSharedPreferenceChanged(PreferencesActivity.kt:1148)
       at android.app.SharedPreferencesImpl$EditorImpl.notifyListeners(SharedPreferencesImpl.java:612)
       at android.app.SharedPreferencesImpl$EditorImpl.apply(SharedPreferencesImpl.java:494)
       at androidx.preference.Preference.tryCommit(Preference.java:1632)
       at androidx.preference.Preference.persistString(Preference.java:1663)
       at org.openhab.habdroid.ui.preference.ItemUpdatingPreference.setValue(ItemUpdatingPreference.kt:109)
       at org.openhab.habdroid.ui.preference.ItemUpdatingPreference$PrefDialogFragment.onDialogClosed(ItemUpdatingPreference.kt:200)
       at androidx.preference.PreferenceDialogFragmentCompat.onDismiss(PreferenceDialogFragmentCompat.java:265)
       at androidx.fragment.app.DialogFragment$3.onDismiss(DialogFragment.java:120)
       at android.app.Dialog$ListenersHandler.handleMessage(Dialog.java:1575)
       at android.os.Handler.dispatchMessage(Handler.java:107)
       at android.os.Looper.loop(Looper.java:213)
       at android.app.ActivityThread.main(ActivityThread.java:8178)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>