### PR TITLE
Fix brightness parsing

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.kt
@@ -140,6 +140,10 @@ data class ParsedState internal constructor(
                     // fall through
                 }
             }
+            val stateAsInt = state.toIntOrNull()
+            if (stateAsInt in 0..100) {
+                return stateAsInt
+            }
             return null
         }
 


### PR DESCRIPTION
While debugging issues with color items I discovered that two SSE events are sent when a slider with a color item is updated.

Item:
````
label: Debug Color 1
type: Color
category: oh:mdi:palette
groupNames: []
groupType: None
function: null
tags: []
````

Sitemap:
````
Slider item=D_Color iconcolor=["itemValue"]
````

The first event contains a state in the hsb format (`10,10,10`), the second events contains the brightness only (`10`). Parsing an integer as brightness failed and the slider was set to `0`.
IMO an integer in the range `0..100` can be considered as brightness.