### PR TITLE
Prefer widget state over item state when dealing with numbers in sitemap

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
@@ -124,13 +124,18 @@ fun String?.toOH2IconResource(): IconResource? {
     return if (isNullOrEmpty() || this == "none") null else IconResource(this, true, "")
 }
 
-internal fun String?.toOH2WidgetIconResource(item: Item?, type: Widget.Type, hasMappings: Boolean): IconResource? {
+internal fun String?.toOH2WidgetIconResource(
+    state: ParsedState?,
+    item: Item?,
+    type: Widget.Type,
+    hasMappings: Boolean
+): IconResource? {
     if (isNullOrEmpty() || this == "none") {
         return null
     }
 
     val itemState = item?.state
-    var iconState = itemState?.asString.orEmpty()
+    var iconState = state?.asString.orEmpty()
     if (itemState != null) {
         if (item.isOfTypeOrGroupType(Item.Type.Color)) {
             // For items that control a color item fetch the correct icon

--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -165,14 +165,15 @@ data class Widget(
         @Throws(JSONException::class)
         fun updateFromEvent(source: Widget, eventPayload: JSONObject): Widget {
             val item = Item.updateFromEvent(source.item, eventPayload.optJSONObject("item"))
+            val state = determineWidgetState(eventPayload.optStringOrNull("state"), item)
             val iconName = eventPayload.optStringOrFallback("icon", source.icon?.icon)
-            val icon = iconName.toOH2WidgetIconResource(item, source.type, source.mappings.isNotEmpty())
+            val icon = iconName.toOH2WidgetIconResource(state, item, source.type, source.mappings.isNotEmpty())
             return Widget(
                 id = source.id,
                 parentId = source.parentId,
                 rawLabel = eventPayload.optString("label", source.label),
                 icon = icon,
-                state = determineWidgetState(eventPayload.optStringOrNull("state"), item),
+                state = state,
                 type = source.type,
                 url = source.url,
                 item = item,
@@ -336,13 +337,14 @@ fun JSONObject.collectWidgets(parent: Widget?): List<Widget> {
     val item = optJSONObject("item")?.toItem()
     val type = getString("type").toWidgetType()
     val icon = optStringOrNull("icon")
+    val state = Widget.determineWidgetState(optStringOrNull("state"), item)
 
     val widget = Widget(
         id = getString("widgetId"),
         parentId = parent?.id,
         rawLabel = optString("label", ""),
-        icon = icon.toOH2WidgetIconResource(item, type, mappings.isNotEmpty()),
-        state = Widget.determineWidgetState(optStringOrNull("state"), item),
+        icon = icon.toOH2WidgetIconResource(state, item, type, mappings.isNotEmpty()),
+        state = state,
         type = type,
         url = optStringOrNull("url"),
         item = item,

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -810,11 +810,11 @@ class WidgetAdapter(
         }
 
         override suspend fun onValueUpdate(value: Float) {
-            val item = boundWidget?.item ?: return
-            if (item.isOfTypeOrGroupType(Item.Type.Color)) {
-                connection.httpClient.sendItemCommand(item, value.beautify())
+            val widget = boundWidget ?: return
+            if (widget.item?.isOfTypeOrGroupType(Item.Type.Color) == true) {
+                connection.httpClient.sendItemCommand(widget.item, value.beautify())
             } else {
-                connection.httpClient.sendItemUpdate(item, item.state?.asNumber.withValue(value))
+                connection.httpClient.sendItemUpdate(widget.item, widget.state?.asNumber.withValue(value))
             }
         }
     }
@@ -895,7 +895,7 @@ class WidgetAdapter(
         override fun bind(widget: Widget) {
             super.bind(widget)
 
-            val stateString = widget.item?.state?.asString
+            val stateString = widget.state?.asString
             val selectedLabel = widget.mappingsOrItemOptions.firstOrNull { mapping -> mapping.value == stateString }
             valueView?.text = selectedLabel?.label ?: stateString
             valueView?.isVisible = valueView?.text.isNullOrEmpty() != true
@@ -975,7 +975,7 @@ class WidgetAdapter(
             }
 
             // check selected view
-            val state = widget.item?.state?.asString
+            val state = widget.state?.asString
             val checkedId = group.children
                 .filter { it.id != R.id.overflow_button }
                 .filter { it.tag == state }
@@ -1003,7 +1003,7 @@ class WidgetAdapter(
             if (visibleChildCount == 1) {
                 onClick(group[0])
             } else if (visibleChildCount == 2) {
-                val state = boundWidget?.item?.state?.asString
+                val state = boundWidget?.state?.asString
                 if (state == group[0].tag.toString()) {
                     onClick(group[1])
                 } else if (state == group[1].tag.toString()) {
@@ -1035,7 +1035,7 @@ class WidgetAdapter(
                 button.isGone = mapping == null
                 if (mapping != null) {
                     button.text = mapping.label
-                    button.isChecked = widget.item?.state?.asString == mapping.value
+                    button.isChecked = widget.state?.asString == mapping.value
                     button.tag = mapping.value
                 }
             }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetDetailBottomSheets.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetDetailBottomSheets.kt
@@ -101,7 +101,7 @@ class SelectionBottomSheet : AbstractWidgetBottomSheet(), RadioGroup.OnCheckedCh
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.bottom_sheet_selection, container, false)
         val group = view.findViewById<RadioGroup>(R.id.group)
-        val stateString = widget.item?.state?.asString
+        val stateString = widget.state?.asString
         for (mapping in widget.mappingsOrItemOptions) {
             val radio = inflater.inflate(R.layout.bottom_sheet_selection_item_radio_button, group, false) as RadioButton
             radio.id = mapping.hashCode()

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetSlider.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetSlider.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.openhab.habdroid.model.Item
+import org.openhab.habdroid.model.ParsedState
 import org.openhab.habdroid.model.Widget
 import org.openhab.habdroid.model.withValue
 import org.openhab.habdroid.util.beautify
@@ -44,7 +45,7 @@ class WidgetSlider constructor(context: Context, attrs: AttributeSet?) :
     private var scope: CoroutineScope? = null
     private var updateJob: Job? = null
     private var updateOnMove = true
-    private var boundItem: Item? = null
+    private var boundWidget: Widget? = null
 
     init {
         addOnChangeListener(this)
@@ -57,12 +58,12 @@ class WidgetSlider constructor(context: Context, attrs: AttributeSet?) :
         val from = if (isColor) 0F else widget.minValue
         val to = if (isColor) 100F else widget.maxValue
         val step = if (isColor) 1F else widget.step
-        val state = widget.item?.state
-        val widgetValue = (if (isColor) state?.asBrightness?.toFloat() else state?.asNumber?.value) ?: from
+        val widgetValue = (if (isColor) widget.state?.asBrightness?.toFloat() else widget.state?.asNumber?.value)
+            ?: from
 
         updateJob?.cancel()
         this.updateOnMove = updateOnMove
-        this.boundItem = widget.item
+        this.boundWidget = widget
 
         // Fix "The stepSize must be 0, or a factor of the valueFrom-valueTo range" exception
         valueTo = to - (to - from).rem(step)
@@ -127,11 +128,11 @@ class WidgetSlider constructor(context: Context, attrs: AttributeSet?) :
     }
 
     override fun getFormattedValue(value: Float): String {
-        val item = boundItem ?: return ""
-        return if (item.isOfTypeOrGroupType(Item.Type.Color)) {
+        val widget = boundWidget
+        return if (widget?.item?.isOfTypeOrGroupType(Item.Type.Color) == true) {
             "${value.beautify()} %"
         } else {
-            item.state?.asNumber.withValue(value).toString()
+            widget?.state?.asNumber.withValue(value).toString()
         }
     }
 


### PR DESCRIPTION
When dealing with UoM, item state may not have the user's preferred unit (e.g. the default setup for percentages in OH4 may be '0.45' for item state and '45%' for widget state when not explicitly having set unit metadata)

Also apply the same change for fetching sitemap icons.