### PR TITLE
Don't fallback to Item name as label

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
@@ -311,7 +311,7 @@ fun JSONObject.toItem(): Item {
 
     return Item(
         name,
-        optString("label", name).trim(),
+        optStringOrNull("label")?.trim(),
         optStringOrNull("category")?.lowercase(Locale.US),
         getString("type").toItemType(),
         optString("groupType").toItemType(),

--- a/mobile/src/test/java/org/openhab/habdroid/model/ItemTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/model/ItemTest.kt
@@ -19,6 +19,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -120,6 +121,12 @@ class ItemTest {
     }
 
     @Test
+    fun testNoLabel() {
+        val sut = itemAsJsonObjectWithoutLabel.toItem()
+        assertNull(sut.label)
+    }
+
+    @Test
     fun testEquals() {
         val sut1a = itemAsJsonObjectWithMembers.toItem()
         val sut1b = itemAsJsonObjectWithMembers.toItem()
@@ -166,6 +173,13 @@ class ItemTest {
                 'label': 'Location Group',
                 'tags': [ "Lighting", "Switchable", "Timestamp", "foobar" ],
                 'category': 'Switch' }
+            """.trimIndent()
+        )
+        private val itemAsJsonObjectWithoutLabel = JSONObject(
+            """
+              { 'state': 'NULL',
+                'type': 'Group',
+                'name': 'LocationGroup' }
             """.trimIndent()
         )
     }


### PR DESCRIPTION
Background: I was looking at a way to hide "internal" items from Android
11 device control, e.g. items used to synchronize between rules or store
rule states.

I discovered that Items without a label are filtered out, but this only
works when the label can be actually null/empty.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>