### PR TITLE
Migrate widget label

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -48,7 +48,7 @@ android {
         applicationId "org.openhab.habdroid"
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode 380
+        versionCode 390
         versionName "2.17.2-beta"
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/mobile/src/main/java/org/openhab/habdroid/core/UpdateBroadcastReceiver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/UpdateBroadcastReceiver.kt
@@ -186,7 +186,8 @@ class UpdateBroadcastReceiver : BroadcastReceiver() {
                         oldData.item,
                         oldData.state,
                         oldData.label,
-                        oldData.widgetLabel ?: context.getString(R.string.item_update_widget_text, oldData.label, oldData.mappedState),
+                        oldData.widgetLabel
+                            ?: context.getString(R.string.item_update_widget_text, oldData.label, oldData.mappedState),
                         oldData.mappedState,
                         oldData.icon,
                         oldData.theme

--- a/mobile/src/main/java/org/openhab/habdroid/core/UpdateBroadcastReceiver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/UpdateBroadcastReceiver.kt
@@ -51,8 +51,11 @@ class UpdateBroadcastReceiver : BroadcastReceiver() {
         }
 
         val prefs = context.getPrefs()
+        val comparableVersion = prefs.getInt(PrefKeys.COMPARABLE_VERSION, 0)
+        Log.d(TAG, "Run with comparableVersion $comparableVersion")
+
         prefs.edit {
-            if (prefs.getInt(PrefKeys.COMPARABLE_VERSION, 0) <= UPDATE_LOCAL_CREDENTIALS) {
+            if (comparableVersion <= UPDATE_LOCAL_CREDENTIALS) {
                 Log.d(TAG, "Checking for putting local username/password to remote username/password.")
                 if (prefs.getStringOrNull("default_openhab_remote_username") == null) {
                     putString("default_openhab_remote_username", prefs.getStringOrNull("default_openhab_username"))
@@ -61,7 +64,7 @@ class UpdateBroadcastReceiver : BroadcastReceiver() {
                     putString("default_openhab_remote_password", prefs.getStringOrNull("default_openhab_password"))
                 }
             }
-            if (prefs.getInt(PrefKeys.COMPARABLE_VERSION, 0) <= SECURE_CREDENTIALS) {
+            if (comparableVersion <= SECURE_CREDENTIALS) {
                 Log.d(TAG, "Put username/password to encrypted prefs.")
                 context.getSecretPrefs().edit {
                     putString("default_openhab_username", prefs.getStringOrNull("default_openhab_username"))
@@ -81,7 +84,7 @@ class UpdateBroadcastReceiver : BroadcastReceiver() {
                 remove("default_openhab_remote_username")
                 remove("default_openhab_remote_password")
             }
-            if (prefs.getInt(PrefKeys.COMPARABLE_VERSION, 0) <= DARK_MODE) {
+            if (comparableVersion <= DARK_MODE) {
                 Log.d(TAG, "Migrate to day/night themes")
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -105,7 +108,7 @@ class UpdateBroadcastReceiver : BroadcastReceiver() {
 
                 putInt(PrefKeys.ACCENT_COLOR, accentColor)
             }
-            if (prefs.getInt(PrefKeys.COMPARABLE_VERSION, 0) <= WIDGET_ICON) {
+            if (comparableVersion <= WIDGET_ICON) {
                 Log.d(TAG, "Migrate widget icon prefs")
                 val widgetComponent = ComponentName(context, ItemUpdateWidget::class.java)
                 AppWidgetManager.getInstance(context).getAppWidgetIds(widgetComponent).forEach { id ->
@@ -119,7 +122,7 @@ class UpdateBroadcastReceiver : BroadcastReceiver() {
                 Log.d(TAG, "Update widgets")
                 ItemUpdateWidget.updateAllWidgets(context)
             }
-            if (prefs.getInt(PrefKeys.COMPARABLE_VERSION, 0) <= MULTI_SERVER_SUPPORT) {
+            if (comparableVersion <= MULTI_SERVER_SUPPORT) {
                 // if local or remote server URL are set, convert them to a server named 'openHAB'
                 val localUrl = prefs.getStringOrNull("default_openhab_url")
                 val remoteUrl = prefs.getStringOrNull("default_openhab_alturl")
@@ -174,6 +177,24 @@ class UpdateBroadcastReceiver : BroadcastReceiver() {
                     }
                 }
             }
+            if (comparableVersion <= WIDGETS_NO_AUTO_GEN_LABEL) {
+                val widgetComponent = ComponentName(context, ItemUpdateWidget::class.java)
+                AppWidgetManager.getInstance(context).getAppWidgetIds(widgetComponent).forEach { id ->
+                    val oldData = ItemUpdateWidget.getInfoForWidget(context, id)
+
+                    val newData = ItemUpdateWidget.ItemUpdateWidgetData(
+                        oldData.item,
+                        oldData.state,
+                        oldData.label,
+                        oldData.widgetLabel ?: context.getString(R.string.item_update_widget_text, oldData.label, oldData.mappedState),
+                        oldData.mappedState,
+                        oldData.icon,
+                        oldData.theme
+                    )
+
+                    ItemUpdateWidget.saveInfoForWidget(context, newData, id)
+                }
+            }
 
             updateComparableVersion(this)
         }
@@ -194,6 +215,7 @@ class UpdateBroadcastReceiver : BroadcastReceiver() {
         private const val DARK_MODE = 200
         private const val WIDGET_ICON = 250
         private const val MULTI_SERVER_SUPPORT = 330
+        private const val WIDGETS_NO_AUTO_GEN_LABEL = 380
 
         fun updateComparableVersion(editor: SharedPreferences.Editor) {
             editor.putInt(PrefKeys.COMPARABLE_VERSION, BuildConfig.VERSION_CODE).apply()

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -449,11 +449,12 @@ class WidgetListFragment : Fragment(), WidgetAdapter.ItemClickListener,
     private fun requestPinAppWidget(context: Context, widget: Widget, state: String, mappedState: String) {
         val appWidgetManager = AppWidgetManager.getInstance(context)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && appWidgetManager.isRequestPinAppWidgetSupported) {
+            val widgetLabel = widget.item?.label.orEmpty()
             val data = ItemUpdateWidget.ItemUpdateWidgetData(
                 widget.item?.name ?: return,
                 state,
-                widget.item.label.orEmpty(),
-                null,
+                widgetLabel,
+                getString(R.string.item_update_widget_text, widgetLabel, mappedState),
                 mappedState,
                 widget.icon,
                 context.getPrefs().getStringOrFallbackIfEmpty(PrefKeys.LAST_WIDGET_THEME, "dark")

--- a/mobile/src/main/java/org/openhab/habdroid/ui/homescreenwidget/ItemUpdateWidget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/homescreenwidget/ItemUpdateWidget.kt
@@ -56,6 +56,7 @@ import org.openhab.habdroid.util.dpToPixel
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getStringOrEmpty
 import org.openhab.habdroid.util.getStringOrFallbackIfEmpty
+import org.openhab.habdroid.util.getStringOrNull
 import org.openhab.habdroid.util.isSvg
 import org.openhab.habdroid.util.showToast
 import org.openhab.habdroid.util.svgToBitmap
@@ -263,7 +264,7 @@ open class ItemUpdateWidget : AppWidgetProvider() {
             val item = prefs.getStringOrEmpty(PreferencesActivity.ITEM_UPDATE_WIDGET_ITEM)
             val state = prefs.getStringOrEmpty(PreferencesActivity.ITEM_UPDATE_WIDGET_STATE)
             val label = prefs.getStringOrEmpty(PreferencesActivity.ITEM_UPDATE_WIDGET_LABEL)
-            val widgetLabel = prefs.getStringOrEmpty(PreferencesActivity.ITEM_UPDATE_WIDGET_WIDGET_LABEL)
+            val widgetLabel = prefs.getStringOrNull(PreferencesActivity.ITEM_UPDATE_WIDGET_WIDGET_LABEL)
             val mappedState = prefs.getStringOrEmpty(PreferencesActivity.ITEM_UPDATE_WIDGET_MAPPED_STATE)
             val icon = prefs.getIconResource(PreferencesActivity.ITEM_UPDATE_WIDGET_ICON)
             // Fallback to the theme of the previously set widget
@@ -314,9 +315,7 @@ open class ItemUpdateWidget : AppWidgetProvider() {
             val views = RemoteViews(context.packageName, layout)
             views.setOnClickPendingIntent(R.id.outer_layout, itemUpdatePendingIntent)
             views.setOnClickPendingIntent(R.id.edit, editPendingIntent)
-            val widgetLabel = data.widgetLabel
-                ?: context.getString(R.string.item_update_widget_text, data.label, data.mappedState)
-            views.setTextViewText(R.id.text, widgetLabel)
+            views.setTextViewText(R.id.text, data.widgetLabel.orEmpty())
             hideLoadingIndicator(views)
             return views
         }


### PR DESCRIPTION
Previously `null` as widget label meant that the label will be generated
automatically based on the item label and item command during widget
update.
Now this is done when selecting an item and command in the
PreferencesActivity.

Fixes #2603

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>