### PR TITLE
Allow custom Frontail URL

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/UpdateBroadcastReceiver.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/UpdateBroadcastReceiver.kt
@@ -149,7 +149,8 @@ class UpdateBroadcastReceiver : BroadcastReceiver() {
                         prefs.getStringOrNull("default_openhab_sslclientcert"),
                         defaultSitemap,
                         null,
-                        false
+                        false,
+                        null
                     )
                     config.saveToPrefs(prefs, secretPrefs)
                     prefs.edit {

--- a/mobile/src/main/java/org/openhab/habdroid/model/ServerConfiguration.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ServerConfiguration.kt
@@ -66,7 +66,8 @@ data class ServerConfiguration(
     val sslClientCert: String?,
     val defaultSitemap: DefaultSitemap?,
     val wifiSsids: Set<String>?,
-    val restrictToWifiSsids: Boolean
+    val restrictToWifiSsids: Boolean,
+    val frontailUrl: String?
 ) : Parcelable {
     fun saveToPrefs(prefs: SharedPreferences, secretPrefs: SharedPreferences) {
         Log.d(TAG, "saveToPrefs: ${this.toRedactedString()}")
@@ -76,6 +77,7 @@ data class ServerConfiguration(
             putString(PrefKeys.buildServerKey(id, PrefKeys.SERVER_NAME_PREFIX), name)
             putString(PrefKeys.buildServerKey(id, PrefKeys.LOCAL_URL_PREFIX), localPath?.url)
             putString(PrefKeys.buildServerKey(id, PrefKeys.REMOTE_URL_PREFIX), remotePath?.url)
+            putString(PrefKeys.buildServerKey(id, PrefKeys.FRONTAIL_URL_PREFIX), frontailUrl)
             putString(PrefKeys.buildServerKey(id, PrefKeys.SSL_CLIENT_CERT_PREFIX), sslClientCert)
             putStringSet(PrefKeys.buildServerKey(id, PrefKeys.WIFI_SSID_PREFIX), wifiSsids)
             putBoolean(PrefKeys.buildServerKey(id, PrefKeys.RESTRICT_TO_SSID_PREFIX), restrictToWifiSsids)
@@ -106,6 +108,7 @@ data class ServerConfiguration(
             remove(PrefKeys.buildServerKey(id, PrefKeys.SERVER_NAME_PREFIX))
             remove(PrefKeys.buildServerKey(id, PrefKeys.LOCAL_URL_PREFIX))
             remove(PrefKeys.buildServerKey(id, PrefKeys.REMOTE_URL_PREFIX))
+            remove(PrefKeys.buildServerKey(id, PrefKeys.FRONTAIL_URL_PREFIX))
             remove(PrefKeys.buildServerKey(id, PrefKeys.SSL_CLIENT_CERT_PREFIX))
             remove(PrefKeys.buildServerKey(id, PrefKeys.DEFAULT_SITEMAP_NAME_PREFIX))
             remove(PrefKeys.buildServerKey(id, PrefKeys.DEFAULT_SITEMAP_LABEL_PREFIX))
@@ -145,7 +148,8 @@ data class ServerConfiguration(
             sslClientCert,
             defaultSitemap,
             wifiSsids,
-            restrictToWifiSsids
+            restrictToWifiSsids,
+            frontailUrl
         ).toString()
     }
 
@@ -181,6 +185,7 @@ data class ServerConfiguration(
             }
             val restrictToWifiSsids =
                 prefs.getBoolean(PrefKeys.buildServerKey(id, PrefKeys.RESTRICT_TO_SSID_PREFIX), false)
+            val frontailPort = prefs.getStringOrNull(PrefKeys.buildServerKey(id, PrefKeys.FRONTAIL_URL_PREFIX))
 
             val config = ServerConfiguration(
                 id,
@@ -190,7 +195,8 @@ data class ServerConfiguration(
                 clientCert,
                 getDefaultSitemap(prefs, id),
                 wifiSsids,
-                restrictToWifiSsids
+                restrictToWifiSsids,
+                frontailPort
             )
             Log.d(TAG, "load: ${config.toRedactedString()}")
             return config

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/FrontailWebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/FrontailWebViewFragment.kt
@@ -13,9 +13,12 @@
 
 package org.openhab.habdroid.ui.activity
 
+import android.util.Log
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.openhab.habdroid.R
 import org.openhab.habdroid.ui.MainActivity
+import org.openhab.habdroid.util.loadActiveServerConfig
 
 class FrontailWebViewFragment : AbstractWebViewFragment() {
     override val titleRes = R.string.mainmenu_openhab_frontail
@@ -28,9 +31,22 @@ class FrontailWebViewFragment : AbstractWebViewFragment() {
     override val shortcutAction = MainActivity.ACTION_FRONTAIL_SELECTED
 
     override fun modifyUrl(orig: HttpUrl): HttpUrl {
-        return orig.newBuilder()
-            .scheme("http")
-            .port(9001)
-            .build()
+        val frontailUrl = context?.loadActiveServerConfig()?.frontailUrl?.toHttpUrlOrNull()
+
+        val builder = orig.newBuilder()
+            .scheme(frontailUrl?.scheme ?: "http")
+            .port(frontailUrl?.port ?: 9001)
+
+        if (frontailUrl != null) {
+            builder.host(frontailUrl.host)
+        }
+
+        return builder.build().also {
+            Log.d(TAG, "Use url '$it'")
+        }
+    }
+
+    companion object {
+        private val TAG = FrontailWebViewFragment::class.java.simpleName
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/fragments/MainSettingsFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/fragments/MainSettingsFragment.kt
@@ -141,7 +141,7 @@ class MainSettingsFragment : AbstractSettingsFragment(), ConnectionFactory.Updat
                 getString(R.string.settings_server_default_name, nextServerId)
             }
             val f = ServerEditorFragment.newInstance(
-                ServerConfiguration(nextServerId, nextName, null, null, null, null, null, false)
+                ServerConfiguration(nextServerId, nextName, null, null, null, null, null, false, null)
             )
             parentActivity.openSubScreen(f)
             true

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/fragments/ServerEditorFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/fragments/ServerEditorFragment.kt
@@ -166,7 +166,8 @@ class ServerEditorFragment :
                 config.sslClientCert,
                 config.defaultSitemap,
                 config.wifiSsids,
-                config.restrictToWifiSsids
+                config.restrictToWifiSsids,
+                config.frontailUrl
             )
             parentActivity.invalidateOptionsMenu()
             true
@@ -212,7 +213,8 @@ class ServerEditorFragment :
                 newValue as String?,
                 config.defaultSitemap,
                 config.wifiSsids,
-                config.restrictToWifiSsids
+                config.restrictToWifiSsids,
+                config.frontailUrl
             )
             true
         }
@@ -272,10 +274,35 @@ class ServerEditorFragment :
                     config.sslClientCert,
                     config.defaultSitemap,
                     ssids,
-                    restrictToSsids
+                    restrictToSsids,
+                    config.frontailUrl
                 )
                 true
             }
+        }
+
+        val frontailUrlPref = getPreference("frontail_url") as EditTextPreference
+        val summaryGenerator = { value: String? ->
+            val actualValue = if (!value.isNullOrEmpty()) value else getString(R.string.info_not_set)
+            getString(R.string.frontail_url_summary, actualValue)
+        }
+        frontailUrlPref.summary = summaryGenerator(config.frontailUrl)
+        frontailUrlPref.text = config.frontailUrl
+        frontailUrlPref.setOnPreferenceChangeListener { _, newValue ->
+            val newUrl = newValue as String?
+            frontailUrlPref.summary = summaryGenerator(newUrl)
+            config = ServerConfiguration(
+                config.id,
+                config.name,
+                config.localPath,
+                config.remotePath,
+                config.sslClientCert,
+                config.defaultSitemap,
+                config.wifiSsids,
+                config.restrictToWifiSsids,
+                newUrl
+            )
+            true
         }
 
         val advancedPrefs = getPreference("advanced_prefs")
@@ -283,6 +310,7 @@ class ServerEditorFragment :
             advancedPrefs.isVisible = false
             clientCertPref.isVisible = true
             wifiSsidPref.isVisible = true
+            frontailUrlPref.isVisible = true
             false
         }
     }
@@ -311,7 +339,8 @@ class ServerEditorFragment :
                 config.sslClientCert,
                 config.defaultSitemap,
                 config.wifiSsids,
-                config.restrictToWifiSsids
+                config.restrictToWifiSsids,
+                config.frontailUrl
             )
         } else {
             ServerConfiguration(
@@ -322,7 +351,8 @@ class ServerEditorFragment :
                 config.sslClientCert,
                 config.defaultSitemap,
                 config.wifiSsids,
-                config.restrictToWifiSsids
+                config.restrictToWifiSsids,
+                config.frontailUrl
             )
         }
         parentActivity.invalidateOptionsMenu()

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -488,6 +488,11 @@ fun Context.getIconFallbackColor(iconBackground: IconBackground) = when (iconBac
     IconBackground.DARK -> ContextCompat.getColor(this, R.color.on_background_default_theme_dark)
 }
 
+fun Context.loadActiveServerConfig(): ServerConfiguration? {
+    val activeServerId = getPrefs().getActiveServerId()
+    return ServerConfiguration.load(getPrefs(), getSecretPrefs(), activeServerId)
+}
+
 fun Activity.shouldUseDynamicColors(): Boolean {
     val colorScheme = getPrefs().getStringOrEmpty(PrefKeys.COLOR_SCHEME)
     return DynamicColors.isDynamicColorAvailable() && colorScheme == getString(R.string.color_scheme_value_dynamic)
@@ -569,7 +574,8 @@ fun ServiceInfo.addToPrefs(context: Context) {
         null,
         null,
         null,
-        false
+        false,
+        null
     )
     config.saveToPrefs(context.getPrefs(), context.getSecretPrefs())
 }

--- a/mobile/src/main/java/org/openhab/habdroid/util/PrefKeys.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/PrefKeys.kt
@@ -34,6 +34,7 @@ object PrefKeys {
     const val DEFAULT_SITEMAP_LABEL_PREFIX = "default_sitemap_label_"
     const val WIFI_SSID_PREFIX = "wifi_ssid_"
     const val RESTRICT_TO_SSID_PREFIX = "restrict_to_ssid_"
+    const val FRONTAIL_URL_PREFIX = "frontail_url_"
     const val CLEAR_DEFAULT_SITEMAP = "clear_default_sitemap"
     fun buildServerKey(id: Int, prefix: String) = "$prefix$id"
 

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -26,7 +26,6 @@
     <string name="habpanel_error">An error occurred while loading HABPanel</string>
     <string name="oh3_ui_error">An error occurred while loading Main UI</string>
     <string name="frontail_error">An error occurred while loading Frontail. Please note that it\'s not available via openHAB Cloud.</string>
-    <string name="frontail_pref_summary">Frontail must run on its default port 9001. It\'s bundled with openHABian or can be installed manually.</string>
     <string name="mainmenu_openhab_selectsitemap">Select default Sitemap</string>
     <string name="mainmenu_openhab_clearcache">Clear images cache</string>
 
@@ -48,6 +47,8 @@
     <string name="settings_openhab_sslclientcert_howto_summary">Tap here to get some hints and explanations on how to set up SSL client certificate authentication</string>
     <string name="settings_openhab_sslclientcert_howto_url" translatable="false">https://community.openhab.org/t/using-nginx-reverse-proxy-for-client-certificate-authentication-start-discussion/43064</string>
     <string name="settings_openhab_sslclientcert_not_supported">SSL client certificates are not supported by your device</string>
+    <string name="frontail_url_title">Frontail URL</string>
+    <string name="frontail_url_summary">The URL of Frontail. It\'s bundled with openHABian or can be installed manually. Leave empty to use the default settings. Current setting: %s</string>
     <string name="settings_openhab_screentimeroff">Disable screen timeout</string>
     <string name="settings_openhab_screentimeroff_summary">The screen doesn\'t turn off when openHAB is running</string>
     <string name="settings_openhab_demomode">Demo mode</string>

--- a/mobile/src/main/res/xml/preferences_drawer_entries.xml
+++ b/mobile/src/main/res/xml/preferences_drawer_entries.xml
@@ -21,7 +21,6 @@
         android:defaultValue="false"
         android:key="show_frontail"
         android:icon="@drawable/ic_outline_format_align_left_grey_24dp"
-        app:summary="@string/frontail_pref_summary"
         android:title="@string/mainmenu_openhab_frontail" />
     <SwitchPreferenceCompat
         android:defaultValue="true"

--- a/mobile/src/main/res/xml/preferences_server.xml
+++ b/mobile/src/main/res/xml/preferences_server.xml
@@ -44,4 +44,11 @@
         app:whitespaceBehavior="trim"
         android:inputType="text"
         android:title="@string/settings_wifi_ssid" />
+    <org.openhab.habdroid.ui.preference.widgets.UrlInputPreference
+        android:key="frontail_url"
+        android:defaultValue="@string/empty_string"
+        android:persistent="false"
+        app:isPreferenceVisible="false"
+        android:title="@string/frontail_url_title"
+        app:isForRemoteServer="false" />
 </PreferenceScreen>


### PR DESCRIPTION
I implemented it this way so users can not only change port, but also scheme and/or host. It also allows us to re-use existing code, e.g. UrlInputPreference.

Closes #3260