### PR TITLE
Show read-only items in widget item picker

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
@@ -70,6 +70,7 @@ abstract class AbstractItemPickerActivity : AbstractBaseActivity(), SwipeRefresh
     protected abstract var hintMessageId: Int
     protected abstract var hintButtonMessageId: Int
     protected abstract var hintIconId: Int
+    protected var hideReadOnly = true
 
     private val suggestedCommandsFactory by lazy {
         SuggestedCommandsFactory(this, true)
@@ -269,7 +270,9 @@ abstract class AbstractItemPickerActivity : AbstractBaseActivity(), SwipeRefresh
                     Log.e(TAG, "Item request failure")
                     return@launch
                 }
-                items = items.filterNot { item -> item.readOnly }
+                if (hideReadOnly) {
+                    items = items.filterNot { item -> item.readOnly }
+                }
 
                 if (forItemCommandOnly) {
                     // Contact Items cannot receive commands

--- a/mobile/src/main/java/org/openhab/habdroid/ui/BasicItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/BasicItemPickerActivity.kt
@@ -33,7 +33,8 @@ class BasicItemPickerActivity(
 
     override fun onCreate(savedInstanceState: Bundle?) {
         initialHighlightItemName = intent.getStringExtra("item")
-        showNoCommand = intent.getBooleanExtra("show_no_command", false)
+        showNoCommand = intent.getBooleanExtra("show_no_command", showNoCommand)
+        hideReadOnly = intent.getBooleanExtra("hide_read_only", hideReadOnly)
         super.onCreate(savedInstanceState)
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/fragments/WidgetSettingsFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/fragments/WidgetSettingsFragment.kt
@@ -132,6 +132,7 @@ class WidgetSettingsFragment :
             val intent = Intent(it.context, BasicItemPickerActivity::class.java)
             intent.putExtra("item", itemAndStatePref.item)
             intent.putExtra("show_no_command", true)
+            intent.putExtra("hide_read_only", false)
             itemAndStatePrefCallback.launch(intent)
             true
         }

--- a/mobile/src/main/java/org/openhab/habdroid/util/SuggestedCommandsFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/SuggestedCommandsFactory.kt
@@ -57,6 +57,7 @@ class SuggestedCommandsFactory(private val context: Context, private val showUnd
     }
 
     private fun fill(item: Item, suggestedCommands: SuggestedCommands, forItemUpdate: Boolean) = when {
+        item.readOnly -> {}
         item.isOfTypeOrGroupType(Item.Type.Color) -> {
             addOnOffCommands(suggestedCommands)
             addIncreaseDecreaseCommands(suggestedCommands)


### PR DESCRIPTION
The item state can be displayed this way.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>