### PR TITLE
Retry work in case of HTTP code 500

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/ItemUpdateWorker.kt
@@ -313,7 +313,7 @@ class ItemUpdateWorker(context: Context, params: WorkerParameters) : CoroutineWo
 
     companion object {
         private val TAG = ItemUpdateWorker::class.java.simpleName
-        private val RETRY_HTTP_ERROR_CODES = listOf(408, 425, 502, 503, 504)
+        private val RETRY_HTTP_ERROR_CODES = listOf(408, 425, 500, 502, 503, 504)
 
         private const val INPUT_DATA_ITEM_NAME = "item"
         private const val INPUT_DATA_LABEL = "label"


### PR DESCRIPTION
I've seen the HTTP code 500 a few times when no connection could be established, so retry in this case.

https://community.openhab.org/t/android-app-item-update-error-http-500-in-case-of-no-connection/149488