### PR TITLE
Hide client cert pref by default

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -839,6 +839,7 @@ class PreferencesActivity : AbstractBaseActivity() {
                 true
             }
 
+            val wifiSsidPref = getPreference("wifi_ssid") as EditTextPreference
             if (prefs.getConfiguredServerIds().isEmpty()) {
                 preferenceScreen.removePreferenceRecursively(PrefKeys.PRIMARY_SERVER_PREF)
                 preferenceScreen.removePreferenceRecursively("wifi_ssid")
@@ -857,7 +858,6 @@ class PreferencesActivity : AbstractBaseActivity() {
                     true
                 }
 
-                val wifiSsidPref = getPreference("wifi_ssid") as EditTextPreference
                 wifiSsidPref.text = config.wifiSsid
                 wifiSsidPref.summaryProvider = Preference.SummaryProvider<EditTextPreference> { preference ->
                     val value = preference.text
@@ -879,6 +879,14 @@ class PreferencesActivity : AbstractBaseActivity() {
                     )
                     true
                 }
+            }
+
+            val advancedPrefs = getPreference("advanced_prefs")
+            advancedPrefs.setOnPreferenceClickListener {
+                advancedPrefs.isVisible = false
+                clientCertPref.isVisible = true
+                wifiSsidPref.isVisible = true
+                false
             }
         }
 

--- a/mobile/src/main/res/drawable/ic_keyboard_arrow_down_grey_24dp.xml
+++ b/mobile/src/main/res/drawable/ic_keyboard_arrow_down_grey_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#757575"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M7.41,8.59L12,13.17l4.59,-4.58L18,10l-6,6 -6,-6 1.41,-1.41z"/>
+</vector>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -121,6 +121,7 @@
     <string name="settings_server_primary_summary_is_not_primary">"%s" is the primary server. Touch to make this server the primary one.\nCurrently only the primary server is supported by all features of this app. Touch the help button for more information.</string>
     <string name="settings_server_primary_url" translatable="false">https://www.openhab.org/docs/apps/android.html#multi-server-support</string>
     <string name="settings_server_default_name">openHAB %d</string>
+    <string name="settings_advanced">Advanced</string>
     <string name="click_here_for_more_information">Touch here for more information</string>
     <string name="settings_multi_server_wifi_ssid_summary_set">The app will select this server when connected to Wi-Fi \'%s\'</string>
     <string name="settings_multi_server_wifi_ssid_summary_unset">The app will not automatically select this server based on connected Wi-Fi network</string>

--- a/mobile/src/main/res/xml/preferences_server.xml
+++ b/mobile/src/main/res/xml/preferences_server.xml
@@ -18,18 +18,6 @@
         android:persistent="false"
         android:title="@string/settings_openhab_alt_connection"
         android:icon="@drawable/ic_tree_outline_grey_24dp" />
-    <org.openhab.habdroid.ui.preference.SslClientCertificatePreference
-        android:defaultValue="@string/settings_openhab_none"
-        android:key="clientcert"
-        android:persistent="false"
-        android:summary="@string/settings_openhab_none"
-        android:title="@string/settings_openhab_sslclientcert" />
-    <org.openhab.habdroid.ui.preference.CustomInputTypePreference
-        android:key="wifi_ssid"
-        android:persistent="false"
-        app:whitespaceBehavior="trim"
-        android:inputType="text"
-        android:title="@string/settings_wifi_ssid" />
     <Preference
         android:clickable="true"
         android:key="clear_default_sitemap"
@@ -38,4 +26,24 @@
         android:key="primary_server_pref"
         android:icon="@drawable/ic_star_border_grey_24dp"
         android:title="@string/settings_server_primary_title" />
+    <Preference
+        android:clickable="true"
+        app:isPreferenceVisible="true"
+        android:key="advanced_prefs"
+        android:icon="@drawable/ic_keyboard_arrow_down_grey_24dp"
+        android:title="@string/settings_advanced" />
+    <org.openhab.habdroid.ui.preference.SslClientCertificatePreference
+        android:defaultValue="@string/settings_openhab_none"
+        android:key="clientcert"
+        android:persistent="false"
+        app:isPreferenceVisible="false"
+        android:summary="@string/settings_openhab_none"
+        android:title="@string/settings_openhab_sslclientcert" />
+    <org.openhab.habdroid.ui.preference.CustomInputTypePreference
+        android:key="wifi_ssid"
+        android:persistent="false"
+        app:isPreferenceVisible="false"
+        app:whitespaceBehavior="trim"
+        android:inputType="text"
+        android:title="@string/settings_wifi_ssid" />
 </PreferenceScreen>


### PR DESCRIPTION
IMO there are more users that are confused by this settings, then
actual users of this. I added an entry "Advanced" that shows the
client cert and wifi prefs when clicked.

The Android settings have the same feature: Under "Network and Internet"
a few preferences are hidden by default, e.g. VPN or DoH.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>