### PR TITLE
Fix crash when scheduling periodic trigger

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -454,9 +454,9 @@ class BackgroundTasksManager : BroadcastReceiver() {
                 .map { key -> prefs.getStringOrNull(key).toItemUpdatePrefValue() }
                 .any { value -> value.first }
             val widgetShowsState = AppWidgetManager.getInstance(context)
-                .getAppWidgetIds(ComponentName(context, ItemUpdateWidget::class.java))
-                .map { id -> ItemUpdateWidget.getInfoForWidget(context, id) }
-                .any { info -> info.showState }
+                ?.getAppWidgetIds(ComponentName(context, ItemUpdateWidget::class.java))
+                ?.map { id -> ItemUpdateWidget.getInfoForWidget(context, id) }
+                ?.any { info -> info.showState } ?: false
 
             if (!periodicWorkIsNeeded &&
                 !CloudMessagingHelper.needsPollingForNotifications(context) &&


### PR DESCRIPTION
```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'int[] android.appwidget.AppWidgetManager.getAppWidgetIds(android.content.ComponentName)' on a null object reference
       at org.openhab.habdroid.background.BackgroundTasksManager$Companion.schedulePeriodicTrigger(BackgroundTasksManager.kt:457)
       at org.openhab.habdroid.background.BackgroundTasksManager$Companion.schedulePeriodicTrigger$default(BackgroundTasksManager.kt:450)
       at org.openhab.habdroid.background.BackgroundTasksManager$Companion.scheduleWorker(BackgroundTasksManager.kt:542)
       at org.openhab.habdroid.background.BackgroundTasksManager$Companion.scheduleWorker$default(BackgroundTasksManager.kt:533)
       at org.openhab.habdroid.background.BackgroundTasksManager.onReceive(BackgroundTasksManager.kt:134)
       at android.app.ActivityThread.handleReceiver(ActivityThread.java:3187)
       at android.app.ActivityThread.-wrap17(ActivityThread.java)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1672)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:164)
       at android.app.ActivityThread.main(ActivityThread.java:6494)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
```

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>