### PR TITLE
Ignore alarms set by Signal

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -311,6 +311,7 @@ class BackgroundTasksManager : BroadcastReceiver() {
             "com.android.calendar",
             "com.samsung.android.calendar",
             "com.miui.securitycenter",
+            "org.thoughtcrime.securesms"
         )
         private val VALUE_GETTER_MAP = HashMap<String, (Context, Intent?) -> ItemUpdateWorker.ValueWithInfo?>()
 


### PR DESCRIPTION
Signal uses AlarmManager for scheduled messages, which are no real alarms.