### PR TITLE
Suggest SSIDs in Settings

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/CustomInputTypePreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/CustomInputTypePreference.kt
@@ -19,12 +19,14 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.View
+import android.widget.ArrayAdapter
 import android.widget.EditText
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.preference.EditTextPreference
 import androidx.preference.EditTextPreferenceDialogFragmentCompat
 import androidx.preference.PreferenceDataStore
+import com.google.android.material.textfield.MaterialAutoCompleteTextView
 import com.google.android.material.textfield.TextInputLayout
 import org.openhab.habdroid.R
 import org.openhab.habdroid.ui.CustomDialogPreference
@@ -83,7 +85,7 @@ open class CustomInputTypePreference constructor(context: Context, attrs: Attrib
 
     class PrefFragment : EditTextPreferenceDialogFragmentCompat(), TextWatcher {
         private lateinit var wrapper: TextInputLayout
-        private lateinit var editor: EditText
+        private lateinit var editor: MaterialAutoCompleteTextView
         private var whitespaceBehavior: WhitespaceBehavior? = null
 
         override fun onBindDialogView(view: View?) {
@@ -114,6 +116,11 @@ open class CustomInputTypePreference constructor(context: Context, attrs: Attrib
                 WhitespaceBehavior.values()[whitespaceBehaviorId]
             } else {
                 WhitespaceBehavior.IGNORE
+            }
+
+            arguments?.getStringArray(KEY_SUGGESTIONS)?.let {
+                val adapter = ArrayAdapter(editor.context, android.R.layout.simple_dropdown_item_1line, it)
+                editor.setAdapter(adapter)
             }
         }
 
@@ -152,6 +159,7 @@ open class CustomInputTypePreference constructor(context: Context, attrs: Attrib
             private const val KEY_INPUT_TYPE = "inputType"
             private const val KEY_TITLE = "title"
             private const val KEY_AUTOFILL_HINTS = "autofillHint"
+            private const val KEY_SUGGESTIONS = "suggestions"
             private const val KEY_WHITESPACE_BEHAVIOR = "whitespaceBehavior"
 
             fun newInstance(
@@ -159,7 +167,8 @@ open class CustomInputTypePreference constructor(context: Context, attrs: Attrib
                 title: CharSequence,
                 inputType: Int,
                 autofillHints: Array<String>?,
-                whitespaceBehavior: Int
+                whitespaceBehavior: Int,
+                suggestions: Array<String>? = null
             ): PrefFragment {
                 val f = PrefFragment()
                 f.arguments = bundleOf(
@@ -167,6 +176,7 @@ open class CustomInputTypePreference constructor(context: Context, attrs: Attrib
                     KEY_TITLE to title,
                     KEY_INPUT_TYPE to inputType,
                     KEY_AUTOFILL_HINTS to autofillHints,
+                    KEY_SUGGESTIONS to suggestions,
                     KEY_WHITESPACE_BEHAVIOR to whitespaceBehavior
                 )
                 return f

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/WifiSsidInputPreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/WifiSsidInputPreference.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.habdroid.ui.preference
+
+import android.content.Context
+import android.text.InputType
+import android.util.AttributeSet
+import androidx.fragment.app.DialogFragment
+import org.openhab.habdroid.core.OpenHabApplication
+import org.openhab.habdroid.util.getCurrentWifiSsid
+
+class WifiSsidInputPreference constructor(context: Context, attrs: AttributeSet) :
+    CustomInputTypePreference(context, attrs) {
+    override fun createDialog(): DialogFragment {
+        val currentSsid = context.getCurrentWifiSsid(OpenHabApplication.DATA_ACCESS_TAG_SELECT_SERVER_WIFI)
+        return PrefFragment.newInstance(
+            key,
+            title,
+            InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS,
+            emptyArray(),
+            WhitespaceBehavior.TRIM.ordinal,
+            currentSsid?.let { arrayOf(it) }
+        )
+    }
+}

--- a/mobile/src/main/res/xml/preferences_server.xml
+++ b/mobile/src/main/res/xml/preferences_server.xml
@@ -37,7 +37,7 @@
         android:persistent="false"
         app:isPreferenceVisible="false"
         android:title="@string/settings_openhab_sslclientcert" />
-    <org.openhab.habdroid.ui.preference.CustomInputTypePreference
+    <org.openhab.habdroid.ui.preference.WifiSsidInputPreference
         android:key="wifi_ssid"
         android:persistent="false"
         app:isPreferenceVisible="false"


### PR DESCRIPTION
TODO:

- [X] ~~Handle missing permissions~~ Even without permissions the user should be able to enter the SSID.

It seems that there's no way to get all saved Wi-Fi SSIDs on the latest Android version. Therefore only suggest the current one.
In most cases the user will be connected to the correct Wi-Fi when setting up the server anyway.

Closes #2663

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>