### PR TITLE
Case insensitive icon name handling

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
@@ -14,6 +14,7 @@
 package org.openhab.habdroid.model
 
 import android.os.Parcelable
+import java.util.Locale
 import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
@@ -311,7 +312,7 @@ fun JSONObject.toItem(): Item {
     return Item(
         name,
         optString("label", name).trim(),
-        optStringOrNull("category"),
+        optStringOrNull("category")?.lowercase(Locale.getDefault()),
         getString("type").toItemType(),
         optString("groupType").toItemType(),
         optStringOrNull("link"),

--- a/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
@@ -312,7 +312,7 @@ fun JSONObject.toItem(): Item {
     return Item(
         name,
         optString("label", name).trim(),
-        optStringOrNull("category")?.lowercase(Locale.getDefault()),
+        optStringOrNull("category")?.lowercase(Locale.US),
         getString("type").toItemType(),
         optString("groupType").toItemType(),
         optStringOrNull("link"),

--- a/mobile/src/test/java/org/openhab/habdroid/model/ItemTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/model/ItemTest.kt
@@ -114,6 +114,12 @@ class ItemTest {
     }
 
     @Test
+    fun getIcon() {
+        val sut = itemAsJsonObject.toItem()
+        assertEquals("switch", sut.category)
+    }
+
+    @Test
     fun testEquals() {
         val sut1a = itemAsJsonObjectWithMembers.toItem()
         val sut1b = itemAsJsonObjectWithMembers.toItem()
@@ -158,7 +164,8 @@ class ItemTest {
                 'type': 'Group',
                 'name': 'LocationGroup',
                 'label': 'Location Group',
-                'tags': [ "Lighting", "Switchable", "Timestamp", "foobar" ] }
+                'tags': [ "Lighting", "Switchable", "Timestamp", "foobar" ],
+                'category': 'Switch' }
             """.trimIndent()
         )
     }


### PR DESCRIPTION
openHAB 3 returns `Switch` as default icon for switch items. Therefore
the icon suggestion for quick tiles fails, because `"Switch" != "switch"`.
Because the icon rest api also works case insensitive, force lower case
on all icon names of items.

Example:

- https://demo.openhab.org/icon/bedroom_blue
- https://demo.openhab.org/icon/BedRoom_blue

Both links show the same icon.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>