### PR TITLE
Improve section switch overflow handling

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -739,8 +739,16 @@ class WidgetAdapter(
         ),
         View.OnClickListener {
         private val group: MaterialButtonToggleGroup = itemView.findViewById(R.id.switch_group)
+        private val overflowButton: MaterialButton = itemView.findViewById(R.id.overflow_button)
         private val spareViews = mutableListOf<View>()
         private val maxButtons = itemView.resources.getInteger(R.integer.section_switch_max_buttons)
+
+        init {
+            overflowButton.setOnClickListener {
+                val widget = boundWidget ?: return@setOnClickListener
+                bottomSheetPresenter.showBottomSheet(SelectionBottomSheet(), widget)
+            }
+        }
 
         override fun bind(widget: Widget) {
             super.bind(widget)
@@ -751,6 +759,9 @@ class WidgetAdapter(
 
             val mappings = widget.mappingsOrItemOptions
             val buttonCount = min(mappings.size, maxButtons)
+
+            // remove overflow button, so it isn't counted when inflating views
+            group.removeView(overflowButton)
 
             // inflate missing views
             while (spareViews.isNotEmpty() && group.childCount < buttonCount) {
@@ -767,29 +778,24 @@ class WidgetAdapter(
                 group.addView(view)
             }
 
-            // bind views
-            mappings.slice(0 until buttonCount).forEachIndexed { index, mapping ->
-                with(group[index] as MaterialButton) {
-                    text = mapping.label
-                    tag = mapping.value
-                    isVisible = true
-                }
-            }
-            if (mappings.size > maxButtons) {
-                // overflow button
-                with(group[maxButtons - 1] as MaterialButton) {
-                    text = "⋯"
-                    tag = null
-                    isVisible = true
-                    isCheckable = false
-                }
-            }
-
             // remove unneeded views
             while (group.childCount > buttonCount) {
                 val view = group[group.childCount - 1]
                 spareViews.add(view)
                 group.removeView(view)
+            }
+
+            // bind views
+            mappings.slice(0 until buttonCount).forEachIndexed { index, mapping ->
+                with(group[index] as MaterialButton) {
+                    text = mapping.label
+                    tag = mapping.value
+                }
+            }
+
+            // add overflow button if needed
+            if (mappings.size > maxButtons) {
+                group.addView(overflowButton)
             }
 
             // check selected view
@@ -809,15 +815,7 @@ class WidgetAdapter(
         }
 
         override fun onClick(view: View) {
-            val tag = view.tag
-            if (tag != null) {
-                // Make sure one can't uncheck buttons by clicking a checked one
-                (view as MaterialButton).isChecked = true
-                connection.httpClient.sendItemCommand(boundWidget?.item, view.tag as String)
-            } else {
-                val widget = boundWidget ?: return
-                bottomSheetPresenter.showBottomSheet(SelectionBottomSheet(), widget)
-            }
+            connection.httpClient.sendItemCommand(boundWidget?.item, view.tag as String)
         }
 
         override fun handleRowClick() {

--- a/mobile/src/main/res/layout/widgetlist_sectionswitchitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_sectionswitchitem.xml
@@ -61,6 +61,10 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/widgeticon"
         app:layout_constraintTop_toBottomOf="@id/labelbarrier"
-        app:singleSelection="true" />
+        app:singleSelection="true">
+
+        <include layout="@layout/widgetlist_sectionswitchitem_overflow_button" />
+
+    </com.google.android.material.button.MaterialButtonToggleGroup>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/mobile/src/main/res/layout/widgetlist_sectionswitchitem_button.xml
+++ b/mobile/src/main/res/layout/widgetlist_sectionswitchitem_button.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.button.MaterialButton
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/Widget.Material3.Button.OutlinedButton"
     android:layout_width="0dp"
@@ -11,5 +12,6 @@
     android:paddingTop="4dp"
     android:paddingBottom="4dp"
     android:textAppearance="?attr/textAppearanceLabelMedium"
+    app:toggleCheckedStateOnClick="false"
     tools:layout_width="wrap_content"
     tools:text="Action 1" />

--- a/mobile/src/main/res/layout/widgetlist_sectionswitchitem_compact.xml
+++ b/mobile/src/main/res/layout/widgetlist_sectionswitchitem_compact.xml
@@ -12,6 +12,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
-        app:singleSelection="true" />
+        app:singleSelection="true">
+
+        <include layout="@layout/widgetlist_sectionswitchitem_overflow_button" />
+
+    </com.google.android.material.button.MaterialButtonToggleGroup>
 
 </LinearLayout>

--- a/mobile/src/main/res/layout/widgetlist_sectionswitchitem_overflow_button.xml
+++ b/mobile/src/main/res/layout/widgetlist_sectionswitchitem_overflow_button.xml
@@ -2,14 +2,13 @@
 <com.google.android.material.button.MaterialButton
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     style="@style/Widget.Material3.Button.OutlinedButton"
+    android:id="@+id/overflow_button"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:minWidth="48dp"
-    android:paddingHorizontal="8dp"
-    android:paddingTop="2dp"
-    android:paddingBottom="2dp"
+    android:minWidth="0dp"
+    android:paddingHorizontal="12dp"
+    android:text="⋯"
     android:textAppearance="?attr/textAppearanceLabelMedium"
-    app:toggleCheckedStateOnClick="false"
-    tools:text="Action 1" />
+    android:checkable="false"
+    app:toggleCheckedStateOnClick="false" />

--- a/mobile/src/main/res/values-w450dp/dimens.xml
+++ b/mobile/src/main/res/values-w450dp/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="section_switch_max_buttons">5</integer>
+</resources>

--- a/mobile/src/main/res/values-w750dp/dimens.xml
+++ b/mobile/src/main/res/values-w750dp/dimens.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <integer name="section_switch_max_buttons">7</integer>
+    <integer name="section_switch_max_buttons">8</integer>
     <dimen name="widgetlist_compact_slider_width">250dp</dimen>
 </resources>

--- a/mobile/src/main/res/values/dimens.xml
+++ b/mobile/src/main/res/values/dimens.xml
@@ -13,5 +13,5 @@
     <dimen name="outlineButtonStrokeWidth">2dp</dimen>
     <dimen name="widget_background_radius">8dp</dimen>
 
-    <integer name="section_switch_max_buttons">5</integer>
+    <integer name="section_switch_max_buttons">4</integer>
 </resources>


### PR DESCRIPTION
- Only assign needed width to overflow button
- Allow more buttons to be shown on large tablets

Fixes #3238