### PR TITLE
Fix ClassCastException when loading server configuration

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/ServerConfiguration.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ServerConfiguration.kt
@@ -170,7 +170,11 @@ data class ServerConfiguration(
                 return null
             }
             val clientCert = prefs.getStringOrNull(PrefKeys.buildServerKey(id, PrefKeys.SSL_CLIENT_CERT_PREFIX))
-            val wifiSsids = prefs.getStringSet(PrefKeys.buildServerKey(id, PrefKeys.WIFI_SSID_PREFIX), emptySet())
+            val wifiSsids = try {
+                prefs.getStringSet(PrefKeys.buildServerKey(id, PrefKeys.WIFI_SSID_PREFIX), emptySet())
+            } catch (e: ClassCastException) {
+                setOf(prefs.getStringOrNull(PrefKeys.buildServerKey(id, PrefKeys.WIFI_SSID_PREFIX)))
+            }
 
             val config = ServerConfiguration(
                 id,


### PR DESCRIPTION
A few devices have the following crash, so it seems that the migration didn't run there.

````
Fatal Exception: java.lang.ClassCastException: java.lang.String cannot be cast to java.util.Set
       at android.app.SharedPreferencesImpl.getStringSet(SharedPreferencesImpl.java:298)
       at org.openhab.habdroid.model.ServerConfiguration$Companion.load(ServerConfiguration.kt:173)
       at org.openhab.habdroid.core.connection.ConnectionFactory.loadServerConnections(ConnectionFactory.kt:221)
       at org.openhab.habdroid.core.connection.ConnectionFactory.updateConnections(ConnectionFactory.kt:206)
       at org.openhab.habdroid.core.connection.ConnectionFactory.updateConnections$default(ConnectionFactory.kt:193)
       at org.openhab.habdroid.core.connection.ConnectionFactory$Companion$initialize$1.invokeSuspend(ConnectionFactory.kt:522)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
````