### PR TITLE
Don't needlessly open about:blank for WebView widgets

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/ConnectionWebViewClient.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ConnectionWebViewClient.kt
@@ -58,13 +58,15 @@ open class ConnectionWebViewClient(
 
     // This is called on older Android versions
     override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
-        if (url.toUri().host == view.url?.toUri()?.host) {
+        val uri = url.toUri()
+        val viewUri = view.url?.toUri()
+        if (uri.host == viewUri?.host) {
             Log.d(TAG, "Same host: Load in WebView ($url)")
             return false
         }
 
-        Log.d(TAG, "New host: Open in external browser ($url)")
-        url.toUri().openInBrowser(view.context)
+        Log.d(TAG, "New host: Open in external browser ($url, WebView is on $viewUri)")
+        uri.openInBrowser(view.context)
 
         return true
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -1143,9 +1143,9 @@ class WidgetAdapter(
             }
             with(webView) {
                 adjustForWidgetHeight(widget, 0)
-                loadUrl("about:blank")
 
                 if (url == null) {
+                    loadUrl("about:blank")
                     return
                 }
                 setUpForConnection(connection, url) { progress ->

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -44,6 +44,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.view.children
 import androidx.core.view.get
 import androidx.core.view.isGone
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.core.widget.ContentLoadingProgressBar
 import androidx.recyclerview.widget.RecyclerView
@@ -1155,7 +1156,9 @@ class WidgetAdapter(
                         progressBar.show()
                     }
                     progressBar.progress = progress
+                    webView.isInvisible = progress == 0
                 }
+                webView.isInvisible = true
                 loadUrl(url.toString())
             }
         }


### PR DESCRIPTION
Doing so causes the the comparisons which check whether to use the WebView or an external browser in ConnectionWebViewClient to fail, as they'll compare the actual URL to about:blank.

Fixes #2633
