### PR TITLE
Bump acra_version from 5.9.5 to 5.9.6

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext.powermock_version = '2.0.9'
     ext.espresso_version = '3.4.0'
     ext.exoplayer_version = '2.18.1'
-    ext.acra_version = '5.9.5'
+    ext.acra_version = '5.9.6'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
Bumps `acra_version` from 5.9.5 to 5.9.6.

Updates `acra-mail` from 5.9.5 to 5.9.6
- [Release notes](https://github.com/ACRA/acra/releases)
- [Commits](https://github.com/ACRA/acra/compare/acra-5.9.5...acra-5.9.6)

Updates `acra-notification` from 5.9.5 to 5.9.6
- [Release notes](https://github.com/ACRA/acra/releases)
- [Commits](https://github.com/ACRA/acra/compare/acra-5.9.5...acra-5.9.6)

---
updated-dependencies:
- dependency-name: ch.acra:acra-mail
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: ch.acra:acra-notification
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>