### PR TITLE
Don't use device locale when formatting state for icons

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
@@ -142,7 +142,7 @@ internal fun String?.toOH2WidgetIconResource(
         stateToUse == null -> "null"
         // Number items need to use state formatted as per their state description
         item.isOfTypeOrGroupType(Item.Type.Number) || item.isOfTypeOrGroupType(Item.Type.NumberWithDimension)-> {
-            stateToUse.asNumber.toString()
+            stateToUse.asNumber?.toString(Locale.US)
         }
         item.isOfTypeOrGroupType(Item.Type.Color) -> when {
             // Color sliders just use the brightness part of the color


### PR DESCRIPTION
The server expects to be able to parse the passed state as number, which is not possible in e.g. German locale: in that case, e.g. '20,0 °C' instead of the expected '20.0 °C' was passed.

Fixes #3472