### PR TITLE
Item control: Don't use TYPE_SHUTTER

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/ItemsControlsProviderService.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/ItemsControlsProviderService.kt
@@ -358,7 +358,7 @@ fun Item.getDeviceType() = when (category?.lowercase()?.substringAfterLast(':'))
     "lock" -> DeviceTypes.TYPE_LOCK
     "fan", "fan_box", "fan_ceiling" -> DeviceTypes.TYPE_FAN
     "blinds" -> DeviceTypes.TYPE_BLINDS
-    "rollershutter" -> DeviceTypes.TYPE_SHUTTER
+    "rollershutter" -> DeviceTypes.TYPE_BLINDS
     "window" -> DeviceTypes.TYPE_WINDOW
     "dryer" -> DeviceTypes.TYPE_DRYER
     "washingmachine" -> DeviceTypes.TYPE_WASHER


### PR DESCRIPTION
TYPE_SHUTTER has the same icon as TYPE_WINDOW. It's also not animated, compared to TYPE_BLINDS.
Use the same icon for `blinds` and `rollershutter` as they are the same in the classic icon set as well.