### PR TITLE
Apply dynamic theme correctly

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -466,10 +466,9 @@ fun Activity.shouldUseDynamicColors(): Boolean {
 }
 
 fun Activity.applyUserSelectedTheme() {
+    setTheme(getActivityThemeId())
     if (shouldUseDynamicColors()) {
         DynamicColors.applyToActivityIfAvailable(this)
-    } else {
-        setTheme(getActivityThemeId())
     }
 }
 


### PR DESCRIPTION
One of our base themes must be set even when using dynamic colors to make our custom attributes work.

Fixes #3214