### PR TITLE
Lookup active server ID in correct shared prefs

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -176,7 +176,7 @@ class ConnectionFactory internal constructor(
         if (key == PrefKeys.DEBUG_MESSAGES) {
             updateHttpLoggerSettings()
         }
-        val serverId = sharedPreferences.getActiveServerId()
+        val serverId = prefs.getActiveServerId()
         if (key in UPDATE_TRIGGERING_KEYS ||
             CLIENT_CERT_UPDATE_TRIGGERING_PREFIXES.any { prefix -> key == PrefKeys.buildServerKey(serverId, prefix) }
         ) {
@@ -220,14 +220,9 @@ class ConnectionFactory internal constructor(
     }
 
     private fun loadServerConnections(serverId: Int): ServerConnections? {
-        val config = ServerConfiguration.load(prefs, secretPrefs, serverId)
-        if (config == null) {
-            return null
-        }
-        val local =
-            config.localPath?.let { path -> DefaultConnection(httpClient, Connection.TYPE_LOCAL, path) }
-        val remote =
-            config.remotePath?.let { path -> DefaultConnection(httpClient, Connection.TYPE_REMOTE, path) }
+        val config = ServerConfiguration.load(prefs, secretPrefs, serverId) ?: return null
+        val local = config.localPath?.let { path -> DefaultConnection(httpClient, Connection.TYPE_LOCAL, path) }
+        val remote = config.remotePath?.let { path -> DefaultConnection(httpClient, Connection.TYPE_REMOTE, path) }
         return ServerConnections(local, remote)
     }
 


### PR DESCRIPTION
This listener is also used for `secretPrefs`. However the active server
ID isn't saved there and therefore `getActiveServerId()` always returns
the default value `0`.

This leads to not updating connections when changing credentials.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>