### PR TITLE
Fix applying first map location

### DIFF
--- a/mobile/src/full/java/org/openhab/habdroid/ui/MapViewHelper.kt
+++ b/mobile/src/full/java/org/openhab/habdroid/ui/MapViewHelper.kt
@@ -46,24 +46,14 @@ object MapViewHelper {
 
         init {
             mapView.onCreate(null)
-            mapView.getMapAsync { map ->
-                this.map = map
-                with(map.uiSettings) {
-                    setAllGesturesEnabled(false)
-                    isMapToolbarEnabled = false
-                }
-                map.setOnMarkerClickListener {
-                    openPopup()
-                    true
-                }
-                map.setOnMapClickListener { openPopup() }
-            }
         }
 
         override fun bindAfterDataSaverCheck(widget: Widget) {
             super.bindAfterDataSaverCheck(widget)
-            map?.clear()
-            map?.applyPositionAndLabel(widget, 15.0f, false)
+            withLoadedMap { map ->
+                map.clear()
+                map.applyPositionAndLabel(widget, 15.0f, false)
+            }
         }
 
         override fun onStart() {
@@ -81,6 +71,28 @@ object MapViewHelper {
         override fun openPopup() {
             val widget = boundWidget ?: return
             fragmentPresenter.showBottomSheet(MapBottomSheet(), widget)
+        }
+
+        private fun withLoadedMap(callback: (map: GoogleMap) -> Unit) {
+            val loadedMap = this.map
+            if (loadedMap != null) {
+                callback(loadedMap)
+                return
+            }
+
+            mapView.getMapAsync { map ->
+                this.map = map
+                with(map.uiSettings) {
+                    setAllGesturesEnabled(false)
+                    isMapToolbarEnabled = false
+                }
+                map.setOnMarkerClickListener {
+                    openPopup()
+                    true
+                }
+                map.setOnMapClickListener { openPopup() }
+                callback(map)
+            }
         }
     }
 }


### PR DESCRIPTION
If the map isn't loaded yet when the first map widget is bound, the bind attempt for that widget was discarded. Fix this by making sure to apply the widget bind attempt after initially loading the map. While at it, also make sure not to load the map until after the data saver check happened to not cause data transfer before that check.

Fixes #3412