### PR TITLE
Fix widgets on API < Android 12

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/homescreenwidget/ItemUpdateWidget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/homescreenwidget/ItemUpdateWidget.kt
@@ -357,8 +357,8 @@ open class ItemUpdateWidget : AppWidgetProvider() {
             views.setViewVisibility(R.id.edit, editButtonVisibility)
 
             views.setTextViewText(R.id.text, label)
-            val alpha = if (label.isNotEmpty() && smallWidget) 0.3F else 1F
-            views.setFloat(R.id.item_icon, "setAlpha", alpha)
+            val alpha = if (label.isNotEmpty() && smallWidget) 76 else 255
+            views.setInt(R.id.item_icon, "setImageAlpha", alpha)
             hideLoadingIndicator(views)
             return views
         }

--- a/mobile/src/main/res/layout/widget_item_update_small.xml
+++ b/mobile/src/main/res/layout/widget_item_update_small.xml
@@ -16,7 +16,6 @@
         android:padding="4dp"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:alpha="0.3"
         android:src="@mipmap/icon"
         android:visibility="gone"
         tools:visibility="visible"


### PR DESCRIPTION
It seems that setting `alpha` via code is causing issues on some API
levels. As it is deprecated anyway, use the replacement `imageAlpha`,
which works on all API levels.

Closes #3387