### PR TITLE
Only show chart/image/video label if specified in sitemap

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -463,6 +463,7 @@ class WidgetAdapter(
         override fun bind(widget: Widget) {
             super.bind(widget)
             val showLabelAndIcon = widget.label.isNotEmpty()
+                && widget.labelSource == Widget.LabelSource.SitemapDefinition
             labelView.isVisible = showLabelAndIcon
             iconView.isVisible = showLabelAndIcon
             if (!showDataSaverPlaceholderIfNeeded(widget, canBindWithoutDataTransfer(widget))) {


### PR DESCRIPTION
This uses the new labelSource JSON response field introduced in openhab-core#3804. If the element isn't present (for older server versions), we'll hide the label by default.