### PR TITLE
Show state in selection even if unmapped

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -757,7 +757,12 @@ class WidgetAdapter(
             var spinnerSelectedIndex = boundMappings.indexOfFirst { mapping -> mapping.value == stateString }
 
             if (spinnerSelectedIndex == -1) {
-                spinnerArray.add("          ")
+                val state = widget.stateFromLabel
+                if (state.isNullOrEmpty()) {
+                    spinnerArray.add("          ")
+                } else {
+                    spinnerArray.add(state)
+                }
                 spinnerSelectedIndex = spinnerArray.size - 1
             }
 


### PR DESCRIPTION
When an item defines a state format in its label, it should be shown in selection widgets, even if the current value isn't in the mappings.

This has been fixed for Basic UI and Classic UI as well: https://github.com/openhab/openhab-webui/issues/247

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>