### PR TITLE
Fix ItemUpdateWorker crash on Android < 12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.5.21'
+    ext.kotlin_version = '1.6.0'
     repositories {
         mavenCentral()
         google()

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -2,7 +2,7 @@ def taskRequests = getGradle().getStartParameter().getTaskRequests().toString()
 def isFoss = taskRequests.contains("Foss") || taskRequests.contains("foss")
 
 buildscript {
-    ext.kotlin_coroutines_version = '1.4.2'
+    ext.kotlin_coroutines_version = '1.5.2'
     ext.ok_http_version = '4.9.3'
     ext.work_manager_version = '2.7.1'
     ext.about_libraries_version = '8.9.4'
@@ -105,7 +105,10 @@ android {
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
-        freeCompilerArgs += ["-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"]
+        freeCompilerArgs += [
+            "-Xopt-in=kotlinx.coroutines.ObsoleteCoroutinesApi",
+            "-Xopt-in=kotlinx.coroutines.DelicateCoroutinesApi"
+        ]
         allWarningsAsErrors = true
     }
 }
@@ -141,7 +144,7 @@ dependencies {
     implementation "androidx.biometric:biometric:1.1.0"
     implementation "com.google.android.material:material:1.4.0"
     implementation "androidx.multidex:multidex:2.0.1"
-    implementation "androidx.work:work-runtime:$work_manager_version"
+    implementation "androidx.work:work-runtime-ktx:$work_manager_version"
     fullImplementation "androidx.work:work-gcm:$work_manager_version"
     implementation "androidx.security:security-crypto:1.0.0"
     implementation "com.google.android.exoplayer:exoplayer:$exoplayer_version"

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -284,7 +284,7 @@ class ConnectionFactory internal constructor(
     ) {
         val prevState = stateChannel.value
         val newState = StateHolder(primary, active, primaryCloud, activeCloud)
-        stateChannel.offer(newState)
+        stateChannel.trySend(newState)
         if (callListenersOnChange) launch {
             if (newState.active?.failureReason != null ||
                 prevState.active?.connection !== newState.active?.connection

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -35,7 +35,9 @@ import javax.net.ssl.X509KeyManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
+import kotlinx.coroutines.channels.onClosed
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -285,6 +287,7 @@ class ConnectionFactory internal constructor(
         val prevState = stateChannel.value
         val newState = StateHolder(primary, active, primaryCloud, activeCloud)
         stateChannel.trySend(newState)
+            .onClosed { throw it ?: ClosedSendChannelException("Channel was closed normally") }
         if (callListenersOnChange) launch {
             if (newState.active?.failureReason != null ||
                 prevState.active?.connection !== newState.active?.connection

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -257,7 +257,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         UpdateBroadcastReceiver.updateComparableVersion(prefs.edit())
 
         val isSpeechRecognizerAvailable = SpeechRecognizer.isRecognitionAvailable(this)
-        GlobalScope.launch {
+        launch {
             showPushNotificationWarningIfNeeded()
             manageVoiceRecognitionShortcut(isSpeechRecognizerAvailable)
             setVoiceWidgetComponentEnabledSetting(VoiceWidget::class.java, isSpeechRecognizerAvailable)
@@ -532,7 +532,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
     override fun onPrimaryCloudConnectionChanged(connection: CloudConnection?) {
         CrashReportingHelper.d(TAG, "onPrimaryCloudConnectionChanged()")
         handlePendingAction()
-        GlobalScope.launch {
+        launch {
             showPushNotificationWarningIfNeeded()
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/util/AsyncServiceResolver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/AsyncServiceResolver.kt
@@ -28,6 +28,8 @@ import javax.jmdns.ServiceListener
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedSendChannelException
+import kotlinx.coroutines.channels.onClosed
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -116,7 +118,8 @@ class AsyncServiceResolver(
 
     override fun serviceResolved(event: ServiceEvent) {
         scope.launch {
-            serviceInfoChannel.offer(event.info)
+            serviceInfoChannel.trySend(event.info)
+                .onClosed { throw it ?: ClosedSendChannelException("Channel was closed normally") }
         }
     }
 

--- a/mobile/src/test/java/org/openhab/habdroid/core/connection/ConnectionFactoryTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/core/connection/ConnectionFactoryTest.kt
@@ -26,7 +26,7 @@ import com.nhaarman.mockitokotlin2.whenever
 import java.io.File
 import java.io.IOException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
@@ -48,7 +48,7 @@ import org.openhab.habdroid.testUtils.RetryRule
 import org.openhab.habdroid.util.PrefKeys
 
 class ConnectionFactoryTest {
-    @ObsoleteCoroutinesApi
+    @ExperimentalCoroutinesApi
     companion object {
         private val mainThread = newSingleThreadContext("UI thread")
 


### PR DESCRIPTION
Workers have to implement `getForegroundInfoAsync()` on Android < 12 or
they will crash.

Solution taken from https://stackoverflow.com/a/69627331

Fixes #2761

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>