### PR TITLE
WIP: Fix cancelling widget creation

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/homescreenwidget/ItemUpdateWidget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/homescreenwidget/ItemUpdateWidget.kt
@@ -338,7 +338,7 @@ open class ItemUpdateWidget : AppWidgetProvider() {
         ): RemoteViews {
             val darkTheme = data.theme == "dark"
             val layout = when {
-                data.widgetLabel?.isEmpty() == true -> {
+                data.widgetLabel.isNullOrEmpty() -> {
                     if (darkTheme) R.layout.widget_item_update_dark_no_text
                     else R.layout.widget_item_update_light_no_text
                 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/fragments/WidgetSettingsFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/fragments/WidgetSettingsFragment.kt
@@ -157,11 +157,16 @@ class WidgetSettingsFragment :
     }
 
     private fun getCurrentPrefsAsWidgetData(): ItemUpdateWidget.ItemUpdateWidgetData {
+        var widgetLabel = namePref.text
+        if (widgetLabel.isNullOrEmpty()) {
+            widgetLabel = null
+        }
+
         return ItemUpdateWidget.ItemUpdateWidgetData(
             item = itemAndStatePref.item.orEmpty(),
             command = itemAndStatePref.state,
             label = itemAndStatePref.label.orEmpty(),
-            widgetLabel = namePref.text.orEmpty(),
+            widgetLabel = widgetLabel,
             mappedState = itemAndStatePref.mappedState.orEmpty(),
             icon = itemAndStatePref.icon.toOH2IconResource(),
             theme = themePref.value,


### PR DESCRIPTION
Make `widgetLabel` not-null as null had a special meaning (auto generated label) some time ago, but this had been migrated > 1 year ago.

`null` vs. empty string is causing an issue when checking if data has been changed.

Fixes #3125

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>