### PR TITLE
Color SVG icons

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/NotificationHelper.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/NotificationHelper.kt
@@ -33,9 +33,11 @@ import org.openhab.habdroid.model.CloudNotification
 import org.openhab.habdroid.model.IconResource
 import org.openhab.habdroid.ui.MainActivity
 import org.openhab.habdroid.util.HttpClient
+import org.openhab.habdroid.util.IconBackground
 import org.openhab.habdroid.util.ImageConversionPolicy
 import org.openhab.habdroid.util.PendingIntent_Immutable
 import org.openhab.habdroid.util.determineDataUsagePolicy
+import org.openhab.habdroid.util.getIconFallbackColor
 import org.openhab.habdroid.util.getNotificationTone
 import org.openhab.habdroid.util.getNotificationVibrationPattern
 import org.openhab.habdroid.util.getPrefs
@@ -171,7 +173,11 @@ class NotificationHelper constructor(private val context: Context) {
                             timeoutMillis = 1000,
                             caching = HttpClient.CachingMode.FORCE_CACHE_IF_POSSIBLE
                         )
-                        .asBitmap(targetSize, ImageConversionPolicy.PreferTargetSize)
+                        .asBitmap(
+                            targetSize,
+                            context.getIconFallbackColor(IconBackground.OS_THEME),
+                            ImageConversionPolicy.PreferTargetSize
+                        )
                         .response
                     bitmap
                 } catch (e: HttpClient.HttpException) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ImageWidgetActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ImageWidgetActivity.kt
@@ -31,9 +31,11 @@ import org.openhab.habdroid.R
 import org.openhab.habdroid.core.connection.Connection
 import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.util.HttpClient
+import org.openhab.habdroid.util.IconBackground
 import org.openhab.habdroid.util.ImageConversionPolicy
 import org.openhab.habdroid.util.ScreenLockMode
 import org.openhab.habdroid.util.determineDataUsagePolicy
+import org.openhab.habdroid.util.getIconFallbackColor
 import org.openhab.habdroid.util.orDefaultIfEmpty
 
 class ImageWidgetActivity : AbstractBaseActivity() {
@@ -113,7 +115,11 @@ class ImageWidgetActivity : AbstractBaseActivity() {
             try {
                 conn.httpClient
                     .get(widgetUrl)
-                    .asBitmap(size, ImageConversionPolicy.PreferTargetSize)
+                    .asBitmap(
+                        size,
+                        getIconFallbackColor(IconBackground.APP_THEME),
+                        ImageConversionPolicy.PreferTargetSize
+                    )
                     .response
             } catch (e: HttpClient.HttpException) {
                 Log.d(TAG, "Failed to load image", e)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -109,6 +109,7 @@ import org.openhab.habdroid.ui.widget.LockableDrawerLayout
 import org.openhab.habdroid.util.AsyncServiceResolver
 import org.openhab.habdroid.util.CrashReportingHelper
 import org.openhab.habdroid.util.HttpClient
+import org.openhab.habdroid.util.IconBackground
 import org.openhab.habdroid.util.ImageConversionPolicy
 import org.openhab.habdroid.util.PendingIntent_Immutable
 import org.openhab.habdroid.util.PrefKeys
@@ -123,6 +124,7 @@ import org.openhab.habdroid.util.getCurrentWifiSsid
 import org.openhab.habdroid.util.getDefaultSitemap
 import org.openhab.habdroid.util.getGroupItems
 import org.openhab.habdroid.util.getHumanReadableErrorMessage
+import org.openhab.habdroid.util.getIconFallbackColor
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getPrimaryServerId
 import org.openhab.habdroid.util.getRemoteUrl
@@ -1106,7 +1108,11 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
                 item.icon = conn.httpClient.get(
                     sitemap.icon.toUrl(context, context.determineDataUsagePolicy(conn).loadIconsWithState)
                 )
-                    .asBitmap(defaultIcon!!.intrinsicWidth, ImageConversionPolicy.ForceTargetSize)
+                    .asBitmap(
+                        defaultIcon!!.intrinsicWidth,
+                        getIconFallbackColor(IconBackground.APP_THEME),
+                        ImageConversionPolicy.ForceTargetSize
+                    )
                     .response
                     .toDrawable(resources)
             } catch (e: HttpClient.HttpException) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -64,6 +64,7 @@ import org.openhab.habdroid.ui.widget.ContextMenuAwareRecyclerView
 import org.openhab.habdroid.ui.widget.RecyclerViewSwipeRefreshLayout
 import org.openhab.habdroid.util.CacheManager
 import org.openhab.habdroid.util.HttpClient
+import org.openhab.habdroid.util.IconBackground
 import org.openhab.habdroid.util.ImageConversionPolicy
 import org.openhab.habdroid.util.PendingIntent_Mutable
 import org.openhab.habdroid.util.PrefKeys
@@ -71,9 +72,9 @@ import org.openhab.habdroid.util.SuggestedCommandsFactory
 import org.openhab.habdroid.util.Util
 import org.openhab.habdroid.util.dpToPixel
 import org.openhab.habdroid.util.getActiveServerId
+import org.openhab.habdroid.util.getIconFallbackColor
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getStringOrEmpty
-import org.openhab.habdroid.util.getStringOrFallbackIfEmpty
 import org.openhab.habdroid.util.openInBrowser
 import org.openhab.habdroid.util.useCompactSitemapLayout
 
@@ -562,9 +563,12 @@ class WidgetListFragment :
         val foregroundSize = activity.resources.dpToPixel(46F).toInt()
         val iconBitmap = if (linkedPage.icon != null) {
             try {
+                val iconFallbackColor = activity.getIconFallbackColor(
+                    if (whiteBackground) IconBackground.LIGHT else IconBackground.DARK
+                )
                 connection.httpClient
                     .get(linkedPage.icon.toUrl(activity, true))
-                    .asBitmap(foregroundSize, ImageConversionPolicy.ForceTargetSize)
+                    .asBitmap(foregroundSize, iconFallbackColor, ImageConversionPolicy.ForceTargetSize)
                     .response
             } catch (e: HttpClient.HttpException) {
                 null

--- a/mobile/src/main/java/org/openhab/habdroid/ui/homescreenwidget/ItemUpdateWidget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/homescreenwidget/ItemUpdateWidget.kt
@@ -220,7 +220,7 @@ open class ItemUpdateWidget : AppWidgetProvider() {
                 val sizeInDp = min(height, width)
                 @Px val size = context.resources.dpToPixel(sizeInDp).toInt()
                 Log.d(TAG, "Icon size: $size")
-                iconData.svgToBitmap(size, ImageConversionPolicy.PreferTargetSize)
+                iconData.svgToBitmap(size, null, ImageConversionPolicy.PreferTargetSize)
             }
 
             val setIcon = { iconData: InputStream, isSvg: Boolean ->

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.kt
@@ -34,7 +34,9 @@ import org.openhab.habdroid.R
 import org.openhab.habdroid.core.connection.Connection
 import org.openhab.habdroid.util.CacheManager
 import org.openhab.habdroid.util.HttpClient
+import org.openhab.habdroid.util.IconBackground
 import org.openhab.habdroid.util.ImageConversionPolicy
+import org.openhab.habdroid.util.getIconFallbackColor
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.isDebugModeEnabled
 
@@ -361,7 +363,11 @@ class WidgetImageView constructor(context: Context, attrs: AttributeSet?) : AppC
                     }
                     val bitmap = client.get(actualUrl.toString(),
                         timeoutMillis = timeoutMillis, caching = cachingMode)
-                        .asBitmap(size, conversionPolicy)
+                        .asBitmap(
+                            size,
+                            context.getIconFallbackColor(IconBackground.APP_THEME),
+                            conversionPolicy
+                        )
                         .response
                     CacheManager.getInstance(context).cacheBitmap(url, bitmap)
                     applyLoadedBitmap(bitmap)

--- a/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.kt
@@ -216,8 +216,14 @@ class HttpClient constructor(client: OkHttpClient, baseUrl: String?, username: S
         }
 
         @Throws(HttpException::class)
-        suspend fun asBitmap(sizeInPixels: Int, conversionPolicy: ImageConversionPolicy): HttpBitmapResult = try {
-            val bitmap = withContext(Dispatchers.IO) { response.toBitmap(sizeInPixels, conversionPolicy) }
+        suspend fun asBitmap(
+            sizeInPixels: Int,
+            fallbackColor: Int,
+            conversionPolicy: ImageConversionPolicy
+        ): HttpBitmapResult = try {
+            val bitmap = withContext(Dispatchers.IO) {
+                response.toBitmap(sizeInPixels, fallbackColor, conversionPolicy)
+            }
             HttpBitmapResult(request, bitmap)
         } catch (e: IOException) {
             throw HttpException(request, originalUrl, e)


### PR DESCRIPTION
The keyword `currentColor` can be used to color SVGs. This seems to be the best solution for the "colorless" icon issue.

Closes #3204