### PR TITLE
Fix slider crash when min and max are equal

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -576,6 +576,13 @@ class WidgetAdapter(
             boundWidget = widget
             val item = widget.item
 
+            val hasValidValues = widget.minValue < widget.maxValue
+            slider.isVisible = hasValidValues
+            if (!hasValidValues) {
+                Log.e(TAG, "Slider has invalid values: from '${widget.minValue}' to '${widget.maxValue}'")
+                return
+            }
+
             if (item?.isOfTypeOrGroupType(Item.Type.Color) == true) {
                 slider.valueTo = 100F
                 slider.valueFrom = 0F


### PR DESCRIPTION
````
Fatal Exception: java.lang.IllegalStateException: valueFrom(0.0) must be smaller than valueTo(0.0)
       at com.google.android.material.slider.BaseSlider.validateValueFrom(BaseSlider.java:520)
       at com.google.android.material.slider.BaseSlider.validateConfigurationIfDirty(BaseSlider.java:608)
       at com.google.android.material.slider.BaseSlider.maybeCalculateTicksCoordinates(BaseSlider.java:1615)
       at com.google.android.material.slider.BaseSlider.updateTrackWidth(BaseSlider.java:1636)
       at com.google.android.material.slider.BaseSlider.onSizeChanged(BaseSlider.java:1606)
````

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>