### PR TITLE
Fix two crashes with search view in log

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/LogActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/LogActivity.kt
@@ -50,7 +50,7 @@ class LogActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListener
     private lateinit var fab: FloatingActionButton
     private lateinit var scrollView: NestedScrollView
     private lateinit var swipeLayout: SwipeRefreshLayout
-    private lateinit var searchView: SearchView
+    private var searchView: SearchView? = null
     private var showErrorsOnly: Boolean = false
     private var fullLog = ""
 
@@ -89,8 +89,8 @@ class LogActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListener
 
         val backCallback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
-                if (!searchView.isIconified) {
-                    searchView.isIconified = true
+                if (searchView?.isIconified == false) {
+                    searchView?.isIconified = true
                 } else {
                     isEnabled = false
                     onBackPressedDispatcher.onBackPressed()
@@ -126,9 +126,9 @@ class LogActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListener
         menuInflater.inflate(R.menu.log_menu, menu)
 
         val searchItem = menu.findItem(R.id.app_bar_search)
-        searchView = searchItem.actionView as SearchView
-        searchView.inputType = InputType.TYPE_CLASS_TEXT
-        searchView.setOnQueryTextListener(this)
+        searchView = searchItem.actionView as SearchView?
+        searchView?.inputType = InputType.TYPE_CLASS_TEXT
+        searchView?.setOnQueryTextListener(this)
 
         updateErrorsOnlyButtonState(menu.findItem(R.id.show_errors))
         return true
@@ -183,7 +183,7 @@ class LogActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListener
 
     private fun fetchLog(clear: Boolean) = launch {
         fullLog = collectLog(clear)
-        onQueryTextChange(searchView.query.toString())
+        onQueryTextChange(searchView?.query?.toString())
         setUiState(false)
         scrollView.post { scrollView.fullScroll(View.FOCUS_DOWN) }
     }


### PR DESCRIPTION
````
kotlin.UninitializedPropertyAccessException: lateinit property searchView has not been initialized
	at org.openhab.habdroid.ui.LogActivity$fetchLog$1.invokeSuspend(LogActivity.kt:186)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at android.os.Handler.handleCallback(Handler.java:883)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loop(Looper.java:213)
	at android.app.ActivityThread.main(ActivityThread.java:7664)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:982)
````

````
Fatal Exception: java.lang.NullPointerException: null cannot be cast to non-null type androidx.appcompat.widget.SearchView
       at org.openhab.habdroid.ui.LogActivity.onCreateOptionsMenu(LogActivity.kt:129)
       at android.app.Activity.onCreatePanelMenu(Activity.java:3388)
       at androidx.activity.ComponentActivity.onCreatePanelMenu(ComponentActivity.java:521)
       at androidx.appcompat.view.WindowCallbackWrapper.onCreatePanelMenu(WindowCallbackWrapper.java:95)
       at androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback.onCreatePanelMenu(AppCompatDelegateImpl.java:3429)
       at androidx.appcompat.app.ToolbarActionBar.populateOptionsMenu(ToolbarActionBar.java:458)
       at androidx.appcompat.app.ToolbarActionBar$1.run(ToolbarActionBar.java:58)
       at android.os.Handler.handleCallback(Handler.java:790)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:164)
       at android.app.ActivityThread.main(ActivityThread.java:6494)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
````

Closes #3153

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>