### PR TITLE
Remove state from Item label

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/ItemsControlsProviderService.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/ItemsControlsProviderService.kt
@@ -186,7 +186,8 @@ class ItemsControlsProviderService : ControlsProviderService() {
         }
 
         fun maybeCreateControl(item: Item): Control? {
-            if (item.label.isNullOrEmpty() || item.readOnly) return null
+            val label = item.label
+            if (label.isNullOrEmpty() || item.readOnly) return null
             val controlTemplate = if (item.options != null) {
                 // Open app when clicking on tile
                 ControlTemplate.getNoTemplateObject()
@@ -253,7 +254,7 @@ class ItemsControlsProviderService : ControlsProviderService() {
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent_Immutable
             )
             val statefulControl = Control.StatefulBuilder(item.name, pi)
-                .setTitle(item.label)
+                .setTitle(label)
                 .setSubtitle(subtitle)
                 .setZone(zone)
                 .setStructure(serverName)

--- a/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
@@ -29,7 +29,7 @@ import org.w3c.dom.Node
 @Parcelize
 data class Item internal constructor(
     val name: String,
-    val label: String?,
+    private val rawLabel: String?,
     val category: String?,
     val type: Type,
     val groupType: Type?,
@@ -44,6 +44,8 @@ data class Item internal constructor(
     val maximum: Float?,
     val step: Float?,
 ) : Parcelable {
+    val label get() = rawLabel?.split("[", "]")?.getOrNull(0)?.trim()
+
     enum class Type {
         None,
         Call,
@@ -237,7 +239,7 @@ data class Item internal constructor(
             val parsedItem = jsonObject.toItem()
             // Events don't contain the link property, so preserve that if previously present
             val link = item?.link ?: parsedItem.link
-            return parsedItem.copy(link = link, label = parsedItem.label?.trim())
+            return parsedItem.copy(link = link, rawLabel = parsedItem.label)
         }
     }
 }
@@ -265,7 +267,7 @@ fun Node.toItem(): Item? {
 
     return Item(
         name = finalName,
-        label = finalName.trim(),
+        rawLabel = finalName,
         category = null,
         type = type,
         groupType = groupType,
@@ -338,7 +340,7 @@ fun JSONObject.toItem(): Item {
 
     return Item(
         name = name,
-        label = optStringOrNull("label")?.trim(),
+        rawLabel = optStringOrNull("label"),
         category = optStringOrNull("category")?.lowercase(Locale.US),
         type = getString("type").toItemType(),
         groupType = optString("groupType").toItemType(),

--- a/mobile/src/test/java/org/openhab/habdroid/model/ItemTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/model/ItemTest.kt
@@ -177,7 +177,7 @@ class ItemTest {
             { 'state': '52.5200066,13.4029540', 'type': 'Location', 'name': 'GroupDemoLocation',
               'label': 'Location 1', 'groupNames': [ 'LocationGroup' ] },
             { 'state': '52.5200066,13.4029540', 'type': 'Location', 'name': 'GroupDemoLocation',
-              'label': 'Location 2', 'groupNames': [ 'LocationGroup' ] },
+              'label': 'Location 2 [foo]', 'groupNames': [ 'LocationGroup' ] },
             ], 'state': 'NULL', 'type': 'Group', 'name': 'LocationGroup', 'label': 'Location Group',
                 'tags': [ "Lighting", "Switchable", "Timestamp", "foobar" ] }
             """.trimIndent()


### PR DESCRIPTION
For #3143 I set the label of an Item to `Color [JS(hsb-to-brightness.js):%s]`. When this Item is fetched via /rest/items/ the brackets aren't resolved to the actual value. When fetched via /rest/sitemaps/ the brackets are placed. Since `[JS(hsb-to-brightness.js):%s]` isn't useful to be shown in the device control, I added a splitting of the label as it's done for Widgets.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>