### PR TITLE
Fix status bar being invisible in chart and image activities

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractBaseActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractBaseActivity.kt
@@ -104,6 +104,7 @@ abstract class AbstractBaseActivity : AppCompatActivity(), CoroutineScope {
         toolbar = findViewById(R.id.openhab_toolbar)
         setSupportActionBar(toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        enableDrawingBehindStatusBar()
 
         coordinator = findViewById(R.id.coordinator)
         content = findViewById(R.id.activity_content)
@@ -134,7 +135,16 @@ abstract class AbstractBaseActivity : AppCompatActivity(), CoroutineScope {
         setFullscreen()
     }
 
-    fun enableDrawingBehindStatusBar() {
+    fun setFullscreen(isEnabled: Boolean = isFullscreenEnabled) {
+        if (isEnabled) {
+            insetsController.hide(WindowInsetsCompat.Type.systemBars())
+            insetsController.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        } else {
+            insetsController.show(WindowInsetsCompat.Type.systemBars())
+        }
+    }
+
+    private fun enableDrawingBehindStatusBar() {
         EdgeToEdgeUtils.applyEdgeToEdge(window, true)
         // Set up a listener to get the window insets so we can apply it to our views. It's important this listener
         // is applied to the toolbar for a combination of reasons:
@@ -150,15 +160,6 @@ abstract class AbstractBaseActivity : AppCompatActivity(), CoroutineScope {
             lastInsets = insets
             applyPaddingsForWindowInsets()
             WindowInsetsCompat.CONSUMED
-        }
-    }
-
-    fun setFullscreen(isEnabled: Boolean = isFullscreenEnabled) {
-        if (isEnabled) {
-            insetsController.hide(WindowInsetsCompat.Type.systemBars())
-            insetsController.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        } else {
-            insetsController.show(WindowInsetsCompat.Type.systemBars())
         }
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
@@ -92,8 +92,6 @@ abstract class AbstractItemPickerActivity : AbstractBaseActivity(), SwipeRefresh
         setContentView(R.layout.activity_item_picker)
         setResult(RESULT_CANCELED)
 
-        enableDrawingBehindStatusBar()
-
         swipeLayout = findViewById(R.id.activity_content)
         swipeLayout.setOnRefreshListener(this)
         swipeLayout.applyColors()

--- a/mobile/src/main/java/org/openhab/habdroid/ui/LogActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/LogActivity.kt
@@ -59,8 +59,6 @@ class LogActivity : AbstractBaseActivity(), SwipeRefreshLayout.OnRefreshListener
 
         setContentView(R.layout.activity_log)
 
-        enableDrawingBehindStatusBar()
-
         fab = findViewById(R.id.shareFab)
         logTextView = findViewById(R.id.log)
         scrollView = findViewById(R.id.scrollview)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -224,7 +224,6 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
         setProgressIndicatorVisible(false)
 
         setupDrawer()
-        enableDrawingBehindStatusBar()
 
         viewPool = RecyclerView.RecycledViewPool()
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/PreferencesActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/PreferencesActivity.kt
@@ -48,7 +48,6 @@ class PreferencesActivity : AbstractBaseActivity() {
 
         setContentView(R.layout.activity_prefs)
 
-        enableDrawingBehindStatusBar()
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         if (savedInstanceState == null) {


### PR DESCRIPTION
Do enableDrawingBehindStatusBar() unconditionally, as otherwise our app bar will be laid out on top of the status bar.