### PR TITLE
Fallback to min/max/step of Item if not set for Widget

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
@@ -22,7 +22,7 @@ import org.openhab.habdroid.R
 import org.openhab.habdroid.util.forEach
 import org.openhab.habdroid.util.map
 import org.openhab.habdroid.util.mapString
-import org.openhab.habdroid.util.optDoubleOrNull
+import org.openhab.habdroid.util.optFloatOrNull
 import org.openhab.habdroid.util.optStringOrNull
 import org.w3c.dom.Node
 
@@ -40,9 +40,9 @@ data class Item internal constructor(
     val state: ParsedState?,
     val tags: List<Tag>,
     val groupNames: List<String>,
-    val minimum: Double?,
-    val maximum: Double?,
-    val step: Double?,
+    val minimum: Float?,
+    val maximum: Float?,
+    val step: Float?,
 ) : Parcelable {
     enum class Type {
         None,
@@ -336,21 +336,21 @@ fun JSONObject.toItem(): Item {
     }
 
     return Item(
-        name,
-        optStringOrNull("label")?.trim(),
-        optStringOrNull("category")?.lowercase(Locale.US),
-        getString("type").toItemType(),
-        optString("groupType").toItemType(),
-        optStringOrNull("link"),
-        readOnly,
-        members,
-        if (options.isNullOrEmpty()) null else options,
-        state.toParsedState(numberPattern),
-        tags,
-        groupNames,
-        stateDescription?.optDoubleOrNull("minimum"),
-        stateDescription?.optDoubleOrNull("maximum"),
-        stateDescription?.optDoubleOrNull("step")
+        name = name,
+        label = optStringOrNull("label")?.trim(),
+        category = optStringOrNull("category")?.lowercase(Locale.US),
+        type = getString("type").toItemType(),
+        groupType = optString("groupType").toItemType(),
+        link = optStringOrNull("link"),
+        readOnly = readOnly,
+        members = members,
+        options = if (options.isNullOrEmpty()) null else options,
+        state = state.toParsedState(numberPattern),
+        tags = tags,
+        groupNames = groupNames,
+        minimum = stateDescription?.optFloatOrNull("minimum"),
+        maximum = stateDescription?.optFloatOrNull("maximum"),
+        step = stateDescription?.optFloatOrNull("step")
     )
 }
 

--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -26,6 +26,7 @@ import org.openhab.habdroid.util.forEach
 import org.openhab.habdroid.util.getChartScalingFactor
 import org.openhab.habdroid.util.map
 import org.openhab.habdroid.util.optBooleanOrNull
+import org.openhab.habdroid.util.optFloatOrNull
 import org.openhab.habdroid.util.optStringOrFallback
 import org.openhab.habdroid.util.optStringOrNull
 import org.openhab.habdroid.util.shouldRequestHighResChart
@@ -285,9 +286,9 @@ fun JSONObject.collectWidgets(parent: Widget?): List<Widget> {
     val type = getString("type").toWidgetType()
     val icon = optStringOrNull("icon")
     val (minValue, maxValue, step) = Widget.sanitizeMinMaxStep(
-        optDouble("minValue", 0.0).toFloat(),
-        optDouble("maxValue", 100.0).toFloat(),
-        optDouble("step", 1.0).toFloat()
+        optFloatOrNull("minValue") ?: item?.minimum ?: 0f,
+        optFloatOrNull("maxValue") ?: item?.maximum ?: 100f,
+        optFloatOrNull("step") ?: item?.step ?: 1f
     )
 
     val widget = Widget(
@@ -306,7 +307,9 @@ fun JSONObject.collectWidgets(parent: Widget?): List<Widget> {
         labelColor = optStringOrNull("labelcolor"),
         valueColor = optStringOrNull("valuecolor"),
         refresh = Widget.sanitizeRefreshRate(optInt("refresh")),
-        minValue = minValue, maxValue = maxValue, step = step,
+        minValue = minValue,
+        maxValue = maxValue,
+        step = step,
         period = Widget.sanitizePeriod(optString("period")),
         service = optString("service", ""),
         legend = optBooleanOrNull("legend"),

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -276,6 +276,10 @@ fun JSONObject.optDoubleOrNull(key: String): Double? {
     return if (has(key)) getDouble(key) else null
 }
 
+fun JSONObject.optFloatOrNull(key: String): Float? {
+    return if (has(key)) getDouble(key).toFloat() else null
+}
+
 fun JSONObject.optBooleanOrNull(key: String): Boolean? {
     return if (has(key)) getBoolean(key) else null
 }

--- a/mobile/src/test/java/org/openhab/habdroid/model/WidgetTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/model/WidgetTest.kt
@@ -166,13 +166,14 @@ class WidgetTest {
 
     @Test
     fun testGetMinValue() {
-        assertEquals(0.0f, sut1[0].minValue)
-        assertEquals(99.7f, sut2[0].minValue)
+        assertEquals(0f, sut1[0].minValue)
+        // this is invalid in JSON (max < min), expected to be adjusted
+        assertEquals(-10f, sut2[0].minValue)
     }
 
     @Test
     fun testGetMaxValue() {
-        assertEquals(10.0f, sut1[0].maxValue)
+        assertEquals(10f, sut1[0].maxValue)
         // this is invalid in JSON (max < min), expected to be adjusted
         assertEquals(99.7f, sut2[0].maxValue)
     }


### PR DESCRIPTION
Sliders require values to be Floats, so I changed
Item.minimum/maximum/step to Float.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>