### PR TITLE
Refactor data saver handling

### DIFF
--- a/mobile/src/full/java/org/openhab/habdroid/core/CloudMessagingHelper.kt
+++ b/mobile/src/full/java/org/openhab/habdroid/core/CloudMessagingHelper.kt
@@ -59,7 +59,8 @@ object CloudMessagingHelper {
     suspend fun getPushNotificationStatus(context: Context): PushNotificationStatus {
         ConnectionFactory.waitForInitialization()
         val prefs = context.getPrefs()
-        val cloudFailure = ConnectionFactory.primaryCloudConnection?.failureReason
+        val cloudConnectionResult = ConnectionFactory.primaryCloudConnection
+        val cloudFailure = cloudConnectionResult?.failureReason
         return when {
             // No remote server is configured
             prefs.getRemoteUrl(prefs.getPrimaryServerId()).isEmpty() ->
@@ -81,7 +82,7 @@ object CloudMessagingHelper {
                 PushNotificationStatus(message, R.drawable.ic_bell_off_outline_grey_24dp, true)
             }
             // Remote server is configured, but it's not a cloud instance
-            ConnectionFactory.primaryCloudConnection?.connection == null && ConnectionFactory.primaryRemoteConnection != null ->
+            cloudConnectionResult?.connection == null && ConnectionFactory.hasPrimaryRemoteConnection ->
                 PushNotificationStatus(
                     context.getString(R.string.push_notification_status_remote_no_cloud),
                     R.drawable.ic_bell_off_outline_grey_24dp,

--- a/mobile/src/main/java/org/openhab/habdroid/core/NotificationHelper.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/NotificationHelper.kt
@@ -125,7 +125,7 @@ class NotificationHelper constructor(private val context: Context) {
 
         if (message.icon != null) {
             val connection = ConnectionFactory.primaryCloudConnection?.connection
-            if (connection != null && context.determineDataUsagePolicy().canDoLargeTransfers) {
+            if (connection != null && context.determineDataUsagePolicy(connection).canDoLargeTransfers) {
                 try {
                     val targetSize = context.resources.getDimensionPixelSize(R.dimen.notificationlist_icon_size)
                     iconBitmap = connection.httpClient

--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHabApplication.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHabApplication.kt
@@ -183,7 +183,7 @@ class OpenHabApplication : MultiDexApplication() {
         }
 
         override fun onReceive(context: Context, intent: Intent?) {
-            val wasDataSaverActive = systemDataSaverStatus
+            val prevSystemDataSaverStatus = systemDataSaverStatus
             val wasBatterySaverActive = batterySaverActive
             when (intent?.action) {
                 ConnectivityManager.ACTION_RESTRICT_BACKGROUND_CHANGED -> {
@@ -196,7 +196,7 @@ class OpenHabApplication : MultiDexApplication() {
                 }
                 else -> return
             }
-            if (wasDataSaverActive != systemDataSaverStatus || wasBatterySaverActive != batterySaverActive) {
+            if (prevSystemDataSaverStatus != systemDataSaverStatus || wasBatterySaverActive != batterySaverActive) {
                 dataUsagePolicyListeners.forEach { l -> l.onDataUsagePolicyChanged() }
             }
         }

--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHabApplication.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHabApplication.kt
@@ -36,14 +36,12 @@ import org.openhab.habdroid.BuildConfig
 import org.openhab.habdroid.background.BackgroundTasksManager
 import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.util.CrashReportingHelper
-import org.openhab.habdroid.util.DataUsagePolicy
-import org.openhab.habdroid.util.determineDataUsagePolicy
 import org.openhab.habdroid.util.getDayNightMode
 import org.openhab.habdroid.util.getPrefs
 
 class OpenHabApplication : MultiDexApplication() {
     interface OnDataUsagePolicyChangedListener {
-        fun onDataUsagePolicyChanged(newPolicy: DataUsagePolicy)
+        fun onDataUsagePolicyChanged()
     }
 
     val secretPrefs: SharedPreferences by lazy {
@@ -185,7 +183,8 @@ class OpenHabApplication : MultiDexApplication() {
         }
 
         override fun onReceive(context: Context, intent: Intent?) {
-            val oldPolicy = determineDataUsagePolicy()
+            val wasDataSaverActive = systemDataSaverStatus
+            val wasBatterySaverActive = batterySaverActive
             when (intent?.action) {
                 ConnectivityManager.ACTION_RESTRICT_BACKGROUND_CHANGED -> {
                     systemDataSaverStatus = getSystemDataSaverStatus(context)
@@ -197,9 +196,8 @@ class OpenHabApplication : MultiDexApplication() {
                 }
                 else -> return
             }
-            val newPolicy = determineDataUsagePolicy()
-            if (oldPolicy != newPolicy) {
-                dataUsagePolicyListeners.forEach { l -> l.onDataUsagePolicyChanged(newPolicy) }
+            if (wasDataSaverActive != systemDataSaverStatus || wasBatterySaverActive != batterySaverActive) {
+                dataUsagePolicyListeners.forEach { l -> l.onDataUsagePolicyChanged() }
             }
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionManagerHelper.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionManagerHelper.kt
@@ -58,18 +58,19 @@ interface ConnectionManagerHelper {
     }
 
     private class HelperApi21 constructor(context: Context) :
-        ConnectionManagerHelper, ChangeCallbackHelperApi25(context) {
+        ConnectionManagerHelper, ChangeCallbackHelperApi21(context) {
         private val typeHelper = NetworkTypeHelper(context)
         override val currentConnections: List<ConnectionType> get() = typeHelper.currentConnections
     }
 
+    @TargetApi(26)
     private class HelperApi26 constructor(context: Context) :
         ConnectionManagerHelper, ChangeCallbackHelperApi26(context) {
         private val typeHelper = NetworkTypeHelper(context)
         override val currentConnections: List<ConnectionType> get() = typeHelper.currentConnections
     }
 
-    private open class ChangeCallbackHelperApi25 constructor(context: Context) : BroadcastReceiver() {
+    private open class ChangeCallbackHelperApi21 constructor(context: Context) : BroadcastReceiver() {
         var changeCallback: ConnectionChangedCallback? = null
         private val context = context.applicationContext
         private var ignoreNextBroadcast: Boolean
@@ -149,7 +150,7 @@ interface ConnectionManagerHelper {
     }
 
     private class NetworkTypeHelper constructor(context: Context) {
-        private val connectivityManager = context.getSystemService(ConnectivityManager::class.java)!!
+        private val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         val currentConnections: List<ConnectionType> get() {
             // TODO: Replace deprecated function
             @Suppress("DEPRECATION")

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/DefaultConnection.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/DefaultConnection.kt
@@ -27,6 +27,7 @@ import org.openhab.habdroid.util.bindToNetworkIfPossible
 
 open class DefaultConnection : AbstractConnection {
     internal var network: Network? = null
+    internal var isMetered = false
 
     internal constructor(
         httpClient: OkHttpClient,

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ChartWidgetActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ChartWidgetActivity.kt
@@ -158,7 +158,7 @@ class ChartWidgetActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefresh
     }
 
     private fun loadChartImage(force: Boolean) {
-        val conn = connection ?: return
+        val conn = connection ?: return finish()
         val chartUrl = widget.toChartUrl(
             getPrefs(),
             chart.width,

--- a/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationAdapter.kt
@@ -113,7 +113,7 @@ class CloudNotificationAdapter(context: Context, private val loadMoreListener: (
                     conn,
                     notification.icon.toUrl(
                         itemView.context,
-                        itemView.context.determineDataUsagePolicy().loadIconsWithState
+                        itemView.context.determineDataUsagePolicy(conn).loadIconsWithState
                     ),
                     timeoutMillis = 2000
                 )

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ItemPickerAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ItemPickerAdapter.kt
@@ -116,12 +116,13 @@ class ItemPickerAdapter(context: Context, private val itemClickListener: ItemCli
             itemLabelView.text = item.label
             itemTypeView.text = item.type.toString()
 
+            val context = itemView.context
             val connection = ConnectionFactory.primaryUsableConnection?.connection
             val icon = item.category.toOH2IconResource()
             if (icon != null && connection != null) {
                 iconView.setImageUrl(
                     connection,
-                    icon.toUrl(itemView.context, itemView.context.determineDataUsagePolicy().loadIconsWithState),
+                    icon.toUrl(context, context.determineDataUsagePolicy(connection).loadIconsWithState),
                     timeoutMillis = 2000
                 )
             } else {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -474,7 +474,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
             failureReason is NoUrlInformationException -> {
                 // Attempt resolving only if we're connected locally and
                 // no local connection is configured yet
-                if (failureReason.wouldHaveUsedLocalConnection() && ConnectionFactory.activeLocalConnection == null) {
+                if (failureReason.wouldHaveUsedLocalConnection() && !ConnectionFactory.hasActiveLocalConnection) {
                     if (serviceResolveJob == null) {
                         val resolver = AsyncServiceResolver(
                             this,
@@ -653,7 +653,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
             }
         } else {
             val hasLocalAndRemote =
-                ConnectionFactory.activeLocalConnection != null && ConnectionFactory.activeRemoteConnection != null
+                ConnectionFactory.hasActiveLocalConnection && ConnectionFactory.hasActiveRemoteConnection
             val type = connection?.connectionType
             if (hasLocalAndRemote && type == Connection.TYPE_LOCAL) {
                 showSnackbar(
@@ -1032,9 +1032,10 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
             return
         }
         launch {
+            val context = this@MainActivity
             try {
                 item.icon = conn.httpClient.get(
-                    sitemap.icon.toUrl(this@MainActivity, determineDataUsagePolicy().loadIconsWithState)
+                    sitemap.icon.toUrl(context, context.determineDataUsagePolicy(conn).loadIconsWithState)
                 )
                     .asBitmap(defaultIcon!!.intrinsicWidth, ImageConversionPolicy.ForceTargetSize)
                     .response
@@ -1243,7 +1244,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
 
     fun showDataSaverHintSnackbarIfNeeded() {
         if (prefs.getBoolean(PrefKeys.DATA_SAVER_EXPLAINED, false) ||
-            determineDataUsagePolicy().loadIconsWithState
+            determineDataUsagePolicy(connection).loadIconsWithState
         ) {
             return
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -87,7 +87,6 @@ import org.openhab.habdroid.ui.widget.ExtendedSpinner
 import org.openhab.habdroid.ui.widget.PeriodicSignalImageButton
 import org.openhab.habdroid.ui.widget.WidgetImageView
 import org.openhab.habdroid.util.CacheManager
-import org.openhab.habdroid.util.DataUsagePolicy
 import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.MjpegStreamer
 import org.openhab.habdroid.util.beautify
@@ -396,7 +395,7 @@ class WidgetAdapter(
         }
 
         private fun showDataSaverPlaceholderIfNeeded(widget: Widget, canBindWithoutData: Boolean): Boolean {
-            val dataSaverActive = !itemView.context.determineDataUsagePolicy().canDoLargeTransfers &&
+            val dataSaverActive = !itemView.context.determineDataUsagePolicy(connection).canDoLargeTransfers &&
                 !canBindWithoutData
 
             dataSaverView.isVisible = dataSaverActive
@@ -425,8 +424,8 @@ class WidgetAdapter(
             return dataSaverActive
         }
 
-        fun handleDataUsagePolicyChange(dataUsagePolicy: DataUsagePolicy) {
-            if (!dataUsagePolicy.canDoLargeTransfers) {
+        fun handleDataUsagePolicyChange() {
+            if (!itemView.context.determineDataUsagePolicy(connection).canDoLargeTransfers) {
                 // Continue showing the old data, but stop any activity that might need more data transfer
                 stop()
             } else {
@@ -688,7 +687,7 @@ class WidgetAdapter(
         }
 
         override fun onStart() {
-            if (itemView.context.determineDataUsagePolicy().canDoRefreshes) {
+            if (itemView.context.determineDataUsagePolicy(connection).canDoRefreshes) {
                 imageView.startRefreshingIfNeeded()
             } else {
                 imageView.cancelRefresh()
@@ -1029,7 +1028,7 @@ class WidgetAdapter(
         }
 
         override fun onStart() {
-            if (itemView.context.determineDataUsagePolicy().canDoRefreshes) {
+            if (itemView.context.determineDataUsagePolicy(connection).canDoRefreshes) {
                 chart.startRefreshingIfNeeded()
             } else {
                 chart.cancelRefresh()
@@ -1073,7 +1072,7 @@ class WidgetAdapter(
         }
 
         override fun onStart() {
-            if (itemView.context.determineDataUsagePolicy().autoPlayVideos) {
+            if (itemView.context.determineDataUsagePolicy(connection).autoPlayVideos) {
                 exoPlayer.play()
             }
         }
@@ -1380,7 +1379,8 @@ class WidgetAdapter(
 
         private fun handleDataSaver(overrideDataSaver: Boolean) {
             val widget = boundWidget ?: return
-            val dataSaverActive = !itemView.context.determineDataUsagePolicy().canDoLargeTransfers && !overrideDataSaver
+            val dataSaverActive = !itemView.context.determineDataUsagePolicy(connection).canDoLargeTransfers &&
+                !overrideDataSaver
 
             dataSaverView.isVisible = dataSaverActive && hasPositions
             baseMapView.isVisible = !dataSaverView.isVisible && hasPositions
@@ -1547,7 +1547,7 @@ fun WidgetImageView.loadWidgetIcon(connection: Connection, widget: Widget, mappe
     }
     setImageUrl(
         connection,
-        widget.icon.toUrl(context, context.determineDataUsagePolicy().loadIconsWithState)
+        widget.icon.toUrl(context, context.determineDataUsagePolicy(connection).loadIconsWithState)
     )
     val color = mapper.mapColor(widget.iconColor)
     if (color != null) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -174,13 +174,13 @@ class WidgetListFragment : Fragment(), WidgetAdapter.ItemClickListener,
         startOrStopVisibleViewHolders(false)
     }
 
-    override fun onDataUsagePolicyChanged(newPolicy: DataUsagePolicy) {
+    override fun onDataUsagePolicyChanged() {
         val firstVisibleItemPosition = layoutManager.findFirstVisibleItemPosition()
         val lastVisibleItemPosition = layoutManager.findLastVisibleItemPosition()
         for (i in firstVisibleItemPosition..lastVisibleItemPosition) {
             val holder = recyclerView.findViewHolderForAdapterPosition(i)
             if (holder is WidgetAdapter.HeavyDataViewHolder) {
-                holder.handleDataUsagePolicyChange(newPolicy)
+                holder.handleDataUsagePolicyChange()
             } else if (holder is WidgetAdapter.AbstractMapViewHolder) {
                 holder.handleDataUsagePolicyChange()
             }


### PR DESCRIPTION
- Make data transfer policy depend on whether the used connection is
  metered or not, and only apply data saver logic on metered connections
- Make sure battery saver does not override data saver constraints
- Remove unneeded NetworkTypeApiHelper variants; all needed APIs are
  available in API 21 and newer
