### PR TITLE
support for Input widget

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
-  </component>
-</project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="11" />
+  </component>
+</project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/render.experimental.xml
+++ b/.idea/render.experimental.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="RenderSettings">
-    <option name="showDecorations" value="true" />
-  </component>
-</project>

--- a/.idea/render.experimental.xml
+++ b/.idea/render.experimental.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RenderSettings">
+    <option name="showDecorations" value="true" />
+  </component>
+</project>

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -97,6 +97,7 @@ android {
         }
     }
     compileOptions {
+        coreLibraryDesugaringEnabled true
         targetCompatibility 1.8
         sourceCompatibility 1.8
     }
@@ -136,6 +137,7 @@ repositories {
 }
 
 dependencies {
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.0.3"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-jdk9:$kotlin_coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"

--- a/mobile/src/foss/java/org/openhab/habdroid/ui/MapViewHelper.kt
+++ b/mobile/src/foss/java/org/openhab/habdroid/ui/MapViewHelper.kt
@@ -104,7 +104,7 @@ object MapViewHelper {
 
         override fun openPopup() {
             val widget = boundWidget ?: return
-            bottomSheetPresenter.showBottomSheet(MapBottomSheet(), widget)
+            fragmentPresenter.showBottomSheet(MapBottomSheet(), widget)
         }
     }
 }

--- a/mobile/src/full/java/org/openhab/habdroid/ui/MapViewHelper.kt
+++ b/mobile/src/full/java/org/openhab/habdroid/ui/MapViewHelper.kt
@@ -13,7 +13,6 @@
 
 package org.openhab.habdroid.ui
 
-import android.content.DialogInterface
 import android.location.Location
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -80,7 +79,7 @@ object MapViewHelper {
 
         override fun openPopup() {
             val widget = boundWidget ?: return
-            bottomSheetPresenter.showBottomSheet(MapBottomSheet(), widget)
+            fragmentPresenter.showBottomSheet(MapBottomSheet(), widget)
         }
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
@@ -316,7 +316,7 @@ fun JSONObject.toItem(): Item {
         emptyList()
     }
 
-    val numberPattern = stateDescription?.optString("pattern")?.let { pattern ->
+    val formatPattern = stateDescription?.optString("pattern")?.let { pattern ->
         // Remove transformation instructions (e.g. for 'MAP(foo.map):%s' keep only '%s')
         val matchResult = """^[A-Z]+(\(.*\))?:(.*)$""".toRegex().find(pattern)
         if (matchResult != null) {
@@ -348,7 +348,7 @@ fun JSONObject.toItem(): Item {
         readOnly = readOnly,
         members = members,
         options = if (options.isNullOrEmpty()) null else options,
-        state = state.toParsedState(numberPattern),
+        state = state.toParsedState(formatPattern),
         tags = tags,
         groupNames = groupNames,
         minimum = stateDescription?.optFloatOrNull("minimum"),

--- a/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.kt
@@ -251,6 +251,10 @@ fun ParsedState.NumberState?.withValue(value: Float): ParsedState.NumberState {
     return ParsedState.NumberState(value, this?.unit, this?.format)
 }
 
+fun ParsedState.DateTimeState?.withValue(value: LocalDateTime): ParsedState.DateTimeState {
+    return ParsedState.DateTimeState(value, this?.format)
+}
+
 /**
  * Parses a state string into the parsed representation.
  *

--- a/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.kt
@@ -20,6 +20,7 @@ import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
+import java.time.format.FormatStyle
 import java.util.IllegalFormatException
 import java.util.Locale
 import java.util.regex.Pattern
@@ -233,12 +234,16 @@ data class ParsedState internal constructor(
             return value.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
         }
 
-        fun toISOLocalDate(): String {
-            return value.format(DateTimeFormatter.ISO_LOCAL_DATE)
+        fun toLocalDate(): String {
+            return value.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT))
         }
 
-        fun toISOLocalTime(): String {
-            return value.format(DateTimeFormatter.ISO_LOCAL_TIME)
+        fun toLocalTime(): String {
+            return value.format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT))
+        }
+
+        fun toLocalDateTime(): String {
+            return value.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT))
         }
 
         fun getActualValue(): LocalDateTime {

--- a/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.kt
@@ -144,20 +144,20 @@ data class ParsedState internal constructor(
 
         private val HSB_PATTERN = Pattern.compile("^([0-9]*\\.?[0-9]+),([0-9]*\\.?[0-9]+),([0-9]*\\.?[0-9]+)$")
 
-        internal fun parseAsDateTime(state: String, format: String?) : DateTimeState? {
+        internal fun parseAsDateTime(state: String, format: String?): DateTimeState? {
             return try {
                 var st = state.trim().split(".")[0]
                 val formatter = if (format != null) {
                     DateTimeFormatter.ofPattern(format)
                 } else {
-                    st = st.replace(" ","T")
-                     if (TIME_PATTERN.matcher(st).find()) {
-                         val refDate = LocalDateTime
-                             .ofEpochSecond(0, 0, ZoneOffset.UTC)
-                             .format(DateTimeFormatter.ISO_LOCAL_DATE)
-                         st = "${refDate}T${st}"
+                    st = st.replace(" ", "T")
+                    if (TIME_PATTERN.matcher(st).find()) {
+                        val refDate = LocalDateTime
+                            .ofEpochSecond(0, 0, ZoneOffset.UTC)
+                            .format(DateTimeFormatter.ISO_LOCAL_DATE)
+                        st = "${refDate}T$st"
                     }
-                    if (!st.contains("T"))  st = "${st}T00:00:00"
+                    if (!st.contains("T")) st = "${st}T00:00:00"
                     DateTimeFormatter.ISO_LOCAL_DATE_TIME
                 }
                 val dt = LocalDateTime.parse(st, formatter)
@@ -267,5 +267,6 @@ fun String?.toParsedState(formatPattern: String? = null): ParsedState? {
         ParsedState.parseAsHsv(this),
         ParsedState.parseAsBrightness(this),
         ParsedState.parseAsLocation(this),
-        ParsedState.parseAsDateTime(this, formatPattern))
+        ParsedState.parseAsDateTime(this, formatPattern)
+    )
 }

--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -191,18 +191,14 @@ data class Widget(
         internal fun sanitizeRefreshRate(refresh: Int) = if (refresh in 1..99) 100 else refresh
         internal fun sanitizePeriod(period: String?) = if (period.isNullOrEmpty()) "D" else period
 
-        internal fun determineWidgetState(state: String?, item: Item?): ParsedState? {
-            val parsedState = if (state != null) {
-                if (item?.isOfTypeOrGroupType(Item.Type.DateTime) == true) {
-                    state.toParsedState(item.state?.asDateTime?.format)
-                } else if (
-                    (item?.isOfTypeOrGroupType(Item.Type.Number) == true) or
-                    (item?.isOfTypeOrGroupType(Item.Type.NumberWithDimension) == true)
-                ) {
-                    state.toParsedState(item?.state?.asNumber?.format)
-                } else state.toParsedState()
-            } else item?.state
-            return parsedState
+        internal fun determineWidgetState(state: String?, item: Item?): ParsedState? = when {
+            state == null -> item?.state
+            item?.isOfTypeOrGroupType(Item.Type.DateTime) == true ->
+                state.toParsedState(item.state?.asDateTime?.format)
+            item?.isOfTypeOrGroupType(Item.Type.Number) == true ||
+                item?.isOfTypeOrGroupType(Item.Type.NumberWithDimension) == true ->
+                state.toParsedState(item.state?.asNumber?.format)
+            else -> state.toParsedState()
         }
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -61,7 +61,7 @@ data class Widget(
     val switchSupport: Boolean,
     val height: Int,
     val visibility: Boolean,
-    val inputHint: Hint?
+    val inputHint: InputTypeHint?
 ) : Parcelable {
     val label get() = rawLabel.split("[", "]")[0].trim()
     val stateFromLabel: String? get() = rawLabel.split("[", "]").getOrNull(1)?.trim()
@@ -108,7 +108,7 @@ data class Widget(
         Unknown
     }
 
-    enum class Hint {
+    enum class InputTypeHint {
         Text,
         Number,
         Date,
@@ -218,10 +218,10 @@ fun String?.toWidgetType(): Widget.Type {
     return Widget.Type.Unknown
 }
 
-fun String?.toInputHint(): Widget.Hint? {
+fun String?.toInputHint(): Widget.InputTypeHint? {
     if (this != null) {
         try {
-            return Widget.Hint.valueOf(this.toString().lowercase().replaceFirstChar { c -> c.uppercase() })
+            return Widget.InputTypeHint.valueOf(this.toString().lowercase().replaceFirstChar { c -> c.uppercase() })
         } catch (e: IllegalArgumentException) {
             // fall through
         }

--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -203,8 +203,6 @@ data class Widget(
 
         internal fun determineWidgetState(state: String?, item: Item?): ParsedState? = when {
             state == null -> item?.state
-            item?.isOfTypeOrGroupType(Item.Type.DateTime) == true ->
-                state.toParsedState(item.state?.asDateTime?.format)
             item?.isOfTypeOrGroupType(Item.Type.Number) == true ||
                 item?.isOfTypeOrGroupType(Item.Type.NumberWithDimension) == true ->
                 state.toParsedState(item.state?.asNumber?.format)

--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -187,12 +187,14 @@ data class Widget(
             val parsedState = if (state != null) {
                 if (item?.isOfTypeOrGroupType(Item.Type.DateTime) == true) {
                     state.toParsedState(item.state?.asDateTime?.format)
-                } else if ((item?.isOfTypeOrGroupType(Item.Type.Number) == true) or
-                    (item?.isOfTypeOrGroupType(Item.Type.NumberWithDimension) == true)) {
+                } else if (
+                    (item?.isOfTypeOrGroupType(Item.Type.Number) == true) or
+                    (item?.isOfTypeOrGroupType(Item.Type.NumberWithDimension) == true)
+                ) {
                     state.toParsedState(item?.state?.asNumber?.format)
                 } else state.toParsedState()
             } else item?.state
-            return  parsedState
+            return parsedState
         }
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -61,7 +61,7 @@ data class Widget(
     val switchSupport: Boolean,
     val height: Int,
     val visibility: Boolean,
-    val rawInputHint: String?
+    val rawInputHint: InputTypeHint?
 ) : Parcelable {
     val label get() = rawLabel.split("[", "]")[0].trim()
     val stateFromLabel: String? get() = rawLabel.split("[", "]").getOrNull(1)?.trim()
@@ -74,11 +74,7 @@ data class Widget(
 
     val inputHint: InputTypeHint get() {
         if (rawInputHint != null) {
-            try {
-                return InputTypeHint.valueOf(rawInputHint.lowercase().replaceFirstChar { c -> c.uppercase() })
-            } catch (e: IllegalArgumentException) {
-                // fall through
-            }
+            return rawInputHint
         }
         if (item?.isOfTypeOrGroupType(Item.Type.DateTime) == true) {
             return InputTypeHint.Datetime
@@ -228,6 +224,13 @@ fun String?.toWidgetType(): Widget.Type {
     return Widget.Type.Unknown
 }
 
+fun String?.toInputHint(): Widget.InputTypeHint? = this?.let { value ->
+    try {
+        return Widget.InputTypeHint.valueOf(value.lowercase().replaceFirstChar { c -> c.uppercase() })
+    } catch (e: IllegalArgumentException) {
+        return null
+    }
+}
 fun Node.collectWidgets(parent: Widget?): List<Widget> {
     var item: Item? = null
     var linkedPage: LinkedPage? = null
@@ -362,7 +365,7 @@ fun JSONObject.collectWidgets(parent: Widget?): List<Widget> {
         yAxisDecimalPattern = optString("yAxisDecimalPattern"),
         switchSupport = optBoolean("switchSupport", false),
         height = optInt("height"),
-        rawInputHint = optStringOrNull("inputHint"),
+        rawInputHint = optStringOrNull("inputHint").toInputHint(),
         visibility = optBoolean("visibility", true)
     )
 

--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -214,13 +214,15 @@ fun String?.toWidgetType(): Widget.Type {
     return Widget.Type.Unknown
 }
 
-fun String?.toInputHint(): Widget.InputTypeHint {
+fun String?.toInputHint(item: Item?): Widget.InputTypeHint {
     if (this != null) {
         try {
             return Widget.InputTypeHint.valueOf(this.toString().lowercase().replaceFirstChar { c -> c.uppercase() })
         } catch (e: IllegalArgumentException) {
             // fall through
         }
+    } else {
+        if (item?.isOfTypeOrGroupType(Item.Type.DateTime) == true) return Widget.InputTypeHint.Datetime
     }
     return Widget.InputTypeHint.Text
 }
@@ -332,7 +334,7 @@ fun JSONObject.collectWidgets(parent: Widget?): List<Widget> {
     val item = optJSONObject("item")?.toItem()
     val type = getString("type").toWidgetType()
     val icon = optStringOrNull("icon")
-    val inputHint = optStringOrNull("inputHint").toInputHint()
+    val inputHint = optStringOrNull("inputHint").toInputHint(item)
 
     val widget = Widget(
         id = getString("widgetId"),

--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -214,7 +214,7 @@ fun String?.toWidgetType(): Widget.Type {
     return Widget.Type.Unknown
 }
 
-fun String?.toInputHint(): Widget.InputTypeHint? {
+fun String?.toInputHint(): Widget.InputTypeHint {
     if (this != null) {
         try {
             return Widget.InputTypeHint.valueOf(this.toString().lowercase().replaceFirstChar { c -> c.uppercase() })
@@ -222,7 +222,7 @@ fun String?.toInputHint(): Widget.InputTypeHint? {
             // fall through
         }
     }
-    return null
+    return Widget.InputTypeHint.Text
 }
 
 fun Node.collectWidgets(parent: Widget?): List<Widget> {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ViewExtensions.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ViewExtensions.kt
@@ -14,12 +14,15 @@
 package org.openhab.habdroid.ui
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.os.Build
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import android.webkit.WebChromeClient
 import android.webkit.WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
 import android.webkit.WebView
 import android.webkit.WebViewDatabase
+import android.widget.EditText
 import android.widget.ImageView
 import android.widget.RemoteViews
 import androidx.appcompat.widget.TooltipCompat
@@ -81,6 +84,15 @@ fun ImageView.setupHelpIcon(url: String, contentDescriptionRes: Int) {
 
 fun ImageView.updateHelpIconAlpha(isEnabled: Boolean) {
     alpha = if (isEnabled) 1.0f else 0.5f
+}
+
+fun EditText.setKeyboardVisible(visible: Boolean) {
+    val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+    if (visible) {
+        imm.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
+    } else {
+        imm.hideSoftInputFromWindow(windowToken, 0)
+    }
 }
 
 fun View.playPressAnimationAndCallBack(postAnimationCallback: () -> Unit) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -689,14 +689,11 @@ class WidgetAdapter(
         override fun handleRowClick() {
             val widget = boundWidget ?: return
             val dt = widget.state?.asDateTime?.getActualValue() ?: LocalDateTime.now()
-            if (widget.inputHint == Widget.InputTypeHint.Date) {
-                showDatePicker(dt, widget, false)
-            } else if (widget.inputHint == Widget.InputTypeHint.Datetime) {
-                showDatePicker(dt, widget, true)
-            } else if (widget.inputHint == Widget.InputTypeHint.Time) {
-                showTimePicker(dt, widget, false)
-            } else {
-                inputText.requestFocus()
+            when (widget.inputHint) {
+                Widget.InputTypeHint.Date -> showDatePicker(dt, widget, false)
+                Widget.InputTypeHint.Datetime -> showDatePicker(dt, widget, true)
+                Widget.InputTypeHint.Time -> showTimePicker(dt, widget, false)
+                else -> inputText.requestFocus()
             }
         }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -664,6 +664,7 @@ class WidgetAdapter(
                 else -> widget.state.asString
             }
             inputText.setText(dataState)
+            inputText.text?.let { inputText.setSelection(it.length) }
             oldValue = dataState
 
             inputTextLayout.suffixText = when (widget.inputHint) {
@@ -678,6 +679,7 @@ class WidgetAdapter(
 
         override fun handleRowClick() {
             inputText.requestFocus()
+            inputText.setSelection(inputText.length())
         }
 
         private fun updateValue() {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -243,7 +243,15 @@ class WidgetAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val wasStarted = holder.stop()
-        holder.vhc = ViewHolderContext(connection, bottomSheetPresenter, datePickerPresenter, timePickerPresenter, colorMapper, serverFlags, chartTheme)
+        holder.vhc = ViewHolderContext(
+            connection,
+            bottomSheetPresenter,
+            datePickerPresenter,
+            timePickerPresenter,
+            colorMapper,
+            serverFlags,
+            chartTheme
+        )
         holder.bind(items[position])
         if (holder is FrameViewHolder) {
             holder.setShownAsFirst(position == firstVisibleWidgetPosition)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -598,13 +598,13 @@ class WidgetAdapter(
 
         init {
             inputText.doAfterTextChanged { if (!isBinding) hasChanged = true }
-            inputText.setOnFocusChangeListener { view, hasFocus ->
+            inputText.setOnFocusChangeListener { _, hasFocus ->
                 inputText.setKeyboardVisible(hasFocus)
                 if (!hasFocus && hasChanged) {
                     inputText.setText(oldValue)
                 }
             }
-            inputText.setOnEditorActionListener { view, action, _ ->
+            inputText.setOnEditorActionListener { _, action, _ ->
                 if (action == EditorInfo.IME_ACTION_DONE) {
                     inputText.setKeyboardVisible(false)
                     if (hasChanged) {
@@ -695,10 +695,15 @@ class WidgetAdapter(
             val displayState = widget.stateFromLabel?.replace("\n", "")
             val dateTimeState = widget.state?.asDateTime
 
-            valueView?.text = if (displayState.isNullOrEmpty()) {
-                dateTimeState?.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT))
-            } else {
-                displayState
+            valueView?.text = when {
+                !displayState.isNullOrEmpty() -> displayState
+                widget.inputHint == Widget.InputTypeHint.Date ->
+                    dateTimeState?.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT))
+                widget.inputHint == Widget.InputTypeHint.Time ->
+                    dateTimeState?.format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT))
+                widget.inputHint == Widget.InputTypeHint.Datetime ->
+                    dateTimeState?.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT))
+                else -> dateTimeState?.toString()
             }
             valueView?.isVisible = !valueView?.text.isNullOrEmpty()
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -614,7 +614,7 @@ class WidgetAdapter(
                 }
             }
             inputText.setOnClickListener {
-                val widget = boundWidget ?: return
+                val widget = boundWidget ?: return@setOnClickListener
                 val dt = widget.state?.asDateTime?.getActualValue() ?: LocalDateTime.now()
                 if (widget.inputHint == Widget.InputTypeHint.Date) {
                     showDatePicker(dt, widget, false)
@@ -671,12 +671,14 @@ class WidgetAdapter(
             }
 
             // Don't directly edit field for date/time when inputHint set, but open popup when clicked
-            val isEditable =
-                widget.inputHint == Widget.InputTypeHint.Text ||
-                widget.inputHint == Widget.InputTypeHint.Number
+            val isEditable = !(
+                widget.inputHint == Widget.InputTypeHint.Date ||
+                widget.inputHint == Widget.InputTypeHint.Time ||
+                widget.inputHint == Widget.InputTypeHint.Datetime
+            )
             inputText.isCursorVisible = isEditable
             inputText.isFocusable = isEditable
-            inputText.isClickable = !isEditable
+            inputText.isClickable = isEditable
 
             inputText.applyWidgetColor(widget.valueColor, colorMapper)
             inputTextLayout.suffixTextView.applyWidgetColor(widget.valueColor, colorMapper)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -613,6 +613,17 @@ class WidgetAdapter(
                     updateValue()
                 }
             }
+            inputText.setOnClickListener {
+                val widget = boundWidget ?: return
+                val dt = widget.state?.asDateTime?.getActualValue() ?: LocalDateTime.now()
+                if (widget.inputHint == Widget.InputTypeHint.Date) {
+                    showDatePicker(dt, widget, false)
+                } else if (widget.inputHint == Widget.InputTypeHint.Datetime) {
+                    showDatePicker(dt, widget, true)
+                } else if (widget.inputHint == Widget.InputTypeHint.Time) {
+                    showTimePicker(dt, widget, false)
+                }
+            }
         }
 
         override fun bind(widget: Widget) {
@@ -660,26 +671,12 @@ class WidgetAdapter(
             }
 
             // Don't directly edit field for date/time when inputHint set, but open popup when clicked
-            if (
-                widget.inputHint == Widget.InputTypeHint.Date ||
-                widget.inputHint == Widget.InputTypeHint.Time ||
-                widget.inputHint == Widget.InputTypeHint.Datetime
-            ) {
-                inputText.isClickable = false
-                inputText.isCursorVisible = false
-                inputText.isFocusable = false
-
-                val dt = widget.state?.asDateTime?.getActualValue() ?: LocalDateTime.now()
-                inputText.setOnClickListener {
-                    if (widget.inputHint == Widget.InputTypeHint.Date) {
-                        showDatePicker(dt, widget, false)
-                    } else if (widget.inputHint == Widget.InputTypeHint.Datetime) {
-                        showDatePicker(dt, widget, true)
-                    } else if (widget.inputHint == Widget.InputTypeHint.Time) {
-                        showTimePicker(dt, widget, false)
-                    }
-                }
-            }
+            val isEditable =
+                widget.inputHint == Widget.InputTypeHint.Text ||
+                widget.inputHint == Widget.InputTypeHint.Number
+            inputText.isCursorVisible = isEditable
+            inputText.isFocusable = isEditable
+            inputText.isClickable = !isEditable
 
             inputText.applyWidgetColor(widget.valueColor, colorMapper)
             inputTextLayout.suffixTextView.applyWidgetColor(widget.valueColor, colorMapper)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -636,29 +636,32 @@ class WidgetAdapter(
             val item = widget.item
 
             inputText.inputType = when (widget.inputHint) {
-                "number" -> (TYPE_CLASS_NUMBER or TYPE_NUMBER_FLAG_DECIMAL or TYPE_NUMBER_FLAG_SIGNED)
-                "date" -> (TYPE_CLASS_DATETIME or TYPE_DATETIME_VARIATION_DATE)
-                "time" -> (TYPE_CLASS_DATETIME or TYPE_DATETIME_VARIATION_TIME)
-                "datetime" -> (TYPE_CLASS_DATETIME or TYPE_DATETIME_VARIATION_NORMAL)
+                Widget.Hint.Number -> (TYPE_CLASS_NUMBER or TYPE_NUMBER_FLAG_DECIMAL or TYPE_NUMBER_FLAG_SIGNED)
+                Widget.Hint.Date -> (TYPE_CLASS_DATETIME or TYPE_DATETIME_VARIATION_DATE)
+                Widget.Hint.Time -> (TYPE_CLASS_DATETIME or TYPE_DATETIME_VARIATION_TIME)
+                Widget.Hint.Datetime -> (TYPE_CLASS_DATETIME or TYPE_DATETIME_VARIATION_NORMAL)
                 else -> TYPE_CLASS_TEXT
             }
 
             val displayState = widget.stateFromLabel?.replace("\n", "") ?: ""
 
             inputTextLayout.placeholderText = if (widget.state == null) {
-                if ((widget.inputHint == "text") && (item?.isOfTypeOrGroupType(Item.Type.DateTime) == true)) {
+                if (
+                    (widget.inputHint == Widget.Hint.Text) and
+                    (item?.isOfTypeOrGroupType(Item.Type.DateTime) == true)
+                ) {
                     "YYYY-MM-DD hh:mm:ss"
                 } else displayState
             } else ""
 
             val dataState = if (widget.state != null) {
-                if (widget.inputHint == "number")
+                if (widget.inputHint == Widget.Hint.Number)
                     widget.state.asNumber?.formatValue()
                 else if (displayState.isNotEmpty()) displayState
                 else if (widget.item?.isOfTypeOrGroupType(Item.Type.DateTime) == true)
                     when (widget.inputHint) {
-                        "date" -> widget.state.asDateTime?.toISOLocalDate()
-                        "time" -> widget.state.asDateTime?.toISOLocalTime()
+                        Widget.Hint.Date -> widget.state.asDateTime?.toISOLocalDate()
+                        Widget.Hint.Time -> widget.state.asDateTime?.toISOLocalTime()
                         else -> widget.state.asDateTime?.toString()
                     }
                 else widget.state.toString()
@@ -666,20 +669,28 @@ class WidgetAdapter(
             inputText.setText(dataState)
             oldValue = dataState
 
-            inputTextLayout.suffixText = if (widget.inputHint == "number") widget.state?.asNumber?.unit else null
+            inputTextLayout.suffixText = if (widget.inputHint == Widget.Hint.Number) {
+                widget.state?.asNumber?.unit
+            } else null
 
             // Don't directly edit field for date/time when inputHint set, but open popup when clicked
-            if ((widget.inputHint == "date") or (widget.inputHint == "time") or (widget.inputHint == "datetime")) {
+            if (
+                (widget.inputHint == Widget.Hint.Date) or
+                (widget.inputHint == Widget.Hint.Time) or
+                (widget.inputHint == Widget.Hint.Datetime)
+            ) {
                 inputText.isClickable = false
                 inputText.isCursorVisible = false
                 inputText.isFocusable = false
 
                 val dt = widget.state?.asDateTime?.getActualValue() ?: LocalDateTime.now()
                 inputText.setOnClickListener {
-                    when (widget.inputHint) {
-                        "date" -> showDatePicker(dt, widget, false)
-                        "datetime" -> showDatePicker(dt, widget, true)
-                        "time" -> showTimePicker(dt, widget, false)
+                    if (widget.inputHint == Widget.Hint.Date) {
+                        showDatePicker(dt, widget, false)
+                    } else if (widget.inputHint == Widget.Hint.Datetime) {
+                        showDatePicker(dt, widget, true)
+                    } else if (widget.inputHint == Widget.Hint.Time) {
+                        showTimePicker(dt, widget, false)
                     }
                 }
             }
@@ -727,8 +738,8 @@ class WidgetAdapter(
         private fun dateTimeUpdater(dateTime: LocalDateTime, widget: Widget) {
             inputText.setText(
                 when (widget.inputHint) {
-                    "date" -> widget.state?.asDateTime?.toISOLocalDate()
-                    "time" -> widget.state?.asDateTime?.toISOLocalTime()
+                    Widget.Hint.Date -> widget.state?.asDateTime?.toISOLocalDate()
+                    Widget.Hint.Time -> widget.state?.asDateTime?.toISOLocalTime()
                     else -> widget.state?.asDateTime?.toString()
                 }
             )

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -655,8 +655,9 @@ class WidgetAdapter(
                 widget.inputHint == Widget.InputTypeHint.Number -> widget.state.asNumber?.formatValue()
                 displayState.isNotEmpty() -> displayState
                 widget.item?.isOfTypeOrGroupType(Item.Type.DateTime) == true -> when (widget.inputHint) {
-                    Widget.InputTypeHint.Date -> widget.state.asDateTime?.toISOLocalDate()
-                    Widget.InputTypeHint.Time -> widget.state.asDateTime?.toISOLocalTime()
+                    Widget.InputTypeHint.Date -> widget.state.asDateTime?.toLocalDate()
+                    Widget.InputTypeHint.Time -> widget.state.asDateTime?.toLocalTime()
+                    Widget.InputTypeHint.Datetime -> widget.state.asDateTime?.toLocalDateTime()
                     else -> widget.state.asDateTime?.toString()
                 }
                 else -> widget.state.toString()
@@ -679,7 +680,6 @@ class WidgetAdapter(
             inputText.isCursorVisible = isEditable
             inputText.isFocusable = isEditable
             inputText.isClickable = isEditable
-            if (isEditable) inputText.requestFocus()
 
             inputText.applyWidgetColor(widget.valueColor, colorMapper)
             inputTextLayout.suffixTextView.applyWidgetColor(widget.valueColor, colorMapper)
@@ -695,6 +695,8 @@ class WidgetAdapter(
                 showDatePicker(dt, widget, true)
             } else if (widget.inputHint == Widget.InputTypeHint.Time) {
                 showTimePicker(dt, widget, false)
+            } else {
+                inputText.requestFocus()
             }
         }
 
@@ -745,8 +747,8 @@ class WidgetAdapter(
             inputText.setText(
                 widget.state?.asDateTime?.withValue(dateTime)?.toString()
                     ?: when (widget.inputHint) {
-                        Widget.InputTypeHint.Date -> ParsedState.DateTimeState(dateTime).toISOLocalDate()
-                        Widget.InputTypeHint.Time -> ParsedState.DateTimeState(dateTime).toISOLocalTime()
+                        Widget.InputTypeHint.Date -> ParsedState.DateTimeState(dateTime).toLocalDate()
+                        Widget.InputTypeHint.Time -> ParsedState.DateTimeState(dateTime).toLocalTime()
                         else -> ParsedState.DateTimeState(dateTime).toString()
                     }
             )

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -615,10 +615,11 @@ class WidgetAdapter(
             inputText.setOnEditorActionListener { view, action, _ ->
                 if (action == EditorInfo.IME_ACTION_DONE) {
                     hideKeyboard(view)
+                    if (hasChanged) updateValue()
                     true
                 } else false
             }
-            inputText.setOnClickListener { handleRowClick() }
+            inputText.setOnClickListener { setFocus() }
         }
 
         private fun hideKeyboard(view: View) {
@@ -687,6 +688,11 @@ class WidgetAdapter(
         }
 
         override fun handleRowClick() {
+            setFocus()
+            inputText.setSelection(inputText.length())
+        }
+
+        private fun setFocus() {
             val widget = boundWidget ?: return
             val dt = widget.state?.asDateTime?.getActualValue() ?: LocalDateTime.now()
             when (widget.inputHint) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -744,8 +744,9 @@ class WidgetAdapter(
                     .withMinute(date.minute)
                 if (showTime) {
                     showTimePicker(widget, newDate)
+                } else {
+                    sendUpdate(widget, newDate)
                 }
-                else sendUpdate(widget, newDate)
             }
             fragmentPresenter.showSelectionFragment(datePicker, widget)
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -659,7 +659,7 @@ class WidgetAdapter(
                     Widget.InputTypeHint.Datetime -> widget.state.asDateTime?.toLocalDateTime()
                     else -> widget.state.asDateTime?.toString()
                 }
-                else -> widget.state.toString()
+                else -> widget.state.asString
             }
             inputText.setText(dataState)
             inputText.text?.let { inputText.setSelection(it.length) }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -61,8 +61,6 @@ import com.google.android.exoplayer2.upstream.DefaultHttpDataSource
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.button.MaterialButtonToggleGroup
 import com.google.android.material.datepicker.MaterialDatePicker
-import com.google.android.material.slider.LabelFormatter
-import com.google.android.material.slider.Slider
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.google.android.material.timepicker.MaterialTimePicker
@@ -743,7 +741,8 @@ class WidgetAdapter(
         }
 
         private fun showTimePicker(widget: Widget, dt: LocalDateTime?) {
-            val date = dt?.truncatedTo(ChronoUnit.MINUTES) ?: LocalDateTime.ofInstant(Instant.ofEpochMilli(0), ZoneOffset.UTC)
+            val date = dt?.truncatedTo(ChronoUnit.MINUTES) ?:
+                LocalDateTime.ofInstant(Instant.ofEpochMilli(0), ZoneOffset.UTC)
             val timePicker = MaterialTimePicker.Builder()
                 .setHour(date.hour)
                 .setMinute(date.minute)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -646,8 +646,8 @@ class WidgetAdapter(
 
             inputTextLayout.placeholderText = when {
                 widget.state != null -> ""
-                widget.inputHint == Widget.InputTypeHint.Text && item?.isOfTypeOrGroupType(Item.Type.DateTime) == true ->
-                    "YYYY-MM-DD hh:mm:ss"
+                widget.inputHint == Widget.InputTypeHint.Text &&
+                    item?.isOfTypeOrGroupType(Item.Type.DateTime) == true -> "YYYY-MM-DD hh:mm:ss"
                 else -> displayState
             }
 
@@ -671,11 +671,9 @@ class WidgetAdapter(
             }
 
             // Don't directly edit field for date/time when inputHint set, but open popup when clicked
-            val isEditable = !(
-                widget.inputHint == Widget.InputTypeHint.Date ||
+            val isEditable = !(widget.inputHint == Widget.InputTypeHint.Date ||
                 widget.inputHint == Widget.InputTypeHint.Time ||
-                widget.inputHint == Widget.InputTypeHint.Datetime
-            )
+                widget.inputHint == Widget.InputTypeHint.Datetime)
             inputText.isCursorVisible = isEditable
             inputText.isFocusable = isEditable
             inputText.isClickable = isEditable

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -672,7 +672,7 @@ class WidgetAdapter(
 
             // Don't directly edit field for date/time when inputHint set, but open popup when clicked
             val isEditable = !(
-                    widget.inputHint == Widget.InputTypeHint.Date ||
+                widget.inputHint == Widget.InputTypeHint.Date ||
                     widget.inputHint == Widget.InputTypeHint.Time ||
                     widget.inputHint == Widget.InputTypeHint.Datetime
                 )

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -648,7 +648,7 @@ class WidgetAdapter(
             inputTextLayout.placeholderText = if (widget.state == null) {
                 if ((widget.inputHint == "text") && (item?.isOfTypeOrGroupType(Item.Type.DateTime) == true)) {
                     "YYYY-MM-DD hh:mm:ss"
-                } else  displayState
+                } else displayState
             } else ""
 
             val dataState = if (widget.state != null) {
@@ -722,14 +722,16 @@ class WidgetAdapter(
                 showingDatePicker = false
                 showingTimePicker = false
             }
-         }
+        }
 
         private fun dateTimeUpdater(dateTime: LocalDateTime, widget: Widget) {
-            inputText.setText(when (widget.inputHint) {
-                "date" -> widget.state?.asDateTime?.toISOLocalDate()
-                "time" -> widget.state?.asDateTime?.toISOLocalTime()
-                else -> widget.state?.asDateTime?.toString()
-            })
+            inputText.setText(
+                when (widget.inputHint) {
+                    "date" -> widget.state?.asDateTime?.toISOLocalDate()
+                    "time" -> widget.state?.asDateTime?.toISOLocalTime()
+                    else -> widget.state?.asDateTime?.toString()
+                }
+            )
             updateValue(dateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
         }
 
@@ -746,15 +748,17 @@ class WidgetAdapter(
             }
 
             val item = boundWidget?.item
-            if ((item?.isOfTypeOrGroupType(Item.Type.Number) == true) or
-                (item?.isOfTypeOrGroupType(Item.Type.NumberWithDimension) == true)) {
+            if (
+                (item?.isOfTypeOrGroupType(Item.Type.Number) == true) or
+                (item?.isOfTypeOrGroupType(Item.Type.NumberWithDimension) == true)
+            ) {
                 val state = newValue?.let { ParsedState.parseAsNumber(it, item?.state?.asNumber?.format) }
                 connection.httpClient.sendItemUpdate(item, state)
             } else if (item?.isOfTypeOrGroupType(Item.Type.DateTime) == true) {
                 val state = newValue?.let { ParsedState.parseAsDateTime(it, item.state?.asDateTime?.format) }
                 connection.httpClient.sendItemUpdate(item, state)
             } else if (newValue != null) {
-                    connection.httpClient.sendItemCommand(item, newValue)
+                connection.httpClient.sendItemCommand(item, newValue)
             }
 
             hasChanged = false

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -714,12 +714,12 @@ class WidgetAdapter(
 
             valueView?.text = when {
                 !displayState.isNullOrEmpty() -> displayState
-                widget.inputHint == Widget.InputTypeHint.Date
-                    -> dateTimeState?.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT))
-                widget.inputHint == Widget.InputTypeHint.Time
-                    -> dateTimeState?.format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT))
-                widget.inputHint == Widget.InputTypeHint.Datetime
-                    -> dateTimeState?.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT))
+                widget.inputHint == Widget.InputTypeHint.Date ->
+                    dateTimeState?.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT))
+                widget.inputHint == Widget.InputTypeHint.Time ->
+                    dateTimeState?.format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT))
+                widget.inputHint == Widget.InputTypeHint.Datetime ->
+                    dateTimeState?.format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT))
                 else -> dateTimeState?.toString()
             }
             valueView?.isVisible = !valueView?.text.isNullOrEmpty()

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -618,6 +618,8 @@ class WidgetAdapter(
                     true
                 } else false
             }
+            // Indicate the UoM unit not being editable
+            inputTextLayout.suffixTextView.alpha = 0.5F
         }
 
         private fun hideKeyboard(view: View) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -671,9 +671,11 @@ class WidgetAdapter(
             }
 
             // Don't directly edit field for date/time when inputHint set, but open popup when clicked
-            val isEditable = !(widget.inputHint == Widget.InputTypeHint.Date ||
-                widget.inputHint == Widget.InputTypeHint.Time ||
-                widget.inputHint == Widget.InputTypeHint.Datetime)
+            val isEditable = !(
+                    widget.inputHint == Widget.InputTypeHint.Date ||
+                    widget.inputHint == Widget.InputTypeHint.Time ||
+                    widget.inputHint == Widget.InputTypeHint.Datetime
+                )
             inputText.isCursorVisible = isEditable
             inputText.isFocusable = isEditable
             inputText.isClickable = isEditable

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -664,7 +664,6 @@ class WidgetAdapter(
                 else -> widget.state.asString
             }
             inputText.setText(dataState)
-            inputText.text?.let { inputText.setSelection(it.length) }
             oldValue = dataState
 
             inputTextLayout.suffixText = when (widget.inputHint) {
@@ -679,7 +678,6 @@ class WidgetAdapter(
 
         override fun handleRowClick() {
             inputText.requestFocus()
-            inputText.setSelection(inputText.length())
         }
 
         private fun updateValue() {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -644,10 +644,10 @@ class WidgetAdapter(
             val item = widget.item
 
             inputText.inputType = when (widget.inputHint) {
-                Widget.Hint.Number -> (TYPE_CLASS_NUMBER or TYPE_NUMBER_FLAG_DECIMAL or TYPE_NUMBER_FLAG_SIGNED)
-                Widget.Hint.Date -> (TYPE_CLASS_DATETIME or TYPE_DATETIME_VARIATION_DATE)
-                Widget.Hint.Time -> (TYPE_CLASS_DATETIME or TYPE_DATETIME_VARIATION_TIME)
-                Widget.Hint.Datetime -> (TYPE_CLASS_DATETIME or TYPE_DATETIME_VARIATION_NORMAL)
+                Widget.InputTypeHint.Number -> (TYPE_CLASS_NUMBER or TYPE_NUMBER_FLAG_DECIMAL or TYPE_NUMBER_FLAG_SIGNED)
+                Widget.InputTypeHint.Date -> (TYPE_CLASS_DATETIME or TYPE_DATETIME_VARIATION_DATE)
+                Widget.InputTypeHint.Time -> (TYPE_CLASS_DATETIME or TYPE_DATETIME_VARIATION_TIME)
+                Widget.InputTypeHint.Datetime -> (TYPE_CLASS_DATETIME or TYPE_DATETIME_VARIATION_NORMAL)
                 else -> TYPE_CLASS_TEXT
             }
 
@@ -655,7 +655,7 @@ class WidgetAdapter(
 
             inputTextLayout.placeholderText = if (widget.state == null) {
                 if (
-                    (widget.inputHint == Widget.Hint.Text) and
+                    (widget.inputHint == Widget.InputTypeHint.Text) and
                     (item?.isOfTypeOrGroupType(Item.Type.DateTime) == true)
                 ) {
                     "YYYY-MM-DD hh:mm:ss"
@@ -663,13 +663,13 @@ class WidgetAdapter(
             } else ""
 
             val dataState = if (widget.state != null) {
-                if (widget.inputHint == Widget.Hint.Number)
+                if (widget.inputHint == Widget.InputTypeHint.Number)
                     widget.state.asNumber?.formatValue()
                 else if (displayState.isNotEmpty()) displayState
                 else if (widget.item?.isOfTypeOrGroupType(Item.Type.DateTime) == true)
                     when (widget.inputHint) {
-                        Widget.Hint.Date -> widget.state.asDateTime?.toISOLocalDate()
-                        Widget.Hint.Time -> widget.state.asDateTime?.toISOLocalTime()
+                        Widget.InputTypeHint.Date -> widget.state.asDateTime?.toISOLocalDate()
+                        Widget.InputTypeHint.Time -> widget.state.asDateTime?.toISOLocalTime()
                         else -> widget.state.asDateTime?.toString()
                     }
                 else widget.state.toString()
@@ -677,15 +677,15 @@ class WidgetAdapter(
             inputText.setText(dataState)
             oldValue = dataState
 
-            inputTextLayout.suffixText = if (widget.inputHint == Widget.Hint.Number) {
+            inputTextLayout.suffixText = if (widget.inputHint == Widget.InputTypeHint.Number) {
                 widget.state?.asNumber?.unit
             } else null
 
             // Don't directly edit field for date/time when inputHint set, but open popup when clicked
             if (
-                (widget.inputHint == Widget.Hint.Date) or
-                (widget.inputHint == Widget.Hint.Time) or
-                (widget.inputHint == Widget.Hint.Datetime)
+                (widget.inputHint == Widget.InputTypeHint.Date) or
+                (widget.inputHint == Widget.InputTypeHint.Time) or
+                (widget.inputHint == Widget.InputTypeHint.Datetime)
             ) {
                 inputText.isClickable = false
                 inputText.isCursorVisible = false
@@ -693,11 +693,11 @@ class WidgetAdapter(
 
                 val dt = widget.state?.asDateTime?.getActualValue() ?: LocalDateTime.now()
                 inputText.setOnClickListener {
-                    if (widget.inputHint == Widget.Hint.Date) {
+                    if (widget.inputHint == Widget.InputTypeHint.Date) {
                         showDatePicker(dt, widget, false)
-                    } else if (widget.inputHint == Widget.Hint.Datetime) {
+                    } else if (widget.inputHint == Widget.InputTypeHint.Datetime) {
                         showDatePicker(dt, widget, true)
-                    } else if (widget.inputHint == Widget.Hint.Time) {
+                    } else if (widget.inputHint == Widget.InputTypeHint.Time) {
                         showTimePicker(dt, widget, false)
                     }
                 }
@@ -746,8 +746,8 @@ class WidgetAdapter(
         private fun dateTimeUpdater(dateTime: LocalDateTime, widget: Widget) {
             inputText.setText(
                 when (widget.inputHint) {
-                    Widget.Hint.Date -> widget.state?.asDateTime?.toISOLocalDate()
-                    Widget.Hint.Time -> widget.state?.asDateTime?.toISOLocalTime()
+                    Widget.InputTypeHint.Date -> widget.state?.asDateTime?.toISOLocalDate()
+                    Widget.InputTypeHint.Time -> widget.state?.asDateTime?.toISOLocalTime()
                     else -> widget.state?.asDateTime?.toString()
                 }
             )

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -49,7 +49,11 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
+import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.timepicker.MaterialTimePicker
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -87,6 +91,8 @@ class WidgetListFragment :
     Fragment(),
     WidgetAdapter.ItemClickListener,
     WidgetAdapter.DetailBottomSheetPresenter,
+    WidgetAdapter.DatePickerPresenter,
+    WidgetAdapter.TimePickerPresenter,
     AbstractWidgetBottomSheet.ConnectionGetter,
     OpenHabApplication.OnDataUsagePolicyChangedListener,
     SharedPreferences.OnSharedPreferenceChangeListener {
@@ -130,7 +136,7 @@ class WidgetListFragment :
 
         val activity = activity as MainActivity
         adapter = activity.connection?.let { conn ->
-            WidgetAdapter(activity, activity.serverProperties!!.flags, conn, this, this)
+            WidgetAdapter(activity, activity.serverProperties!!.flags, conn, this, this, this, this)
         }
 
         layoutManager = LinearLayoutManager(activity)
@@ -216,6 +222,23 @@ class WidgetListFragment :
     override fun showBottomSheet(sheet: AbstractWidgetBottomSheet, widget: Widget) {
         sheet.arguments = AbstractWidgetBottomSheet.createArguments(widget)
         sheet.show(childFragmentManager, "${sheet.javaClass.simpleName}-${widget.id}")
+    }
+
+    override fun showDatePicker(dateTime: LocalDateTime, widget: Widget): MaterialDatePicker<Long> {
+        val dateTimeMilli = dateTime.atOffset(ZoneOffset.UTC) .toInstant().toEpochMilli()
+        val datePicker = MaterialDatePicker.Builder.datePicker().setSelection(dateTimeMilli).build()
+
+        datePicker.show(childFragmentManager, "DatePicker-${widget.id}")
+
+        return datePicker
+    }
+
+    override fun showTimePicker(dateTime: LocalDateTime, widget: Widget): MaterialTimePicker {
+        val timePicker = MaterialTimePicker.Builder().setHour(dateTime.hour).setMinute(dateTime.minute).build()
+
+        timePicker.show(childFragmentManager, "TimePicker-${widget.id}")
+
+        return timePicker
     }
 
     override fun onSharedPreferenceChanged(prefs: SharedPreferences?, key: String?) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -45,15 +45,12 @@ import androidx.core.graphics.drawable.IconCompat
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
-import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.snackbar.Snackbar
-import com.google.android.material.timepicker.MaterialTimePicker
-import java.time.LocalDateTime
-import java.time.ZoneOffset
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -90,9 +87,7 @@ import org.openhab.habdroid.util.useCompactSitemapLayout
 class WidgetListFragment :
     Fragment(),
     WidgetAdapter.ItemClickListener,
-    WidgetAdapter.DetailBottomSheetPresenter,
-    WidgetAdapter.DatePickerPresenter,
-    WidgetAdapter.TimePickerPresenter,
+    WidgetAdapter.FragmentPresenter,
     AbstractWidgetBottomSheet.ConnectionGetter,
     OpenHabApplication.OnDataUsagePolicyChangedListener,
     SharedPreferences.OnSharedPreferenceChangeListener {
@@ -136,7 +131,7 @@ class WidgetListFragment :
 
         val activity = activity as MainActivity
         adapter = activity.connection?.let { conn ->
-            WidgetAdapter(activity, activity.serverProperties!!.flags, conn, this, this, this, this)
+            WidgetAdapter(activity, activity.serverProperties!!.flags, conn, this, this)
         }
 
         layoutManager = LinearLayoutManager(activity)
@@ -224,21 +219,8 @@ class WidgetListFragment :
         sheet.show(childFragmentManager, "${sheet.javaClass.simpleName}-${widget.id}")
     }
 
-    override fun showDatePicker(dateTime: LocalDateTime, widget: Widget): MaterialDatePicker<Long> {
-        val dateTimeMilli = dateTime.atOffset(ZoneOffset.UTC).toInstant().toEpochMilli()
-        val datePicker = MaterialDatePicker.Builder.datePicker().setSelection(dateTimeMilli).build()
-
-        datePicker.show(childFragmentManager, "DatePicker-${widget.id}")
-
-        return datePicker
-    }
-
-    override fun showTimePicker(dateTime: LocalDateTime, widget: Widget): MaterialTimePicker {
-        val timePicker = MaterialTimePicker.Builder().setHour(dateTime.hour).setMinute(dateTime.minute).build()
-
-        timePicker.show(childFragmentManager, "TimePicker-${widget.id}")
-
-        return timePicker
+    override fun showSelectionFragment(fragment: DialogFragment, widget: Widget) {
+        fragment.show(childFragmentManager, "Selection-${widget.id}")
     }
 
     override fun onSharedPreferenceChanged(prefs: SharedPreferences?, key: String?) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -225,7 +225,7 @@ class WidgetListFragment :
     }
 
     override fun showDatePicker(dateTime: LocalDateTime, widget: Widget): MaterialDatePicker<Long> {
-        val dateTimeMilli = dateTime.atOffset(ZoneOffset.UTC) .toInstant().toEpochMilli()
+        val dateTimeMilli = dateTime.atOffset(ZoneOffset.UTC).toInstant().toEpochMilli()
         val datePicker = MaterialDatePicker.Builder.datePicker().setSelection(dateTimeMilli).build()
 
         datePicker.show(childFragmentManager, "DatePicker-${widget.id}")

--- a/mobile/src/main/res/drawable/ic_calendar_clock_24dp.xml
+++ b/mobile/src/main/res/drawable/ic_calendar_clock_24dp.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#fff" android:pathData="M15,13H16.5V15.82L18.94,17.23L18.19,18.53L15,16.69V13M19,8H5V19H9.67C9.24,18.09 9,17.07 9,16A7,7 0 0,1 16,9C17.07,9 18.09,9.24 19,9.67V8M5,21C3.89,21 3,20.1 3,19V5C3,3.89 3.89,3 5,3H6V1H8V3H16V1H18V3H19A2,2 0 0,1 21,5V11.1C22.24,12.36 23,14.09 23,16A7,7 0 0,1 16,23C14.09,23 12.36,22.24 11.1,21H5M16,11.15A4.85,4.85 0 0,0 11.15,16C11.15,18.68 13.32,20.85 16,20.85A4.85,4.85 0 0,0 20.85,16C20.85,13.32 18.68,11.15 16,11.15Z" />
+</vector>

--- a/mobile/src/main/res/layout/widgetlist_datetimeinputitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_datetimeinputitem.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    style="@style/WidgetListItemContainer">
+
+    <include layout="@layout/widgetlist_iconvaluetext" />
+
+    <ImageView
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_gravity="end|center_vertical"
+        android:layout_marginStart="8dp"
+        android:src="@drawable/ic_calendar_clock_24dp"
+        android:scaleType="centerInside"
+        app:tint="?attr/colorOnSurface" />
+
+</LinearLayout>

--- a/mobile/src/main/res/layout/widgetlist_datetimeinputitem_compact.xml
+++ b/mobile/src/main/res/layout/widgetlist_datetimeinputitem_compact.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    style="@style/WidgetListItemContainerCompact">
+
+    <include layout="@layout/widgetlist_iconvaluetext_compact" />
+
+    <ImageView
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_gravity="end|center_vertical"
+        android:layout_marginStart="8dp"
+        android:src="@drawable/ic_calendar_clock_24dp"
+        android:scaleType="centerInside"
+        app:tint="?attr/colorOnSurface" />
+
+</LinearLayout>

--- a/mobile/src/main/res/layout/widgetlist_icontext_compact.xml
+++ b/mobile/src/main/res/layout/widgetlist_icontext_compact.xml
@@ -8,6 +8,7 @@
         android:id="@+id/widgeticon"
         android:layout_width="@dimen/widgetlist_icon_size"
         android:layout_height="@dimen/widgetlist_icon_size"
+        android:layout_marginEnd="8dp"
         android:layout_gravity="center_vertical"
         app:imageScalingType="scaleToFit"
         tools:src="@drawable/ic_openhab_appicon_24dp" />
@@ -17,7 +18,6 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:layout_marginStart="8dp"
         android:layout_weight="1"
         android:ellipsize="end"
         android:maxLines="1"

--- a/mobile/src/main/res/layout/widgetlist_iconvaluetext_compact.xml
+++ b/mobile/src/main/res/layout/widgetlist_iconvaluetext_compact.xml
@@ -30,7 +30,6 @@
         android:id="@+id/widgetvalue"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
         android:layout_gravity="center_vertical"
         android:textDirection="anyRtl"
         android:maxLines="1"

--- a/mobile/src/main/res/layout/widgetlist_inputitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_inputitem.xml
@@ -61,8 +61,7 @@
             android:imeOptions="actionDone"
             android:layout_width="match_parent"
             android:layout_height="48dp"
-            android:gravity="end"
-            android:selectAllOnFocus="true" />
+            android:gravity="end" />
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/mobile/src/main/res/layout/widgetlist_inputitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_inputitem.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/WidgetListItemContainer"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <org.openhab.habdroid.ui.widget.WidgetImageView
+        android:id="@+id/widgeticon"
+        android:layout_width="@dimen/widgetlist_icon_size"
+        android:layout_height="@dimen/widgetlist_icon_size"
+        app:imageScalingType="scaleToFit"
+        app:layout_constraintEnd_toStartOf="@+id/widgetlabel"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:src="@drawable/ic_openhab_appicon_24dp" />
+
+    <TextView
+        android:id="@+id/widgetlabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_marginStart="16dp"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textAppearance="?attr/textAppearanceBodyLarge"
+        android:textDirection="locale"
+        app:layout_constraintStart_toEndOf="@id/widgeticon"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Widget title" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/labelbarrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="widgetlabel" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/widgetinput"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="4dp"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
+        app:hintEnabled="false"
+        app:expandedHintEnabled="false"
+        app:boxCornerRadiusTopEnd="16dp"
+        app:boxCornerRadiusTopStart="16dp"
+        app:boxCornerRadiusBottomStart="16dp"
+        app:boxCornerRadiusBottomEnd="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/widgeticon"
+        app:layout_constraintTop_toBottomOf="@id/labelbarrier" >
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/widgetinputvalue"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:gravity="end" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/mobile/src/main/res/layout/widgetlist_inputitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_inputitem.xml
@@ -41,7 +41,6 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/widgetinput"
-        android:imeOptions="actionDone"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
@@ -59,6 +58,7 @@
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/widgetinputvalue"
+            android:imeOptions="actionDone"
             android:layout_width="match_parent"
             android:layout_height="48dp"
             android:gravity="end" />

--- a/mobile/src/main/res/layout/widgetlist_inputitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_inputitem.xml
@@ -41,6 +41,7 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/widgetinput"
+        android:imeOptions="actionDone"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"

--- a/mobile/src/main/res/layout/widgetlist_inputitem.xml
+++ b/mobile/src/main/res/layout/widgetlist_inputitem.xml
@@ -61,7 +61,8 @@
             android:imeOptions="actionDone"
             android:layout_width="match_parent"
             android:layout_height="48dp"
-            android:gravity="end" />
+            android:gravity="end"
+            android:selectAllOnFocus="true" />
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/mobile/src/main/res/layout/widgetlist_inputitem_compact.xml
+++ b/mobile/src/main/res/layout/widgetlist_inputitem_compact.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     style="@style/WidgetListItemContainerCompact"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -10,6 +9,7 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/widgetinput"
+        android:imeOptions="actionDone"
         android:layout_width="245dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"

--- a/mobile/src/main/res/layout/widgetlist_inputitem_compact.xml
+++ b/mobile/src/main/res/layout/widgetlist_inputitem_compact.xml
@@ -29,7 +29,8 @@
             android:imeOptions="actionDone"
             android:layout_width="match_parent"
             android:layout_height="48dp"
-            android:gravity="end" />
+            android:gravity="end"
+            android:selectAllOnFocus="true" />
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/mobile/src/main/res/layout/widgetlist_inputitem_compact.xml
+++ b/mobile/src/main/res/layout/widgetlist_inputitem_compact.xml
@@ -9,7 +9,7 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/widgetinput"
-        android:layout_width="245dp"
+        android:layout_width="225dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="4dp"

--- a/mobile/src/main/res/layout/widgetlist_inputitem_compact.xml
+++ b/mobile/src/main/res/layout/widgetlist_inputitem_compact.xml
@@ -29,8 +29,7 @@
             android:imeOptions="actionDone"
             android:layout_width="match_parent"
             android:layout_height="48dp"
-            android:gravity="end"
-            android:selectAllOnFocus="true" />
+            android:gravity="end" />
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/mobile/src/main/res/layout/widgetlist_inputitem_compact.xml
+++ b/mobile/src/main/res/layout/widgetlist_inputitem_compact.xml
@@ -9,7 +9,6 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/widgetinput"
-        android:imeOptions="actionDone"
         android:layout_width="245dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
@@ -27,6 +26,7 @@
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/widgetinputvalue"
+            android:imeOptions="actionDone"
             android:layout_width="match_parent"
             android:layout_height="48dp"
             android:gravity="end" />

--- a/mobile/src/main/res/layout/widgetlist_inputitem_compact.xml
+++ b/mobile/src/main/res/layout/widgetlist_inputitem_compact.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/WidgetListItemContainerCompact"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <include layout="@layout/widgetlist_icontext_compact" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/widgetinput"
+        android:layout_width="245dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="4dp"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
+        app:hintEnabled="false"
+        app:expandedHintEnabled="false"
+        app:boxCornerRadiusTopEnd="16dp"
+        app:boxCornerRadiusTopStart="16dp"
+        app:boxCornerRadiusBottomStart="16dp"
+        app:boxCornerRadiusBottomEnd="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/widgeticon"
+        app:layout_constraintTop_toBottomOf="@id/labelbarrier" >
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/widgetinputvalue"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:gravity="end" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/mobile/src/main/res/layout/widgetlist_inputitem_compact.xml
+++ b/mobile/src/main/res/layout/widgetlist_inputitem_compact.xml
@@ -3,33 +3,34 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     style="@style/WidgetListItemContainerCompact"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical">
 
     <include layout="@layout/widgetlist_icontext_compact" />
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/widgetinput"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
         android:layout_width="225dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="4dp"
-        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
-        app:hintEnabled="false"
-        app:expandedHintEnabled="false"
+        android:layout_marginTop="2dp"
+        android:layout_marginBottom="2dp"
+        app:boxCornerRadiusBottomEnd="16dp"
+        app:boxCornerRadiusBottomStart="16dp"
         app:boxCornerRadiusTopEnd="16dp"
         app:boxCornerRadiusTopStart="16dp"
-        app:boxCornerRadiusBottomStart="16dp"
-        app:boxCornerRadiusBottomEnd="16dp"
+        app:expandedHintEnabled="false"
+        app:hintEnabled="false"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/widgeticon"
-        app:layout_constraintTop_toBottomOf="@id/labelbarrier" >
+        app:layout_constraintStart_toEndOf="@id/widgeticon">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/widgetinputvalue"
-            android:imeOptions="actionDone"
             android:layout_width="match_parent"
             android:layout_height="48dp"
-            android:gravity="end" />
+            android:gravity="end"
+            android:imeOptions="actionDone" />
 
     </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
closes [#3285](https://github.com/openhab/openhab-android/issues/3285)
depends on [#3431](https://github.com/openhab/openhab-core/pull/3431)

This PR adds support for the new input widget to the android app.

This is my first time writing for an Android app and writing code in Kotlin. So I will need help to get this finalized, but I hope this is a good basis to start.
I have been running the app in an Android emulator from Android studio, not on a real device. The full syntax is supported (see the BasicUI PR [#1787](https://github.com/openhab/openhab-webui/pull/1787) for my test data and expected behaviour).
Note you will need to run a core with the core PR included to be able to test this.

Known issues at this point observed in the emulator, probably due to my limited understanding of Android development:

- Keyboard popups don't automatically go away after input.
- My sample sitemap has a text input field as the first element in the sitemap. After using one of the date/time input fields, I also get the date/time input field as a popup on this first field, rather than a keyboard.

Appreciate all feedback on this.
