### PR TITLE
Fix touch target size warnings

### DIFF
--- a/mobile/src/main/res/values/styles.xml
+++ b/mobile/src/main/res/values/styles.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="openHAB.ActionButton" parent="Widget.Material3.Button.IconButton">
-        <item name="android:layout_width">44dip</item>
-        <item name="android:layout_height">44dp</item>
+        <item name="android:layout_width">48dp</item>
+        <item name="android:layout_height">48dp</item>
         <item name="android:layout_gravity">center_vertical</item>
         <item name="android:background">?attr/selectableItemBackgroundBorderless</item>
         <item name="iconTint">?attr/colorOnBackground</item>


### PR DESCRIPTION
In compact mode the line height is at least `48dp` high, so no additional scrolling is required after this change.

Closes #3158

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>