### PR TITLE
Trigger all 'Send device info' workers when opening app

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -703,7 +703,9 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         }
         propsUpdateHandle = ServerProperties.fetch(this, connection!!,
             successCb, this::handlePropertyFetchFailure)
-        BackgroundTasksManager.triggerPeriodicWork(this)
+        BackgroundTasksManager.KNOWN_KEYS.forEach { key ->
+            BackgroundTasksManager.scheduleWorker(this, key, false)
+        }
     }
 
     private fun chooseSitemap() {


### PR DESCRIPTION
This helps in two cases:
1. The user clicks on the 'Failed to update item' notification. In this
   case the notification and therefore also the notification action
   'retry' vanishes. Then the user cannot retry sending e.g. the alarm
   clock.
2. Existing 'waiting for network' workers are queued again and will
   send the update immediatly.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>