### PR TITLE
Make sending bluetooth device addresses event based

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -110,7 +110,7 @@ class BackgroundTasksManager : BroadcastReceiver() {
                 Log.d(TAG, "Wifi state changed")
                 scheduleWorker(context, PrefKeys.SEND_WIFI_SSID, true)
             }
-            BluetoothDevice.ACTION_ACL_DISCONNECTED, BluetoothDevice.ACTION_ACL_CONNECTED -> {
+            BluetoothDevice.ACTION_ACL_CONNECTED, BluetoothDevice.ACTION_ACL_DISCONNECTED -> {
                 Log.d(TAG, "Bluetooth device connected")
                 scheduleWorker(context, PrefKeys.SEND_BLUETOOTH_DEVICES, true)
             }
@@ -297,7 +297,6 @@ class BackgroundTasksManager : BroadcastReceiver() {
             PrefKeys.SEND_BATTERY_LEVEL,
             PrefKeys.SEND_CHARGING_STATE,
             PrefKeys.SEND_WIFI_SSID,
-            PrefKeys.SEND_BLUETOOTH_DEVICES,
             PrefKeys.SEND_DND_MODE
         )
         private val IGNORED_PACKAGES_FOR_ALARM = listOf(
@@ -336,10 +335,6 @@ class BackgroundTasksManager : BroadcastReceiver() {
                     }
                     if (prefs.isItemUpdatePrefEnabled(PrefKeys.SEND_WIFI_SSID)) {
                         addAction(WifiManager.NETWORK_STATE_CHANGED_ACTION)
-                    }
-                    if (prefs.isItemUpdatePrefEnabled(PrefKeys.SEND_BLUETOOTH_DEVICES)) {
-                        addAction(BluetoothDevice.ACTION_ACL_CONNECTED)
-                        addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED)
                     }
                     if (prefs.isItemUpdatePrefEnabled(PrefKeys.SEND_GADGETBRIDGE)) {
                         GADGETBRIDGE_ACTIONS.forEach { action ->

--- a/mobile/src/main/java/org/openhab/habdroid/background/EventListenerService.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/EventListenerService.kt
@@ -109,7 +109,6 @@ class EventListenerService : Service() {
             PrefKeys.SEND_BATTERY_LEVEL,
             PrefKeys.SEND_CHARGING_STATE,
             PrefKeys.SEND_WIFI_SSID,
-            PrefKeys.SEND_BLUETOOTH_DEVICES,
             PrefKeys.SEND_DND_MODE,
             PrefKeys.SEND_GADGETBRIDGE
         )
@@ -127,7 +126,6 @@ class EventListenerService : Service() {
             PrefKeys.SEND_BATTERY_LEVEL -> R.string.settings_battery_level
             PrefKeys.SEND_CHARGING_STATE -> R.string.settings_charging_state
             PrefKeys.SEND_WIFI_SSID -> R.string.settings_wifi_ssid
-            PrefKeys.SEND_BLUETOOTH_DEVICES -> R.string.settings_bluetooth_devices
             PrefKeys.SEND_DND_MODE -> R.string.settings_dnd_mode
             PrefKeys.SEND_GADGETBRIDGE -> R.string.settings_gadgetbridge
             else -> throw IllegalArgumentException("No summary for $key")

--- a/mobile/src/main/res/xml/preferences_device_information.xml
+++ b/mobile/src/main/res/xml/preferences_device_information.xml
@@ -28,6 +28,15 @@
             app:iconEnabled="@drawable/ic_phone_outline_grey_24dp"
             app:iconDisabled="@drawable/ic_phone_off_outline_grey_24dp" />
         <org.openhab.habdroid.ui.preference.ItemUpdatingPreference
+            android:defaultValue="false|BluetoothDevices"
+            android:key="send_bluetooth_devices"
+            app:helpUrl="https://www.openhab.org/docs/apps/android.html#bluetooth-devices"
+            app:summaryEnabled="@string/settings_bluetooth_devices_summary_on"
+            app:summaryDisabled="@string/settings_bluetooth_devices_summary_off"
+            android:title="@string/settings_bluetooth_devices"
+            app:iconEnabled="@drawable/ic_baseline_bluetooth_grey_24dp"
+            app:iconDisabled="@drawable/ic_baseline_bluetooth_disabled_grey_24dp" />
+        <org.openhab.habdroid.ui.preference.ItemUpdatingPreference
             android:defaultValue="false|Gadgetbridge"
             android:key="send_gadgetbridge"
             app:helpUrl="@string/settings_gadgetbridge_howto_url"
@@ -80,15 +89,6 @@
             android:title="@string/settings_wifi_ssid"
             app:iconEnabled="@drawable/ic_wifi_strength_outline_grey_24dp"
             app:iconDisabled="@drawable/ic_wifi_strength_off_outline_grey_24dp" />
-        <org.openhab.habdroid.ui.preference.ItemUpdatingPreference
-            android:defaultValue="false|BluetoothDevices"
-            android:key="send_bluetooth_devices"
-            app:helpUrl="https://www.openhab.org/docs/apps/android.html#bluetooth-devices"
-            app:summaryEnabled="@string/settings_bluetooth_devices_summary_on"
-            app:summaryDisabled="@string/settings_bluetooth_devices_summary_off"
-            android:title="@string/settings_bluetooth_devices"
-            app:iconEnabled="@drawable/ic_baseline_bluetooth_grey_24dp"
-            app:iconDisabled="@drawable/ic_baseline_bluetooth_disabled_grey_24dp" />
         <org.openhab.habdroid.ui.preference.ItemUpdatingPreference
             android:defaultValue="false|DndMode"
             android:key="send_dnd_mode"


### PR DESCRIPTION
See https://github.com/openhab/openhab-android/issues/2895#issuecomment-1133591328

There's an exeception for bluetooth related broadcasts: https://developer.android.com/guide/components/broadcast-exceptions.html

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>