### PR TITLE
Display item states in color items

### DIFF
--- a/mobile/src/main/res/layout/widgetlist_coloritem.xml
+++ b/mobile/src/main/res/layout/widgetlist_coloritem.xml
@@ -6,7 +6,7 @@
     android:descendantFocusability="blocksDescendants"
     style="@style/WidgetListItemContainer">
 
-    <include layout="@layout/widgetlist_icontext" />
+    <include layout="@layout/widgetlist_iconvaluetext" />
 
     <Button
         style="@style/openHAB.ActionButton"


### PR DESCRIPTION
Color widgets are the only widgets that don't show there state directly in the Sitemap. There's enough space to display a value and IMO it's a good addition.

Server-side I'm using the JS map to get the brightness in percent from the item state.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>