### PR TITLE
Revert "Bump material from 1.4.0 to 1.5.0 (#2797)"

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -142,7 +142,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.1.3"
     implementation "androidx.preference:preference-ktx:1.1.1"
     implementation "androidx.biometric:biometric:1.1.0"
-    implementation "com.google.android.material:material:1.5.0"
+    implementation "com.google.android.material:material:1.4.0"
     implementation "androidx.multidex:multidex:2.0.1"
     implementation "androidx.work:work-runtime-ktx:$work_manager_version"
     fullImplementation "androidx.work:work-gcm:$work_manager_version"


### PR DESCRIPTION
This version requires some migrations, see #2799

This reverts commit db5853cf0ff64a8bcd2a4a9a569762ab8a878993.