### PR TITLE
Fix window insets calculations for API level <= 29

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractBaseActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractBaseActivity.kt
@@ -54,6 +54,7 @@ import org.openhab.habdroid.util.ScreenLockMode
 import org.openhab.habdroid.util.applyUserSelectedTheme
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getScreenLockMode
+import org.openhab.habdroid.util.getVisibileInsets
 import org.openhab.habdroid.util.hasPermissions
 import org.openhab.habdroid.util.resolveThemedColor
 
@@ -107,7 +108,7 @@ abstract class AbstractBaseActivity : AppCompatActivity(), CoroutineScope {
     fun enableDrawingBehindStatusBar() {
         EdgeToEdgeUtils.applyEdgeToEdge(window, true)
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.activity_content)) { view, insets ->
-            view.updatePadding(bottom = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom)
+            view.updatePadding(bottom = insets.getVisibileInsets(WindowInsetsCompat.Type.systemBars()).bottom)
             insets
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
@@ -64,6 +64,7 @@ import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.getHumanReadableErrorMessage
 import org.openhab.habdroid.util.getPrefs
+import org.openhab.habdroid.util.getVisibileInsets
 import org.openhab.habdroid.util.getWifiManager
 import org.openhab.habdroid.util.isDebugModeEnabled
 import org.openhab.habdroid.util.openInBrowser
@@ -546,7 +547,7 @@ abstract class ContentController protected constructor(private val activity: Mai
     }
 
     private fun updateContentViewForInsets() {
-        val i = insets?.getInsets(WindowInsetsCompat.Type.systemBars())
+        val i = insets?.getVisibileInsets(WindowInsetsCompat.Type.systemBars())
         val actionBarVisible = activity.supportActionBar?.isShowing() == true
         contentView.updatePadding(top = if (i != null && !actionBarVisible) i.top else 0)
     }

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -44,7 +44,9 @@ import androidx.annotation.StringRes
 import androidx.annotation.StyleRes
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.Insets
 import androidx.core.net.toUri
+import androidx.core.view.WindowInsetsCompat
 import androidx.preference.PreferenceManager
 import com.caverock.androidsvg.SVG
 import com.google.android.material.color.DynamicColors
@@ -609,3 +611,6 @@ inline fun <reified T> Bundle.parcelableArrayList(key: String): List<T>? = when 
     Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getParcelableArrayList(key, T::class.java)
     else -> @Suppress("DEPRECATION") getParcelableArrayList(key)
 }
+
+fun WindowInsetsCompat.getVisibileInsets(type: Int): Insets =
+    if (isVisible(type)) getInsets(type) else Insets.NONE


### PR DESCRIPTION
For those API levels invisible insets are not automatically subtracted from the insets returned by getInsets(), so do it manually.