### PR TITLE
Use the new MaterialSwitch instead of SwitchMaterial

### DIFF
--- a/mobile/src/main/res/layout/widgetlist_switchitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_switchitem.xml
@@ -6,9 +6,8 @@
 
     <include layout="@layout/widgetlist_iconvaluetext" />
 
-    <com.google.android.material.switchmaterial.SwitchMaterial
+    <com.google.android.material.materialswitch.MaterialSwitch
         android:id="@+id/toggle"
-        style="@style/Widget.Material3.CompoundButton.MaterialSwitch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"

--- a/mobile/src/main/res/layout/widgetlist_switchitem_compact.xml
+++ b/mobile/src/main/res/layout/widgetlist_switchitem_compact.xml
@@ -6,9 +6,8 @@
 
     <include layout="@layout/widgetlist_iconvaluetext_compact" />
 
-    <com.google.android.material.switchmaterial.SwitchMaterial
+    <com.google.android.material.materialswitch.MaterialSwitch
         android:id="@+id/toggle"
-        style="@style/Widget.Material3.CompoundButton.MaterialSwitch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"


### PR DESCRIPTION
Keep the old one in dialogs in the settings to have a consistent look in PreferencesActivity.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>