### PR TITLE
Adjust image/chart/map/video header line

### DIFF
--- a/mobile/src/main/res/layout/widgetlist_icontext_for_heavy_data.xml
+++ b/mobile/src/main/res/layout/widgetlist_icontext_for_heavy_data.xml
@@ -3,13 +3,14 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="wrap_content"
-    android:layout_width="match_parent">
+    android:layout_width="match_parent"
+    android:layout_marginBottom="4dp"
+    android:orientation="horizontal">
 
     <org.openhab.habdroid.ui.widget.WidgetImageView
         android:id="@+id/widgeticon"
-        android:layout_width="@dimen/widgetlist_icon_size"
-        android:layout_height="@dimen/widgetlist_icon_size"
-        android:layout_gravity="center_vertical"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
         app:imageScalingType="scaleToFit"
         tools:src="@drawable/ic_openhab_appicon_24dp" />
 
@@ -18,12 +19,12 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:layout_marginStart="16dp"
+        android:layout_marginStart="8dp"
         android:layout_weight="1"
         android:ellipsize="end"
         android:maxLines="1"
         android:textDirection="locale"
-        android:textAppearance="?attr/textAppearanceBodyLarge"
+        android:textAppearance="?attr/textAppearanceBodyMedium"
         tools:text="Widget title" />
 
 </LinearLayout>


### PR DESCRIPTION
Make icon and font smaller to match what we used for MapView prior to commit 527cd275f32745054ec4532dc3f18493f4261dd9.
See https://github.com/openhab/openhab-webui/issues/2065#issuecomment-1720807556 for a screenshot and rationale.