### PR TITLE
Don't check overflow button

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -802,6 +802,7 @@ class WidgetAdapter(
             // check selected view
             val state = widget.item?.state?.asString
             val checkedId = group.children
+                .filter { it.id != R.id.overflow_button }
                 .filter { it.tag == state }
                 .map { it.id }
                 .firstOrNull()


### PR DESCRIPTION
If the item state is `null`, the overflow button is checked as its tag is also `null`.