### PR TITLE
Show activities launched by device control on lock screen

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -106,10 +106,15 @@
         <activity
             android:name=".ui.ColorItemActivity"
             android:label="@string/widget_type_color"
-            android:exported="false" />
+            android:showWhenLocked="true"
+            android:exported="false"
+            tools:targetApi="o_mr1" />
         <activity
             android:name=".ui.SelectionItemActivity"
-            android:exported="false" />
+            android:showWhenLocked="true"
+            android:exported="false"
+            tools:targetApi="o_mr1" />
+
         <activity
             android:name=".ui.MainActivity"
             android:launchMode="singleTop"


### PR DESCRIPTION
Closes #3354

Android still requires authentication when the setting 'Require screen to be unlocked' is enabled.