### PR TITLE
Migrate to Material 3 

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -145,7 +145,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
     implementation "androidx.preference:preference-ktx:1.2.0"
     implementation "androidx.biometric:biometric:1.1.0"
-    implementation "com.google.android.material:material:1.6.1"
+    implementation "com.google.android.material:material:1.7.0"
     implementation "androidx.multidex:multidex:2.0.1"
     implementation "androidx.work:work-runtime-ktx:$work_manager_version"
     fullImplementation "androidx.work:work-gcm:$work_manager_version"

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -155,10 +155,7 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:$ok_http_version"
     implementation "com.squareup.okhttp3:logging-interceptor:$ok_http_version"
     implementation "com.squareup.okhttp3:okhttp-sse:$ok_http_version"
-    // Color picker for Sitemap
     implementation "com.github.QuadFlask:colorpicker:0.0.15"
-    // Color picker for preference
-    implementation "com.jaredrummler:colorpicker:1.1.0"
     implementation "com.caverock:androidsvg-aar:1.4"
     implementation "com.github.AppIntro:AppIntro:6.2.0"
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'

--- a/mobile/src/main/java/org/openhab/habdroid/core/UpdateBroadcastReceiver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/UpdateBroadcastReceiver.kt
@@ -22,7 +22,6 @@ import android.content.SharedPreferences
 import android.os.Build
 import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import org.openhab.habdroid.BuildConfig
 import org.openhab.habdroid.R
@@ -33,8 +32,8 @@ import org.openhab.habdroid.model.ServerConfiguration
 import org.openhab.habdroid.model.ServerPath
 import org.openhab.habdroid.model.putIconResource
 import org.openhab.habdroid.model.toOH2IconResource
-import org.openhab.habdroid.ui.preference.PreferencesActivity
 import org.openhab.habdroid.ui.homescreenwidget.ItemUpdateWidget
+import org.openhab.habdroid.ui.preference.PreferencesActivity
 import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.getConfiguredServerIds
 import org.openhab.habdroid.util.getDayNightMode
@@ -100,14 +99,6 @@ class UpdateBroadcastReceiver : BroadcastReceiver() {
                 }
 
                 AppCompatDelegate.setDefaultNightMode(prefs.getDayNightMode(context))
-
-                val accentColor = when (prefs.getStringOrNull("default_openhab_theme")) {
-                    "basicui", "basicuidark" -> ContextCompat.getColor(context, R.color.indigo_500)
-                    "black", "dark" -> ContextCompat.getColor(context, R.color.blue_grey_700)
-                    else -> ContextCompat.getColor(context, R.color.openhab_orange)
-                }
-
-                putInt(PrefKeys.ACCENT_COLOR, accentColor)
             }
             if (comparableVersion <= WIDGET_ICON) {
                 Log.d(TAG, "Migrate widget icon prefs")

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractBaseActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractBaseActivity.kt
@@ -14,18 +14,15 @@
 package org.openhab.habdroid.ui
 
 import android.Manifest
-import android.app.ActivityManager
 import android.app.KeyguardManager
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
-import android.graphics.BitmapFactory
 import android.os.Build
 import android.os.Bundle
 import android.os.SystemClock
 import android.provider.Settings
 import android.util.Log
-import android.view.Menu
 import android.view.View
 import androidx.annotation.CallSuper
 import androidx.annotation.ColorInt
@@ -36,8 +33,6 @@ import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import androidx.core.graphics.drawable.DrawableCompat
-import androidx.core.view.forEach
 import androidx.core.view.isInvisible
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
@@ -72,36 +67,6 @@ abstract class AbstractBaseActivity : AppCompatActivity(), CoroutineScope {
     @CallSuper
     override fun onCreate(savedInstanceState: Bundle?) {
         setTheme(getActivityThemeId())
-
-        val colorPrimary = resolveThemedColor(R.attr.colorPrimary)
-
-        val taskDescription = when {
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> {
-                ActivityManager.TaskDescription.Builder()
-                    .setLabel(getString(R.string.app_name))
-                    .setIcon(R.mipmap.icon)
-                    .setPrimaryColor(colorPrimary)
-                    .build()
-            }
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.P -> {
-                @Suppress("DEPRECATION")
-                ActivityManager.TaskDescription(
-                    getString(R.string.app_name),
-                    R.mipmap.icon,
-                    colorPrimary
-                )
-            }
-            else -> {
-                @Suppress("DEPRECATION")
-                ActivityManager.TaskDescription(
-                    getString(R.string.app_name),
-                    BitmapFactory.decodeResource(resources, R.mipmap.icon),
-                    colorPrimary
-                )
-            }
-        }
-
-        setTaskDescription(taskDescription)
 
         super.onCreate(savedInstanceState)
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractBaseActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractBaseActivity.kt
@@ -25,6 +25,7 @@ import android.os.Bundle
 import android.os.SystemClock
 import android.provider.Settings
 import android.util.Log
+import android.view.Menu
 import android.view.View
 import androidx.annotation.CallSuper
 import androidx.annotation.ColorInt
@@ -35,6 +36,8 @@ import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.DrawableCompat
+import androidx.core.view.forEach
 import androidx.core.view.isInvisible
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
@@ -30,12 +30,12 @@ import androidx.activity.OnBackPressedCallback
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
-import androidx.appcompat.widget.Toolbar
 import androidx.core.content.edit
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -84,7 +84,7 @@ abstract class AbstractItemPickerActivity : AbstractBaseActivity(), SwipeRefresh
         setContentView(R.layout.activity_item_picker)
         setResult(RESULT_CANCELED)
 
-        val toolbar = findViewById<Toolbar>(R.id.openhab_toolbar)
+        val toolbar = findViewById<MaterialToolbar>(R.id.openhab_toolbar)
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -49,7 +49,6 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.graphics.drawable.DrawableCompat
@@ -63,6 +62,7 @@ import androidx.core.view.isVisible
 import androidx.core.widget.ContentLoadingProgressBar
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.navigation.NavigationView
 import com.google.android.material.snackbar.Snackbar
 import java.nio.charset.Charset
@@ -811,7 +811,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
     }
 
     private fun setupToolbar() {
-        val toolbar = findViewById<Toolbar>(R.id.openhab_toolbar)
+        val toolbar = findViewById<MaterialToolbar>(R.id.openhab_toolbar)
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.setHomeButtonEnabled(true)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/fragments/MainSettingsFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/fragments/MainSettingsFragment.kt
@@ -31,11 +31,9 @@ import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
-import androidx.fragment.app.commit
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
-import androidx.preference.SwitchPreference
-import com.jaredrummler.android.colorpicker.ColorPreferenceCompat
+import androidx.preference.SwitchPreferenceCompat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.openhab.habdroid.R
@@ -114,7 +112,6 @@ class MainSettingsFragment : PreferencesActivity.AbstractSettingsFragment(), Con
         notificationStatusHint = getPreference(PrefKeys.NOTIFICATION_STATUS_HINT)
         val drawerEntriesPrefs = getPreference(PrefKeys.DRAWER_ENTRIES)
         val themePref = getPreference(PrefKeys.THEME)
-        val accentColorPref = getPreference(PrefKeys.ACCENT_COLOR) as ColorPreferenceCompat
         val clearCachePref = getPreference(PrefKeys.CLEAR_CACHE)
         val fullscreenPref = getPreference(PrefKeys.FULLSCREEN)
         val launcherPref = getPreference(PrefKeys.LAUNCHER)
@@ -129,7 +126,7 @@ class MainSettingsFragment : PreferencesActivity.AbstractSettingsFragment(), Con
         val crashReporting = getPreference(PrefKeys.CRASH_REPORTING)
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            val dataSaverPref = getPreference(PrefKeys.DATA_SAVER) as SwitchPreference
+            val dataSaverPref = getPreference(PrefKeys.DATA_SAVER) as SwitchPreferenceCompat
             dataSaverPref.setSwitchTextOff(R.string.data_saver_off_pre_n)
         }
 
@@ -179,19 +176,6 @@ class MainSettingsFragment : PreferencesActivity.AbstractSettingsFragment(), Con
             parentActivity.launch(Dispatchers.Main) {
                 val mode = parentActivity.getPrefs().getDayNightMode(parentActivity)
                 AppCompatDelegate.setDefaultNightMode(mode)
-                parentActivity.handleThemeChange()
-            }
-            true
-        }
-
-        previousColor = prefs.getInt(accentColorPref.key, 0)
-        accentColorPref.setOnPreferenceChangeListener { _, newValue ->
-            parentFragmentManager.findFragmentByTag(accentColorPref.fragmentTag)?.let { dialog ->
-                parentFragmentManager.commit(allowStateLoss = true) {
-                    remove(dialog)
-                }
-            }
-            if (previousColor != newValue) {
                 parentActivity.handleThemeChange()
             }
             true

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/fragments/WidgetSettingsFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/fragments/WidgetSettingsFragment.kt
@@ -28,7 +28,7 @@ import androidx.core.content.edit
 import androidx.core.os.bundleOf
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
-import androidx.preference.SwitchPreference
+import androidx.preference.SwitchPreferenceCompat
 import com.google.android.material.snackbar.Snackbar
 import org.openhab.habdroid.R
 import org.openhab.habdroid.background.BackgroundTasksManager
@@ -49,7 +49,7 @@ class WidgetSettingsFragment :
 
     private lateinit var itemAndStatePref: ItemAndStatePreference
     private lateinit var namePref: CustomInputTypePreference
-    private lateinit var showStatePref: SwitchPreference
+    private lateinit var showStatePref: SwitchPreferenceCompat
     private lateinit var themePref: ListPreference
     private var itemAndStatePrefCallback = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/PeriodicSignalImageButton.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/PeriodicSignalImageButton.kt
@@ -19,7 +19,7 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
 import androidx.annotation.CallSuper
-import androidx.appcompat.widget.AppCompatImageButton
+import com.google.android.material.button.MaterialButton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -28,7 +28,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class PeriodicSignalImageButton constructor(context: Context, attrs: AttributeSet?) :
-    AppCompatImageButton(context, attrs),
+    MaterialButton(context, attrs),
     View.OnLongClickListener {
     private var scope: CoroutineScope? = null
     private var periodicCallbackExecutor: Job? = null

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/PeriodicSignalImageButton.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/PeriodicSignalImageButton.kt
@@ -19,7 +19,7 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
 import androidx.annotation.CallSuper
-import com.google.android.material.button.MaterialButton
+import androidx.appcompat.widget.AppCompatImageButton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -28,7 +28,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class PeriodicSignalImageButton constructor(context: Context, attrs: AttributeSet?) :
-    MaterialButton(context, attrs),
+    AppCompatImageButton(context, attrs),
     View.OnLongClickListener {
     private var scope: CoroutineScope? = null
     private var periodicCallbackExecutor: Job? = null

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -455,13 +455,10 @@ fun Context.isDarkModeActive(): Boolean {
 }
 
 @StyleRes fun Context.getActivityThemeId(): Int {
-    val isBlackTheme = getPrefs().getStringOrNull(PrefKeys.THEME) == getString(R.string.theme_value_black)
-    return when (getPrefs().getInt(PrefKeys.ACCENT_COLOR, 0)) {
-        ContextCompat.getColor(this, R.color.indigo_500) ->
-            if (isBlackTheme) R.style.openHAB_Black_basicui else R.style.openHAB_DayNight_basicui
-        ContextCompat.getColor(this, R.color.blue_grey_700) ->
-            if (isBlackTheme) R.style.openHAB_Black_grey else R.style.openHAB_DayNight_grey
-        else -> if (isBlackTheme) R.style.openHAB_Black_orange else R.style.openHAB_DayNight_orange
+    return if (getPrefs().getStringOrNull(PrefKeys.THEME) == getString(R.string.theme_value_black)) {
+        R.style.openHAB_DayNight_Black
+    } else {
+        R.style.openHAB_DayNight
     }
 }
 

--- a/mobile/src/main/java/org/openhab/habdroid/util/PrefKeys.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/PrefKeys.kt
@@ -47,7 +47,6 @@ object PrefKeys {
 
     const val DRAWER_ENTRIES = "drawer_entries"
     const val THEME = "theme"
-    const val ACCENT_COLOR = "theme_color"
     const val SCREEN_TIMER_OFF = "default_openhab_screentimeroff"
     const val FULLSCREEN = "default_openhab_fullscreen"
     const val LAUNCHER = "launcher"

--- a/mobile/src/main/res/layout/activity_about.xml
+++ b/mobile/src/main/res/layout/activity_about.xml
@@ -6,14 +6,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/openhab_toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        android:elevation="8dp"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+    <include layout="@layout/app_bar" />
 
     <FrameLayout
         android:id="@+id/activity_content"

--- a/mobile/src/main/res/layout/activity_chart.xml
+++ b/mobile/src/main/res/layout/activity_chart.xml
@@ -5,17 +5,11 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/openhab_toolbar"
-        android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        android:elevation="8dp"
+    <include
+        layout="@layout/app_bar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/activity_content"

--- a/mobile/src/main/res/layout/activity_color_picker.xml
+++ b/mobile/src/main/res/layout/activity_color_picker.xml
@@ -4,17 +4,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/openhab_toolbar"
-        android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        android:elevation="8dp"
+
+    <include
+        android:id="@+id/included_toolbar"
+        layout="@layout/app_bar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.flask.colorpicker.ColorPickerView
         android:id="@+id/picker"
@@ -27,7 +23,7 @@
         app:density="12"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/openhab_toolbar"
+        app:layout_constraintTop_toBottomOf="@+id/included_toolbar"
         app:wheelType="CIRCLE" />
 
     <com.google.android.material.slider.Slider

--- a/mobile/src/main/res/layout/activity_image.xml
+++ b/mobile/src/main/res/layout/activity_image.xml
@@ -5,17 +5,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/openhab_toolbar"
-        android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        android:elevation="8dp"
+    <include
+        android:id="@+id/included_toolbar"
+        layout="@layout/app_bar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.github.chrisbanes.photoview.PhotoView
         android:id="@+id/activity_content"
@@ -24,5 +19,5 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/openhab_toolbar" />
+        app:layout_constraintTop_toBottomOf="@+id/included_toolbar" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/mobile/src/main/res/layout/activity_item_picker.xml
+++ b/mobile/src/main/res/layout/activity_item_picker.xml
@@ -7,17 +7,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/openhab_toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        android:elevation="8dp"
+    <include
+        android:id="@+id/included_toolbar"
+        layout="@layout/app_bar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <LinearLayout
         android:id="@+id/additional_config_parent"
@@ -27,7 +22,7 @@
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/openhab_toolbar"
+        app:layout_constraintTop_toBottomOf="@+id/included_toolbar"
         tools:visibility="visible">
 
         <ViewStub
@@ -36,7 +31,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
-        <Switch
+        <MaterialSwitch
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Switch"
@@ -52,7 +47,7 @@
 
         <TextView
             android:text="@string/item_update_widget_item_picker_title"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+            android:textAppearance="@style/TextAppearance.Material3.HeadlineSmall"
             android:textColor="?colorAccent"
             android:padding="8dp"
             android:layout_width="wrap_content"

--- a/mobile/src/main/res/layout/activity_log.xml
+++ b/mobile/src/main/res/layout/activity_log.xml
@@ -6,17 +6,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/openhab_toolbar"
-        android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        android:elevation="8dp"
+    <include
+        android:id="@+id/included_toolbar"
+        layout="@layout/app_bar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/shareFab"
@@ -31,7 +26,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         android:contentDescription="@string/log_activity_content_description_share"
         android:visibility="gone"
-        app:tint="@color/light"
         tools:visibility="visible" />
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
@@ -41,7 +35,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/openhab_toolbar">
+        app:layout_constraintTop_toBottomOf="@id/included_toolbar">
 
         <ScrollView
             android:id="@+id/scrollview"

--- a/mobile/src/main/res/layout/activity_main.xml
+++ b/mobile/src/main/res/layout/activity_main.xml
@@ -1,29 +1,10 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/openhab_toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        android:elevation="8dp"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
-
-        <androidx.core.widget.ContentLoadingProgressBar
-            android:id="@+id/toolbar_progress_bar"
-            style="@style/Widget.AppCompat.ProgressBar"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="16dp"
-            android:layout_gravity="end|center_vertical"
-            android:indeterminateTint="#ffffff"
-            android:indeterminateTintMode="src_in" />
-    </androidx.appcompat.widget.Toolbar>
+    <include layout="@layout/app_bar" />
 
     <org.openhab.habdroid.ui.widget.LockableDrawerLayout
         android:id="@+id/activity_content"

--- a/mobile/src/main/res/layout/activity_prefs.xml
+++ b/mobile/src/main/res/layout/activity_prefs.xml
@@ -1,19 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/openhab_toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        android:elevation="8dp"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+    <include layout="@layout/app_bar" />
 
     <FrameLayout
         android:id="@+id/activity_content"

--- a/mobile/src/main/res/layout/activity_selection_item.xml
+++ b/mobile/src/main/res/layout/activity_selection_item.xml
@@ -1,18 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/openhab_toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        android:elevation="8dp"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+    <include layout="@layout/app_bar" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/selection_list"

--- a/mobile/src/main/res/layout/activity_writetag.xml
+++ b/mobile/src/main/res/layout/activity_writetag.xml
@@ -1,6 +1,5 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -8,14 +7,7 @@
     android:orientation="vertical"
     tools:context="org.openhab.habdroid.ui.WriteTagActivity">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/openhab_toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
-        android:elevation="8dp"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+    <include layout="@layout/app_bar" />
 
     <FrameLayout
         android:id="@+id/activity_content"

--- a/mobile/src/main/res/layout/app_bar.xml
+++ b/mobile/src/main/res/layout/app_bar.xml
@@ -18,7 +18,7 @@
             android:layout_height="wrap_content"
             android:layout_margin="16dp"
             android:layout_gravity="end|center_vertical"
-            android:indeterminateTint="#ffffff"
+            android:indeterminateTint="?android:textColorSecondary"
             android:indeterminateTintMode="src_in"
             android:visibility="gone"
             tools:visibility="visible" />

--- a/mobile/src/main/res/layout/app_bar.xml
+++ b/mobile/src/main/res/layout/app_bar.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/openhab_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:elevation="8dp"
+        android:theme="@style/ThemeOverlay.MaterialComponents.AppBar">
+
+        <androidx.core.widget.ContentLoadingProgressBar
+            android:id="@+id/toolbar_progress_bar"
+            style="@style/Widget.AppCompat.ProgressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:layout_gravity="end|center_vertical"
+            android:indeterminateTint="#ffffff"
+            android:indeterminateTintMode="src_in"
+            android:visibility="gone"
+            tools:visibility="visible" />
+    </com.google.android.material.appbar.MaterialToolbar>
+</LinearLayout>

--- a/mobile/src/main/res/layout/app_bar.xml
+++ b/mobile/src/main/res/layout/app_bar.xml
@@ -8,9 +8,8 @@
         android:id="@+id/openhab_toolbar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:background="?attr/colorPrimary"
         android:elevation="8dp"
-        android:theme="@style/ThemeOverlay.MaterialComponents.AppBar">
+        style="@style/Widget.Material3.Toolbar">
 
         <androidx.core.widget.ContentLoadingProgressBar
             android:id="@+id/toolbar_progress_bar"

--- a/mobile/src/main/res/layout/drawer_header.xml
+++ b/mobile/src/main/res/layout/drawer_header.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/server_selector"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -9,7 +9,7 @@
     android:paddingBottom="8dp"
     android:paddingStart="16dp"
     android:paddingTop="8dp"
-    android:background="?colorPrimary">
+    android:background="?colorPrimaryContainer">
 
     <TextView
         android:id="@+id/server_name"
@@ -18,7 +18,7 @@
         android:layout_weight="1"
         android:layout_gravity="center_vertical"
         android:textAppearance="@style/TextAppearance.AppCompat.Small"
-        android:textColor="@android:color/white"
+        android:textColor="?colorOnPrimaryContainer"
         android:textStyle="bold"
         tools:text="server" />
 
@@ -29,6 +29,7 @@
         android:layout_gravity="center_vertical"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:scaleType="center"
+        app:tint="?colorOnPrimaryContainer"
         android:src="@drawable/ic_menu_down_24dp" />
 
 </LinearLayout>

--- a/mobile/src/main/res/layout/item_updating_pref_dialog.xml
+++ b/mobile/src/main/res/layout/item_updating_pref_dialog.xml
@@ -33,7 +33,7 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/itemNameWrapper"
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/enabled"

--- a/mobile/src/main/res/layout/pref_dialog_device_identifier.xml
+++ b/mobile/src/main/res/layout/pref_dialog_device_identifier.xml
@@ -9,7 +9,7 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/input_wrapper"
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"

--- a/mobile/src/main/res/layout/pref_dialog_wifi_ssid.xml
+++ b/mobile/src/main/res/layout/pref_dialog_wifi_ssid.xml
@@ -10,7 +10,7 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/input_wrapper"
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"

--- a/mobile/src/main/res/layout/text_input_pref_dialog.xml
+++ b/mobile/src/main/res/layout/text_input_pref_dialog.xml
@@ -7,7 +7,7 @@
     android:padding="?attr/dialogPreferredPadding">
 
     <com.google.android.material.textfield.TextInputLayout
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
         android:id="@+id/input_wrapper"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">

--- a/mobile/src/main/res/layout/widget_item_update_dark_text.xml
+++ b/mobile/src/main/res/layout/widget_item_update_dark_text.xml
@@ -33,7 +33,7 @@
             android:layout_height="0dp"
             android:layout_weight="50"
             android:gravity="center"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
             android:textColor="@color/light"
             android:visibility="gone"
             tools:visibility="visible"

--- a/mobile/src/main/res/layout/widget_item_update_dark_text_small.xml
+++ b/mobile/src/main/res/layout/widget_item_update_dark_text_small.xml
@@ -26,7 +26,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center"
-        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+        android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
         android:textColor="@color/light"
         android:visibility="gone"
         tools:visibility="visible"

--- a/mobile/src/main/res/layout/widget_item_update_light_text.xml
+++ b/mobile/src/main/res/layout/widget_item_update_light_text.xml
@@ -33,7 +33,7 @@
             android:layout_height="0dp"
             android:layout_weight="50"
             android:gravity="center"
-            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
             android:textColor="@color/black"
             android:visibility="gone"
             tools:visibility="visible"

--- a/mobile/src/main/res/layout/widget_item_update_light_text_small.xml
+++ b/mobile/src/main/res/layout/widget_item_update_light_text_small.xml
@@ -26,7 +26,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center"
-        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+        android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
         android:textColor="@color/black"
         android:visibility="gone"
         tools:visibility="visible"

--- a/mobile/src/main/res/layout/widgetlist_coloritem.xml
+++ b/mobile/src/main/res/layout/widgetlist_coloritem.xml
@@ -9,19 +9,19 @@
     <include layout="@layout/widgetlist_icontext" />
 
     <org.openhab.habdroid.ui.widget.PeriodicSignalImageButton
-        style="@style/ActionButton"
+        style="@style/openHAB.ActionButton"
         android:id="@+id/up_button"
         android:contentDescription="@string/content_description_color_up"
         android:src="@drawable/ic_keyboard_arrow_up_themed_24dp" />
 
     <ImageButton
-        style="@style/ActionButton"
+        style="@style/openHAB.ActionButton"
         android:id="@+id/select_color_button"
         android:contentDescription="@string/content_description_open_color_wheel"
         android:src="@drawable/ic_palette_outline_themed_24dp" />
 
     <org.openhab.habdroid.ui.widget.PeriodicSignalImageButton
-        style="@style/ActionButton"
+        style="@style/openHAB.ActionButton"
         android:id="@+id/down_button"
         android:contentDescription="@string/content_description_color_down"
         android:src="@drawable/ic_keyboard_arrow_down_themed_24dp" />

--- a/mobile/src/main/res/layout/widgetlist_frameitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_frameitem.xml
@@ -33,8 +33,8 @@
         android:minHeight="36dp"
         android:ellipsize="end"
         android:maxLines="2"
-        android:textColor="@color/colorAccent_themeDark"
-        android:textStyle="bold"
-        tools:ignore="SelectableText" />
+        android:textAppearance="@style/TextAppearance.Material3.LabelMedium"
+        tools:ignore="SelectableText"
+        tools:text="Some topic"/>
 
 </LinearLayout>

--- a/mobile/src/main/res/layout/widgetlist_rollershutteritem.xml
+++ b/mobile/src/main/res/layout/widgetlist_rollershutteritem.xml
@@ -9,19 +9,19 @@
     <include layout="@layout/widgetlist_iconsmallvaluetext" />
 
     <ImageButton
-        style="@style/ActionButton"
+        style="@style/openHAB.ActionButton"
         android:id="@+id/up_button"
         android:contentDescription="@string/content_description_open_roller_shutter"
         android:src="@drawable/ic_keyboard_arrow_up_themed_24dp" />
 
     <ImageButton
-        style="@style/ActionButton"
+        style="@style/openHAB.ActionButton"
         android:id="@+id/stop_button"
         android:contentDescription="@string/content_description_stop_roller_shutter"
         android:src="@drawable/ic_clear_themed_24dp" />
 
     <ImageButton
-        style="@style/ActionButton"
+        style="@style/openHAB.ActionButton"
         android:id="@+id/down_button"
         android:contentDescription="@string/content_description_close_roller_shutter"
         android:src="@drawable/ic_keyboard_arrow_down_themed_24dp" />

--- a/mobile/src/main/res/layout/widgetlist_sectionswitchitem_button.xml
+++ b/mobile/src/main/res/layout/widgetlist_sectionswitchitem_button.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.button.MaterialButton
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     style="?materialButtonOutlinedStyle"
-    android:theme="@style/ThemeOverlay.MaterialComponents.SecondaryAsPrimary"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
-    android:minWidth="0dp" />
+    android:textAppearance="?android:attr/textAppearanceMedium"
+    android:minWidth="0dp"
+    tools:text="Action 1" />

--- a/mobile/src/main/res/layout/widgetlist_setpointitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_setpointitem.xml
@@ -17,14 +17,14 @@
         android:contentDescription="@string/content_description_open_number_picker" />
 
     <ImageButton
-        style="@style/ActionButton"
+        style="@style/openHAB.ActionButton"
         android:id="@+id/up_button"
         android:padding="4dp"
         android:contentDescription="@string/content_description_increase_item_value"
         android:src="@drawable/ic_keyboard_arrow_up_themed_24dp" />
 
     <ImageButton
-        style="@style/ActionButton"
+        style="@style/openHAB.ActionButton"
         android:id="@+id/down_button"
         android:padding="4dp"
         android:contentDescription="@string/content_description_decrease_item_value"

--- a/mobile/src/main/res/layout/widgetlist_switchitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_switchitem.xml
@@ -8,7 +8,7 @@
 
     <com.google.android.material.switchmaterial.SwitchMaterial
         android:id="@+id/toggle"
-        style="@style/Widget.MaterialComponents.CompoundButton.Switch"
+        style="@style/Widget.Material3.CompoundButton.MaterialSwitch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"

--- a/mobile/src/main/res/menu/chart_menu.xml
+++ b/mobile/src/main/res/menu/chart_menu.xml
@@ -6,12 +6,14 @@
         android:id="@+id/show_legend"
         android:icon="@drawable/ic_error_outline_white_24dp"
         android:title="@string/chart_activity_show_legend"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="ifRoom"
+        app:iconTint="?android:textColorSecondary" />
     <item
         android:id="@+id/period"
         android:title="@string/chart_activity_period"
         android:icon="@drawable/ic_access_time_white_24dp"
-        app:showAsAction="ifRoom">
+        app:showAsAction="ifRoom"
+        app:iconTint="?android:textColorSecondary">
         <menu>
             <item
                 android:id="@+id/period_h"
@@ -59,5 +61,6 @@
         android:id="@+id/refresh"
         android:icon="@drawable/ic_refresh_white_24dp"
         android:title="@string/log_activity_action_reload"
-        app:showAsAction="never" />
+        app:showAsAction="never"
+        app:iconTint="?android:textColorSecondary" />
 </menu>

--- a/mobile/src/main/res/menu/fullscreen_image_menu.xml
+++ b/mobile/src/main/res/menu/fullscreen_image_menu.xml
@@ -5,5 +5,6 @@
         android:id="@+id/refresh"
         android:icon="@drawable/ic_refresh_white_24dp"
         android:title="@string/log_activity_action_reload"
-        app:showAsAction="always" />
+        app:showAsAction="always"
+        app:iconTint="?android:textColorSecondary" />
 </menu>

--- a/mobile/src/main/res/menu/item_picker.xml
+++ b/mobile/src/main/res/menu/item_picker.xml
@@ -6,5 +6,6 @@
         android:icon="@drawable/ic_search_white_24dp"
         android:title="@string/search"
         app:showAsAction="always"
-        app:actionViewClass="androidx.appcompat.widget.SearchView" />
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:iconTint="?android:textColorSecondary" />
 </menu>

--- a/mobile/src/main/res/menu/log_menu.xml
+++ b/mobile/src/main/res/menu/log_menu.xml
@@ -7,20 +7,24 @@
         android:icon="@drawable/ic_search_white_24dp"
         android:title="@string/search"
         app:showAsAction="always"
-        app:actionViewClass="androidx.appcompat.widget.SearchView" />
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:iconTint="?android:textColorSecondary" />
     <item
         android:id="@+id/delete_log"
         android:icon="@drawable/ic_delete_outline_white_24dp"
         android:title="@string/log_activity_action_clear_log"
-        app:showAsAction="always" />
+        app:showAsAction="always"
+        app:iconTint="?android:textColorSecondary" />
     <item
         android:id="@+id/show_errors"
         android:icon="@drawable/ic_error_outline_white_24dp"
         android:title="@string/log_activity_action_show_errors"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="ifRoom"
+        app:iconTint="?android:textColorSecondary" />
     <item
         android:id="@+id/refresh"
         android:icon="@drawable/ic_refresh_white_24dp"
         android:title="@string/log_activity_action_reload"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="ifRoom"
+        app:iconTint="?android:textColorSecondary" />
 </menu>

--- a/mobile/src/main/res/menu/main_menu.xml
+++ b/mobile/src/main/res/menu/main_menu.xml
@@ -8,7 +8,8 @@
         android:icon="@drawable/ic_microphone_outline_white_24dp"
         android:orderInCategory="100"
         android:title="@string/mainmenu_openhab_voice_recognition"
-        app:showAsAction="always" />
+        app:showAsAction="always"
+        app:iconTint="?android:textColorSecondary" />
     <item
         android:id="@+id/mainmenu_crash"
         android:orderInCategory="999"

--- a/mobile/src/main/res/menu/prefs_save.xml
+++ b/mobile/src/main/res/menu/prefs_save.xml
@@ -5,5 +5,6 @@
         android:id="@+id/save"
         android:icon="@drawable/ic_baseline_check_24"
         android:title="@string/save"
-        app:showAsAction="always" />
+        app:showAsAction="always"
+        app:iconTint="?android:textColorSecondary" />
 </menu>

--- a/mobile/src/main/res/menu/server_editor.xml
+++ b/mobile/src/main/res/menu/server_editor.xml
@@ -5,10 +5,12 @@
         android:id="@+id/delete"
         android:icon="@drawable/ic_delete_outline_white_24dp"
         android:title="@string/delete"
-        app:showAsAction="always" />
+        app:showAsAction="always"
+        app:iconTint="?android:textColorSecondary" />
     <item
         android:id="@+id/save"
         android:icon="@drawable/ic_baseline_check_24"
         android:title="@string/save"
-        app:showAsAction="always" />
+        app:showAsAction="always"
+        app:iconTint="?android:textColorSecondary" />
 </menu>

--- a/mobile/src/main/res/values-night/colors.xml
+++ b/mobile/src/main/res/values-night/colors.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="secondary_color_grey_theme">@color/light</color>
-</resources>

--- a/mobile/src/main/res/values-night/themes.xml
+++ b/mobile/src/main/res/values-night/themes.xml
@@ -4,6 +4,41 @@
         <item name="chartTheme">dark</item>
         <item name="transparentChartTheme">dark_transparent</item>
         <item name="valueColors">@array/valueColorsDarkBackground</item>
+
+        <item name="colorPrimary">@color/md_theme_dark_primary</item>
+        <item name="colorOnPrimary">@color/md_theme_dark_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/md_theme_dark_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/md_theme_dark_onPrimaryContainer</item>
+        <item name="colorSecondary">@color/md_theme_dark_secondary</item>
+        <item name="colorOnSecondary">@color/md_theme_dark_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/md_theme_dark_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/md_theme_dark_onSecondaryContainer</item>
+        <item name="colorTertiary">@color/md_theme_dark_tertiary</item>
+        <item name="colorOnTertiary">@color/md_theme_dark_onTertiary</item>
+        <item name="colorTertiaryContainer">@color/md_theme_dark_tertiaryContainer</item>
+        <item name="colorOnTertiaryContainer">@color/md_theme_dark_onTertiaryContainer</item>
+        <item name="colorError">@color/md_theme_dark_error</item>
+        <item name="colorErrorContainer">@color/md_theme_dark_errorContainer</item>
+        <item name="colorOnError">@color/md_theme_dark_onError</item>
+        <item name="colorOnErrorContainer">@color/md_theme_dark_onErrorContainer</item>
+        <item name="android:colorBackground">@color/md_theme_dark_background</item>
+        <item name="colorOnBackground">@color/md_theme_dark_onBackground</item>
+        <item name="colorSurface">@color/md_theme_dark_surface</item>
+        <item name="colorOnSurface">@color/md_theme_dark_onSurface</item>
+        <item name="colorSurfaceVariant">@color/md_theme_dark_surfaceVariant</item>
+        <item name="colorOnSurfaceVariant">@color/md_theme_dark_onSurfaceVariant</item>
+        <item name="colorOutline">@color/md_theme_dark_outline</item>
+        <item name="colorOnSurfaceInverse">@color/md_theme_dark_inverseOnSurface</item>
+        <item name="colorSurfaceInverse">@color/md_theme_dark_inverseSurface</item>
+        <item name="colorPrimaryInverse">@color/md_theme_dark_inversePrimary</item>
+
+        <!-- Darker status bar -->
+        <item name="android:statusBarColor">?colorOnPrimary</item>
+    </style>
+
+    <!-- Darker app bar -->
+    <style name="ThemeOverlay.MaterialComponents.AppBar">
+        <item name="colorPrimary">?colorOnPrimary</item>
     </style>
 
     <style name="openHAB.Launch" parent="openHAB.Base">

--- a/mobile/src/main/res/values-night/themes.xml
+++ b/mobile/src/main/res/values-night/themes.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <style name="openHAB.DayNight" parent="openHAB.Base">
         <item name="chartTheme">dark</item>
         <item name="transparentChartTheme">dark_transparent</item>
         <item name="valueColors">@array/valueColorsDarkBackground</item>
+        <item name="android:statusBarColor">?android:colorBackground</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
 
         <item name="colorPrimary">@color/md_theme_dark_primary</item>
         <item name="colorOnPrimary">@color/md_theme_dark_onPrimary</item>

--- a/mobile/src/main/res/values-night/themes.xml
+++ b/mobile/src/main/res/values-night/themes.xml
@@ -31,14 +31,6 @@
         <item name="colorOnSurfaceInverse">@color/md_theme_dark_inverseOnSurface</item>
         <item name="colorSurfaceInverse">@color/md_theme_dark_inverseSurface</item>
         <item name="colorPrimaryInverse">@color/md_theme_dark_inversePrimary</item>
-
-        <!-- Darker status bar -->
-        <item name="android:statusBarColor">?colorOnPrimary</item>
-    </style>
-
-    <!-- Darker app bar -->
-    <style name="ThemeOverlay.MaterialComponents.AppBar">
-        <item name="colorPrimary">?colorOnPrimary</item>
     </style>
 
     <style name="openHAB.Launch" parent="openHAB.Base">

--- a/mobile/src/main/res/values-v23/themes.xml
+++ b/mobile/src/main/res/values-v23/themes.xml
@@ -1,19 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="openHAB.Base" parent="Theme.Material3.DayNight.NoActionBar">
-        <item name="android:windowBackground">?android:colorBackground</item>
-        <item name="sliderStyle">@style/Widget.Material3.Slider</item>
-        <item name="switchStyle">@style/Widget.Material3.CompoundButton.MaterialSwitch</item>
-        <item name="materialButtonOutlinedStyle">@style/openHAB.OutlineButton</item>
-        <item name="floatingActionButtonStyle">@style/Widget.Material3.FloatingActionButton.Primary</item>
-        <item name="selectedWidgetBackgroundColor">#5cff5722</item>
-    </style>
-
+<resources>
     <style name="openHAB.DayNight" parent="openHAB.Base">
         <item name="chartTheme">white</item>
         <item name="transparentChartTheme">white_transparent</item>
         <item name="valueColors">@array/valueColorsBrightBackground</item>
-        <item name="android:statusBarColor">?colorPrimary</item>
+        <item name="android:statusBarColor">?android:colorBackground</item>
+        <item name="android:windowLightStatusBar">true</item>
 
         <item name="colorPrimary">@color/md_theme_light_primary</item>
         <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
@@ -41,28 +33,5 @@
         <item name="colorOnSurfaceInverse">@color/md_theme_light_inverseOnSurface</item>
         <item name="colorSurfaceInverse">@color/md_theme_light_inverseSurface</item>
         <item name="colorPrimaryInverse">@color/md_theme_light_inversePrimary</item>
-    </style>
-
-    <style name="openHAB.DayNight.Black" parent="openHAB.DayNight">
-        <item name="chartTheme">black</item>
-        <item name="transparentChartTheme">black_transparent</item>
-        <item name="android:windowBackground">@color/black</item>
-    </style>
-
-    <style name="openHAB.Launch" parent="openHAB.Base">
-        <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
-        <item name="colorPrimaryDark">@android:color/background_light</item>
-    </style>
-
-    <style name="Theme.MaterialComponents.TranslucentBase">
-        <item name="android:windowNoTitle">true</item>
-        <item name="android:windowBackground">@android:color/transparent</item>
-        <item name="android:colorBackgroundCacheHint">@null</item>
-        <item name="android:windowIsTranslucent">true</item>
-        <item name="android:windowAnimationStyle">@null</item>
-    </style>
-
-    <style name="Theme.MaterialComponents.Translucent" parent="Theme.MaterialComponents.TranslucentBase">
-        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 </resources>

--- a/mobile/src/main/res/values/arrays.xml
+++ b/mobile/src/main/res/values/arrays.xml
@@ -144,12 +144,6 @@
         <item>@string/device_control_subtitle_item_name_value</item>
     </string-array>
 
-    <array name="accentColors">
-        <item>@color/openhab_orange</item>
-        <item>@color/indigo_500</item>
-        <item>@color/blue_grey_700</item>
-    </array>
-
     <string-array name="send_device_info_schedule_values">
         <item>15</item>
         <item>60</item>

--- a/mobile/src/main/res/values/colors.xml
+++ b/mobile/src/main/res/values/colors.xml
@@ -1,16 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <color name="light">#ffffff</color>
     <color name="black">#000000</color>
-    <color name="colorAccent_themeDark">#9E9E9E</color>
     <color name="openhab_orange">#ff5722</color>
-    <color name="openhab_orange_dark">#bf360c</color>
-    <color name="indigo_500">#3f51b5</color>
-    <color name="indigo_800">#283593</color>
-    <color name="pink_a200">#ff4081</color>
-    <color name="blue_grey_700">#455A64</color>
-    <color name="blue_grey_900">#263238</color>
-    <color name="secondary_color_grey_theme">@color/blue_grey_700</color>
     <color name="empty_list_text_color">#b2b2b2</color>
     <color name="pref_icon_red">#D32F2F</color>
     <color name="pref_icon_green">#388E3C</color>
@@ -18,4 +10,65 @@
     <color name="pref_icon_grey">#757575</color>
 
     <color name="ic_launcher_background">#FFFFFF</color>
+
+    <!-- Created with https://m3.material.io/theme-builder#/custom -->
+    <color name="seed">#ff5722</color>
+    <color name="md_theme_light_primary">#B02F00</color>
+    <color name="md_theme_light_onPrimary">#FFFFFF</color>
+    <color name="md_theme_light_primaryContainer">#FFDBD1</color>
+    <color name="md_theme_light_onPrimaryContainer">#3B0900</color>
+    <color name="md_theme_light_secondary">#B22C01</color>
+    <color name="md_theme_light_onSecondary">#FFFFFF</color>
+    <color name="md_theme_light_secondaryContainer">#FFDBD1</color>
+    <color name="md_theme_light_onSecondaryContainer">#3B0800</color>
+    <color name="md_theme_light_tertiary">#B22C01</color>
+    <color name="md_theme_light_onTertiary">#FFFFFF</color>
+    <color name="md_theme_light_tertiaryContainer">#FFDBD1</color>
+    <color name="md_theme_light_onTertiaryContainer">#3B0800</color>
+    <color name="md_theme_light_error">#BA1A1A</color>
+    <color name="md_theme_light_errorContainer">#FFDAD6</color>
+    <color name="md_theme_light_onError">#FFFFFF</color>
+    <color name="md_theme_light_onErrorContainer">#410002</color>
+    <color name="md_theme_light_background">#FFFBFF</color>
+    <color name="md_theme_light_onBackground">#201A18</color>
+    <color name="md_theme_light_surface">#FFFBFF</color>
+    <color name="md_theme_light_onSurface">#201A18</color>
+    <color name="md_theme_light_surfaceVariant">#F5DED8</color>
+    <color name="md_theme_light_onSurfaceVariant">#53433F</color>
+    <color name="md_theme_light_outline">#85736E</color>
+    <color name="md_theme_light_inverseOnSurface">#FBEEEB</color>
+    <color name="md_theme_light_inverseSurface">#362F2D</color>
+    <color name="md_theme_light_inversePrimary">#FFB5A0</color>
+    <color name="md_theme_light_shadow">#000000</color>
+    <color name="md_theme_light_surfaceTint">#B02F00</color>
+    <color name="md_theme_light_surfaceTintColor">#B02F00</color>
+    <color name="md_theme_dark_primary">#FFB5A0</color>
+    <color name="md_theme_dark_onPrimary">#5F1500</color>
+    <color name="md_theme_dark_primaryContainer">#862200</color>
+    <color name="md_theme_dark_onPrimaryContainer">#FFDBD1</color>
+    <color name="md_theme_dark_secondary">#FFB5A1</color>
+    <color name="md_theme_dark_onSecondary">#601300</color>
+    <color name="md_theme_dark_secondaryContainer">#881F00</color>
+    <color name="md_theme_dark_onSecondaryContainer">#FFDBD1</color>
+    <color name="md_theme_dark_tertiary">#FFB5A1</color>
+    <color name="md_theme_dark_onTertiary">#601300</color>
+    <color name="md_theme_dark_tertiaryContainer">#881F00</color>
+    <color name="md_theme_dark_onTertiaryContainer">#FFDBD1</color>
+    <color name="md_theme_dark_error">#FFB4AB</color>
+    <color name="md_theme_dark_errorContainer">#93000A</color>
+    <color name="md_theme_dark_onError">#690005</color>
+    <color name="md_theme_dark_onErrorContainer">#FFDAD6</color>
+    <color name="md_theme_dark_background">#201A18</color>
+    <color name="md_theme_dark_onBackground">#EDE0DC</color>
+    <color name="md_theme_dark_surface">#201A18</color>
+    <color name="md_theme_dark_onSurface">#EDE0DC</color>
+    <color name="md_theme_dark_surfaceVariant">#53433F</color>
+    <color name="md_theme_dark_onSurfaceVariant">#D8C2BC</color>
+    <color name="md_theme_dark_outline">#A08C87</color>
+    <color name="md_theme_dark_inverseOnSurface">#201A18</color>
+    <color name="md_theme_dark_inverseSurface">#EDE0DC</color>
+    <color name="md_theme_dark_inversePrimary">#B02F00</color>
+    <color name="md_theme_dark_shadow">#000000</color>
+    <color name="md_theme_dark_surfaceTint">#FFB5A0</color>
+    <color name="md_theme_dark_surfaceTintColor">#FFB5A0</color>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -57,8 +57,6 @@
     <string name="start_page_title">Start page</string>
     <string name="drawer_entries">Side menu entries</string>
     <string name="settings_openhab_theme">Theme</string>
-    <string name="settings_accent_color">Accent color</string>
-    <string name="settings_select_a_color">Select a color</string>
     <string name="settings_openhab_fullscreen">Fullscreen</string>
     <string name="settings_set_as_launcher">Allow app to be used as launcher</string>
     <string name="settings_openhab_icon_format">Icon format</string>

--- a/mobile/src/main/res/values/styles.xml
+++ b/mobile/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="ActionButton">
+    <style name="openHAB.ActionButton" parent="Widget.Material3.Button.IconButton">
         <item name="android:layout_width">44dip</item>
         <item name="android:layout_height">44dp</item>
         <item name="android:layout_gravity">center_vertical</item>
@@ -8,34 +8,7 @@
         <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
     </style>
 
-    <style name="openHAB.Dialog.Base" parent="@style/Theme.MaterialComponents.DayNight.Dialog.Alert">
-        <item name="dialogCornerRadius">8dp</item>
-    </style>
-
-    <style name="openHAB.Dialog.orange" parent="@style/openHAB.Dialog.Base">
-        <item name="colorPrimary">@color/openhab_orange</item>
-        <item name="colorSecondary">@color/openhab_orange</item>
-    </style>
-
-    <style name="openHAB.Dialog.basicui" parent="@style/openHAB.Dialog.Base">
-        <item name="colorPrimary">@color/pink_a200</item>
-        <item name="colorSecondary">@color/pink_a200</item>
-    </style>
-
-    <style name="openHAB.Dialog.grey" parent="@style/openHAB.Dialog.Base">
-        <item name="colorPrimary">@color/secondary_color_grey_theme</item>
-        <item name="colorSecondary">@color/secondary_color_grey_theme</item>
-    </style>
-
-    <style name="openHAB.Slider" parent="@style/Widget.MaterialComponents.Slider">
-        <item name="materialThemeOverlay">@style/ThemeOverlay.MaterialComponents.SecondaryAsPrimary</item>
-    </style>
-
-    <style name="openHAB.OutlineButton" parent="@style/Widget.MaterialComponents.Button.OutlinedButton">
+    <style name="openHAB.OutlineButton" parent="@style/Widget.Material3.Button.OutlinedButton">
         <item name="strokeWidth">@dimen/outlineButtonStrokeWidth</item>
-    </style>
-
-    <style name="openHAB.FAB.grey" parent="@style/Widget.MaterialComponents.FloatingActionButton">
-        <item name="backgroundTint">?colorPrimary</item>
     </style>
 </resources>

--- a/mobile/src/main/res/values/themes.xml
+++ b/mobile/src/main/res/values/themes.xml
@@ -68,7 +68,4 @@
     <style name="Theme.MaterialComponents.Translucent" parent="Theme.MaterialComponents.TranslucentBase">
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
-
-    <!-- Overridden for night mode -->
-    <style name="ThemeOverlay.MaterialComponents.AppBar" />
 </resources>

--- a/mobile/src/main/res/values/themes.xml
+++ b/mobile/src/main/res/values/themes.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <style name="openHAB.Base" parent="Theme.Material3.DayNight.NoActionBar">
-        <item name="windowNoTitle">true</item>
-        <item name="windowActionBar">false</item>
-        <item name="windowActionBarOverlay">false</item>
         <item name="android:windowBackground">?android:colorBackground</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
         <item name="sliderStyle">@style/Widget.Material3.Slider</item>

--- a/mobile/src/main/res/values/themes.xml
+++ b/mobile/src/main/res/values/themes.xml
@@ -1,68 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="openHAB.Base" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="openHAB.Base" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
         <item name="windowActionBarOverlay">false</item>
         <item name="android:windowBackground">?android:colorBackground</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
-        <item name="sliderStyle">@style/openHAB.Slider</item>
+        <item name="sliderStyle">@style/Widget.Material3.Slider</item>
+        <item name="switchStyle">@style/Widget.Material3.CompoundButton.MaterialSwitch</item>
         <item name="materialButtonOutlinedStyle">@style/openHAB.OutlineButton</item>
-        <item name="floatingActionButtonStyle">@style/Widget.MaterialComponents.FloatingActionButton</item>
+        <item name="floatingActionButtonStyle">@style/Widget.Material3.FloatingActionButton.Primary</item>
+        <item name="selectedWidgetBackgroundColor">#5cff5722</item>
     </style>
 
     <style name="openHAB.DayNight" parent="openHAB.Base">
         <item name="chartTheme">white</item>
         <item name="transparentChartTheme">white_transparent</item>
         <item name="valueColors">@array/valueColorsBrightBackground</item>
+
+        <item name="colorPrimary">@color/md_theme_light_primary</item>
+        <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/md_theme_light_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/md_theme_light_onPrimaryContainer</item>
+        <item name="colorSecondary">@color/md_theme_light_secondary</item>
+        <item name="colorOnSecondary">@color/md_theme_light_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/md_theme_light_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/md_theme_light_onSecondaryContainer</item>
+        <item name="colorTertiary">@color/md_theme_light_tertiary</item>
+        <item name="colorOnTertiary">@color/md_theme_light_onTertiary</item>
+        <item name="colorTertiaryContainer">@color/md_theme_light_tertiaryContainer</item>
+        <item name="colorOnTertiaryContainer">@color/md_theme_light_onTertiaryContainer</item>
+        <item name="colorError">@color/md_theme_light_error</item>
+        <item name="colorErrorContainer">@color/md_theme_light_errorContainer</item>
+        <item name="colorOnError">@color/md_theme_light_onError</item>
+        <item name="colorOnErrorContainer">@color/md_theme_light_onErrorContainer</item>
+        <item name="android:colorBackground">@color/md_theme_light_background</item>
+        <item name="colorOnBackground">@color/md_theme_light_onBackground</item>
+        <item name="colorSurface">@color/md_theme_light_surface</item>
+        <item name="colorOnSurface">@color/md_theme_light_onSurface</item>
+        <item name="colorSurfaceVariant">@color/md_theme_light_surfaceVariant</item>
+        <item name="colorOnSurfaceVariant">@color/md_theme_light_onSurfaceVariant</item>
+        <item name="colorOutline">@color/md_theme_light_outline</item>
+        <item name="colorOnSurfaceInverse">@color/md_theme_light_inverseOnSurface</item>
+        <item name="colorSurfaceInverse">@color/md_theme_light_inverseSurface</item>
+        <item name="colorPrimaryInverse">@color/md_theme_light_inversePrimary</item>
+    </style>
+
+    <style name="openHAB.DayNight.Black" parent="openHAB.DayNight">
+        <item name="chartTheme">black</item>
+        <item name="transparentChartTheme">black_transparent</item>
+        <item name="android:windowBackground">@color/black</item>
     </style>
 
     <style name="openHAB.Launch" parent="openHAB.Base">
         <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
         <item name="colorPrimaryDark">@android:color/background_light</item>
-    </style>
-
-    <style name="openHAB.DayNight.orange" parent="openHAB.DayNight">
-        <item name="colorPrimary">@color/openhab_orange</item>
-        <item name="colorSecondary">@color/openhab_orange</item>
-        <item name="colorPrimaryDark">@color/openhab_orange_dark</item>
-        <item name="selectedWidgetBackgroundColor">#5cff5722</item>
-        <item name="alertDialogTheme">@style/openHAB.Dialog.orange</item>
-    </style>
-
-    <style name="openHAB.DayNight.basicui" parent="openHAB.DayNight">
-        <item name="colorPrimary">@color/indigo_500</item>
-        <item name="colorSecondary">@color/pink_a200</item>
-        <item name="colorPrimaryDark">@color/indigo_800</item>
-        <item name="selectedWidgetBackgroundColor">#5cff4081</item>
-        <item name="alertDialogTheme">@style/openHAB.Dialog.basicui</item>
-    </style>
-
-    <style name="openHAB.DayNight.grey" parent="openHAB.DayNight">
-        <item name="colorPrimary">@color/blue_grey_700</item>
-        <item name="colorSecondary">@color/secondary_color_grey_theme</item>
-        <item name="colorPrimaryDark">@color/blue_grey_900</item>
-        <item name="selectedWidgetBackgroundColor">#5c455A64</item>
-        <item name="alertDialogTheme">@style/openHAB.Dialog.grey</item>
-        <item name="floatingActionButtonStyle">@style/openHAB.FAB.grey</item>
-    </style>
-
-    <style name="openHAB.Black.orange" parent="openHAB.DayNight.orange">
-        <item name="chartTheme">black</item>
-        <item name="transparentChartTheme">black_transparent</item>
-        <item name="android:windowBackground">@color/black</item>
-    </style>
-
-    <style name="openHAB.Black.basicui" parent="openHAB.DayNight.basicui">
-        <item name="chartTheme">black</item>
-        <item name="transparentChartTheme">black_transparent</item>
-        <item name="android:windowBackground">@color/black</item>
-    </style>
-
-    <style name="openHAB.Black.grey" parent="openHAB.DayNight.grey">
-        <item name="chartTheme">black</item>
-        <item name="transparentChartTheme">black_transparent</item>
-        <item name="android:windowBackground">@color/black</item>
     </style>
 
     <style name="Theme.MaterialComponents.TranslucentBase">
@@ -73,11 +65,10 @@
         <item name="android:windowAnimationStyle">@null</item>
     </style>
 
-    <style name="ThemeOverlay.MaterialComponents.SecondaryAsPrimary">
-        <item name="colorPrimary">?colorSecondary</item>
-    </style>
-
     <style name="Theme.MaterialComponents.Translucent" parent="Theme.MaterialComponents.TranslucentBase">
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
+
+    <!-- Overridden for night mode -->
+    <style name="ThemeOverlay.MaterialComponents.AppBar" />
 </resources>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -5,7 +5,7 @@
     <PreferenceCategory
         android:title="@string/settings_connection_title"
         android:key="connection">
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:disableDependentsState="true"
             android:key="default_openhab_demomode"
@@ -31,7 +31,7 @@
             android:clickable="true"
             android:key="default_openhab_cleacache"
             android:title="@string/mainmenu_openhab_clearcache" />
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="imageWidgetScaleToFit"
             android:title="@string/settings_image_widget_scaling"
@@ -42,7 +42,7 @@
             android:summary="@string/settings_chart_scaling_summary"
             android:key="chartScalingFactor"
             android:defaultValue="1.5" />
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="default_openhab_chart_hq"
             android:summary="@string/settings_openhab_chart_hq_summary"
@@ -68,25 +68,16 @@
             android:entries="@array/themeArray"
             android:entryValues="@array/themeValues"
             android:icon="@drawable/ic_palette_outline_grey_24dp" />
-        <com.jaredrummler.android.colorpicker.ColorPreferenceCompat
-            android:defaultValue="@color/openhab_orange"
-            android:key="theme_color"
-            app:cpv_dialogType="preset"
-            app:cpv_showColorShades="false"
-            app:cpv_allowCustom="false"
-            app:cpv_dialogTitle="@string/settings_select_a_color"
-            app:cpv_colorPresets="@array/accentColors"
-            android:title="@string/settings_accent_color"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="default_openhab_screentimeroff"
             android:summary="@string/settings_openhab_screentimeroff_summary"
             android:title="@string/settings_openhab_screentimeroff" />
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="default_openhab_fullscreen"
             android:title="@string/settings_openhab_fullscreen" />
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="launcher"
             android:title="@string/settings_set_as_launcher" />
@@ -146,12 +137,12 @@
             android:key="device_control"
             android:persistent="false"
             android:title="@string/device_control" />
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="taskerPlugin"
             android:title="@string/settings_tasker_plugin"
             android:summary="@string/settings_tasker_plugin_summary" />
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:key="data_saver"
             android:defaultValue="false"
             android:title="@string/data_saver_title"
@@ -159,7 +150,7 @@
             android:summaryOff="@string/data_saver_off" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_troubleshooting_title">
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="default_openhab_debug_messages"
             android:title="@string/settings_debug_messages_title" />
@@ -167,7 +158,7 @@
             android:clickable="true"
             android:key="default_openhab_log"
             android:title="@string/view_log" />
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:key="crash_reporting"
             android:defaultValue="true"
             android:title="@string/setting_crash_reporting_title"

--- a/mobile/src/main/res/xml/preferences_drawer_entries.xml
+++ b/mobile/src/main/res/xml/preferences_drawer_entries.xml
@@ -2,27 +2,27 @@
 <androidx.preference.PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="show_sitemaps"
         android:title="@string/settings_show_sitemaps_in_drawer" />
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:defaultValue="true"
         android:key="show_oh3_ui"
         android:icon="@drawable/ic_outline_looks_3_grey_24dp"
         android:title="@string/mainmenu_openhab_oh3_ui" />
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:defaultValue="true"
         android:key="show_habpanel"
         android:icon="@drawable/ic_view_dashboard_outline_grey_24dp"
         android:title="@string/mainmenu_openhab_habpanel" />
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="show_frontail"
         android:icon="@drawable/ic_outline_format_align_left_grey_24dp"
         app:summary="@string/frontail_pref_summary"
         android:title="@string/mainmenu_openhab_frontail" />
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:defaultValue="true"
         android:key="show_nfc"
         android:icon="@drawable/ic_nfc_grey_24dp"

--- a/mobile/src/main/res/xml/preferences_homescreen_widget.xml
+++ b/mobile/src/main/res/xml/preferences_homescreen_widget.xml
@@ -12,7 +12,7 @@
         android:title="@string/tile_name"
         app:whitespaceBehavior="ignore"
         android:inputType="text" />
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:persistent="false"
         android:key="show_state"
         android:title="@string/widget_show_state"


### PR DESCRIPTION
Theme has been generated with https://m3.material.io/theme-builder#/custom and the openHAB orange as seed color.

To reduce complexity, remove the accent color preference.

Fixes https://github.com/openhab/openhab-android/issues/2799
Fixes https://github.com/openhab/openhab-android/issues/1058


TODO:

- [x] Up/Down buttons of color widgets aren't shown
- [x] Change app bar text color to white in light mode
- [x] Update color of app bar action buttons to match text color of app bar
- [X] ~Update color used in `ActivityManager.TaskDescription()`~ Remove custom task description