### PR TITLE
Connect to Wi-Fi if permissions are missing

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -461,6 +461,10 @@ class ConnectionFactory internal constructor(
         }
 
         val currentSsid = context.getCurrentWifiSsid(OpenHabApplication.DATA_ACCESS_TAG_SELECT_SERVER_WIFI)
+        if (currentSsid.isNullOrEmpty()) {
+            Log.d(TAG, "Got SSID '$currentSsid'. Assume missing permissions and connect to server.")
+            return true
+        }
         return serverPrefs.wifiSsids?.contains(currentSsid) == true
     }
 


### PR DESCRIPTION
Otherwise when the permissions for location access isn't granted, the
background tasks silently fail.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>