### PR TITLE
Item control: Don't print an error for ALIVE events

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/ItemsControlsProviderService.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/ItemsControlsProviderService.kt
@@ -88,6 +88,10 @@ class ItemsControlsProviderService : ControlsProviderService() {
             while (isActive) {
                 try {
                     val event = JSONObject(eventSubscription.getNextEvent())
+                    if (event.optString("type") == "ALIVE") {
+                        Log.d(TAG, "Got ALIVE event")
+                        continue
+                    }
                     val topic = event.getString("topic")
                     val topicPath = topic.split('/')
                     if (topicPath.size != 4) {


### PR DESCRIPTION
Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>