### PR TITLE
Check for crashes in beta before publishing

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -12,8 +12,10 @@ body:
       options:
         - label: Check for major crashes in latest stable version
           required: false
-        - label: Merge new translations
+        - label: Check for major crashes in beta versions since last stable version
           required: false
+        - label: Merge new translations
+          required: false  
   - type: textarea
     id: release-notes
     attributes:

--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -15,7 +15,7 @@ body:
         - label: Check for major crashes in beta versions since last stable version
           required: false
         - label: Merge new translations
-          required: false  
+          required: false
   - type: textarea
     id: release-notes
     attributes:


### PR DESCRIPTION
When the beta version is downloaded from GitHub manually, crashes are sent to Firebase.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>