### PR TITLE
Improve execution of periodic work

### DIFF
--- a/mobile/src/full/java/org/openhab/habdroid/core/CloudMessagingHelper.kt
+++ b/mobile/src/full/java/org/openhab/habdroid/core/CloudMessagingHelper.kt
@@ -52,7 +52,8 @@ object CloudMessagingHelper {
 
     fun needsPollingForNotifications(@Suppress("UNUSED_PARAMETER") context: Context) = false
 
-    fun pollForNotifications(@Suppress("UNUSED_PARAMETER") context: Context) {
+    @Suppress("RedundantSuspendModifier") // Function requires suspend in foss flavor
+    suspend fun pollForNotifications(@Suppress("UNUSED_PARAMETER") context: Context) {
         // Used in foss flavor
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -442,9 +442,9 @@ class BackgroundTasksManager : BroadcastReceiver() {
             }
         }
 
-        fun triggerPeriodicWork(context: Context) {
-            Log.d(TAG, "triggerPeriodicWork()")
-            KNOWN_PERIODIC_KEYS.forEach { key -> scheduleWorker(context, key, false) }
+        fun scheduleUpdatesForAllKeys(context: Context) {
+            Log.d(TAG, "scheduleUpdatesForAllKeys()")
+            KNOWN_KEYS.forEach { key -> scheduleWorker(context, key, false) }
         }
 
         fun schedulePeriodicTrigger(context: Context, force: Boolean = false) {

--- a/mobile/src/main/java/org/openhab/habdroid/background/PeriodicItemUpdateWorker.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/PeriodicItemUpdateWorker.kt
@@ -24,21 +24,21 @@ import org.openhab.habdroid.ui.homescreenwidget.ItemUpdateWidget
 class PeriodicItemUpdateWorker(val context: Context, params: WorkerParameters) : Worker(context, params) {
     override fun doWork(): Result {
         Log.d(TAG, "doWork()")
-        doPeriodicWork(context)
+        runBlocking {
+            doPeriodicWork(context)
+        }
         return Result.success()
     }
 
     companion object {
         private val TAG = PeriodicItemUpdateWorker::class.java.simpleName
 
-        fun doPeriodicWork(context: Context) {
+        suspend fun doPeriodicWork(context: Context) {
             Log.d(TAG, "doPeriodicWork()")
             BackgroundTasksManager.scheduleUpdatesForAllKeys(context)
             ItemUpdateWidget.updateAllWidgets(context)
             if (CloudMessagingHelper.needsPollingForNotifications(context)) {
-                runBlocking {
-                    CloudMessagingHelper.pollForNotifications(context)
-                }
+                CloudMessagingHelper.pollForNotifications(context)
             }
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/background/PeriodicItemUpdateWorker.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/PeriodicItemUpdateWorker.kt
@@ -14,6 +14,7 @@
 package org.openhab.habdroid.background
 
 import android.content.Context
+import android.util.Log
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import kotlinx.coroutines.runBlocking
@@ -22,13 +23,23 @@ import org.openhab.habdroid.ui.homescreenwidget.ItemUpdateWidget
 
 class PeriodicItemUpdateWorker(val context: Context, params: WorkerParameters) : Worker(context, params) {
     override fun doWork(): Result {
-        BackgroundTasksManager.triggerPeriodicWork(context)
-        ItemUpdateWidget.updateAllWidgets(context)
-        if (CloudMessagingHelper.needsPollingForNotifications(context)) {
-            runBlocking {
-                CloudMessagingHelper.pollForNotifications(context)
+        Log.d(TAG, "doWork()")
+        doPeriodicWork(context)
+        return Result.success()
+    }
+
+    companion object {
+        private val TAG = PeriodicItemUpdateWorker::class.java.simpleName
+
+        fun doPeriodicWork(context: Context) {
+            Log.d(TAG, "doPeriodicWork()")
+            BackgroundTasksManager.scheduleUpdatesForAllKeys(context)
+            ItemUpdateWidget.updateAllWidgets(context)
+            if (CloudMessagingHelper.needsPollingForNotifications(context)) {
+                runBlocking {
+                    CloudMessagingHelper.pollForNotifications(context)
+                }
             }
         }
-        return Result.success()
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -739,7 +739,9 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
             successCb,
             this::handlePropertyFetchFailure
         )
-        PeriodicItemUpdateWorker.doPeriodicWork(this)
+        CoroutineScope(Dispatchers.IO + Job()).launch {
+            PeriodicItemUpdateWorker.doPeriodicWork(this@MainActivity)
+        }
     }
 
     private fun chooseSitemap() {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -80,6 +80,7 @@ import org.openhab.habdroid.R
 import org.openhab.habdroid.background.BackgroundTasksManager
 import org.openhab.habdroid.background.EventListenerService
 import org.openhab.habdroid.background.NotificationUpdateObserver
+import org.openhab.habdroid.background.PeriodicItemUpdateWorker
 import org.openhab.habdroid.core.CloudMessagingHelper
 import org.openhab.habdroid.core.OpenHabApplication
 import org.openhab.habdroid.core.UpdateBroadcastReceiver
@@ -99,7 +100,6 @@ import org.openhab.habdroid.model.WebViewUi
 import org.openhab.habdroid.model.sortedWithDefaultName
 import org.openhab.habdroid.model.toTagData
 import org.openhab.habdroid.ui.activity.ContentController
-import org.openhab.habdroid.ui.homescreenwidget.ItemUpdateWidget
 import org.openhab.habdroid.ui.homescreenwidget.VoiceWidget
 import org.openhab.habdroid.ui.homescreenwidget.VoiceWidgetWithIcon
 import org.openhab.habdroid.ui.preference.PreferencesActivity
@@ -272,7 +272,6 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         }
 
         EventListenerService.startOrStopService(this)
-        ItemUpdateWidget.updateAllWidgets(this)
     }
 
     override fun onPostCreate(savedInstanceState: Bundle?) {
@@ -734,11 +733,13 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
             }
             handlePendingAction()
         }
-        propsUpdateHandle = ServerProperties.fetch(this, connection!!,
-            successCb, this::handlePropertyFetchFailure)
-        BackgroundTasksManager.KNOWN_KEYS.forEach { key ->
-            BackgroundTasksManager.scheduleWorker(this, key, false)
-        }
+        propsUpdateHandle = ServerProperties.fetch(
+            this,
+            connection!!,
+            successCb,
+            this::handlePropertyFetchFailure
+        )
+        PeriodicItemUpdateWorker.doPeriodicWork(this)
     }
 
     private fun chooseSitemap() {


### PR DESCRIPTION
* Add a function to do several kind of periodic work: `doPeriodicWork()`
* Call `doPeriodicWork()` instead of `BackgroundTasksManager.triggerPeriodicWork()` and `ItemUpdateWidget.updateAllWidgets()`

With this change notifications are polled when starting the app.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>