### PR TITLE
Fix crash when shortcut title is empty

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
@@ -253,9 +253,11 @@ abstract class AbstractWebViewFragment : Fragment(), ConnectionFactory.UpdateLis
             .setTitle(getString(R.string.home_shortcut_title))
             .setView(input)
             .setPositiveButton(android.R.string.ok) { _, _ ->
+                val label = if (input.text.isNullOrEmpty()) " " else input.text
+
                 callback(
                     ShortcutInfoCompat.Builder(orig)
-                        .setShortLabel(input.text)
+                        .setShortLabel(label)
                         .build()
                 )
             }


### PR DESCRIPTION
Fixes #2637

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>