### PR TITLE
Fix SslClientCertificatePreference persistence

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/PreferencesActivity.kt
@@ -818,6 +818,7 @@ class PreferencesActivity : AbstractBaseActivity() {
                 )
                 true
             }
+            clientCertPref.setValue(config.sslClientCert)
 
             val clearDefaultSitemapPref = getPreference(PrefKeys.CLEAR_DEFAULT_SITEMAP)
             if (config.defaultSitemap?.name.isNullOrEmpty()) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/SslClientCertificatePreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/SslClientCertificatePreference.kt
@@ -110,7 +110,7 @@ class SslClientCertificatePreference constructor(context: Context, attrs: Attrib
         }
     }
 
-    private fun setValue(value: String?) {
+    fun setValue(value: String?) {
         val changed = value != currentAlias
         if (changed || currentAlias == null) {
             currentAlias = value


### PR DESCRIPTION
`onSetInitialValue()` calls `getPersistedString()`, but
SslClientCertificatePreference isn't persistent and therefore always
loads the default value, which is `null`.
This resulted in a loss of the cert whenever the server prefs have been
saved.

Fixes #2566

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>