### PR TITLE
Declare camera and mic as optional hardware

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -34,11 +34,15 @@
 
     <uses-sdk tools:overrideLibrary="androidx.security"/>
 
+    <!-- Declare features are optional, see https://developer.android.com/guide/topics/manifest/uses-feature-element#permissions -->
     <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
     <uses-feature android:name="android.hardware.location" android:required="false" />
     <uses-feature android:name="android.hardware.location.gps" android:required="false" />
     <uses-feature android:name="android.hardware.nfc" android:required="false" />
     <uses-feature android:name="android.hardware.wifi" android:required="false" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+    <uses-feature android:name="android.hardware.microphone" android:required="false" />
 
     <queries>
         <package android:name="net.dinglisch.android.taskerm" />


### PR DESCRIPTION
Otherwise the newly introduced permissions imply that these hardware features are required.