### PR TITLE
Improve hiding section switches

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -360,7 +360,7 @@ class WidgetAdapter(
     ) : ViewHolder(inflater, parent, layoutResId) {
         protected val labelView: TextView = itemView.findViewById(R.id.widgetlabel)
         private val valueView: TextView? = itemView.findViewById(R.id.widgetvalue)
-        private val iconView: WidgetImageView = itemView.findViewById(R.id.widgeticon)
+        protected val iconView: WidgetImageView = itemView.findViewById(R.id.widgeticon)
 
         override fun bind(widget: Widget) {
             labelView.text = widget.label
@@ -854,7 +854,7 @@ class WidgetAdapter(
 
         override fun onGlobalLayout() {
             Log.d(TAG, "onGlobalLayout()")
-            group.isVisible = group.measuredWidth < (itemView.width * 0.8)
+            group.isVisible = group.measuredWidth < (itemView.width - iconView.measuredWidth)
             spinner.isVisible = !group.isVisible
         }
 

--- a/mobile/src/main/res/layout/widgetlist_icontext.xml
+++ b/mobile/src/main/res/layout/widgetlist_icontext.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
     <org.openhab.habdroid.ui.widget.WidgetImageView
         android:id="@+id/widgeticon"
         android:layout_width="@dimen/widgetlist_icon_size"
@@ -18,6 +19,7 @@
         android:ellipsize="end"
         android:maxLines="1"
         android:textDirection="locale"
-        android:textAppearance="?android:attr/textAppearanceMedium" />
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        tools:text="Some label"/>
 
 </merge>


### PR DESCRIPTION
Use the actual available space for the switches, not 'just' 80% of the device width.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>