### PR TITLE
Custom sitemaps for device control

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/ItemsControlsProviderService.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/ItemsControlsProviderService.kt
@@ -30,6 +30,7 @@ import android.service.controls.templates.ToggleRangeTemplate
 import android.service.controls.templates.ToggleTemplate
 import android.util.Log
 import androidx.annotation.RequiresApi
+import androidx.core.net.toUri
 import java.util.concurrent.Flow
 import java.util.function.Consumer
 import kotlin.math.max
@@ -59,6 +60,7 @@ import org.openhab.habdroid.util.getDeviceControlSubtitle
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getPrimaryServerId
 import org.openhab.habdroid.util.getSecretPrefs
+import org.openhab.habdroid.util.openInBrowser
 import org.openhab.habdroid.util.orDefaultIfEmpty
 
 @RequiresApi(Build.VERSION_CODES.R)
@@ -279,6 +281,10 @@ class ItemsControlsProviderService : ControlsProviderService() {
                 val intent = Intent(context, ColorItemActivity::class.java).apply {
                     putExtra(ColorItemActivity.EXTRA_ITEM, item)
                 }
+                Pair(intent, item.hashCode())
+            }
+            item.linkToMore != null -> {
+                val intent = Intent(Intent.ACTION_VIEW, item.linkToMore)
                 Pair(intent, item.hashCode())
             }
             else -> {

--- a/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Item.kt
@@ -13,7 +13,9 @@
 
 package org.openhab.habdroid.model
 
+import android.net.Uri
 import android.os.Parcelable
+import androidx.core.net.toUri
 import java.util.Locale
 import kotlinx.parcelize.Parcelize
 import org.json.JSONException
@@ -43,6 +45,7 @@ data class Item internal constructor(
     val minimum: Float?,
     val maximum: Float?,
     val step: Float?,
+    val linkToMore: Uri?
 ) : Parcelable {
     val label get() = rawLabel?.split("[", "]")?.getOrNull(0)?.trim()
 
@@ -280,7 +283,8 @@ fun Node.toItem(): Item? {
         groupNames = emptyList(),
         minimum = null,
         maximum = null,
-        step = null
+        step = null,
+        linkToMore = null
     )
 }
 
@@ -338,6 +342,12 @@ fun JSONObject.toItem(): Item {
         emptyList()
     }
 
+    val linkToMore = try {
+        optJSONObject("metadata")?.optJSONObject("link_to_more")?.optStringOrNull("value")?.toUri()
+    } catch (e: Exception) { // TODO: Lower exception
+        null
+    }
+
     return Item(
         name = name,
         rawLabel = optStringOrNull("label"),
@@ -353,7 +363,8 @@ fun JSONObject.toItem(): Item {
         groupNames = groupNames,
         minimum = stateDescription?.optFloatOrNull("minimum"),
         maximum = stateDescription?.optFloatOrNull("maximum"),
-        step = stateDescription?.optFloatOrNull("step")
+        step = stateDescription?.optFloatOrNull("step"),
+        linkToMore = linkToMore
     )
 }
 

--- a/mobile/src/main/java/org/openhab/habdroid/model/LinkedPage.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/LinkedPage.kt
@@ -13,7 +13,9 @@
 
 package org.openhab.habdroid.model
 
+import android.net.Uri
 import android.os.Parcelable
+import androidx.core.net.toUri
 
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
@@ -32,6 +34,19 @@ data class LinkedPage(
     val icon: IconResource?,
     val link: String
 ) : Parcelable {
+    fun createLink(): Uri {
+        val sitemapUri = link.toUri()
+        val path = sitemapUri.path.orEmpty()
+        if (!path.startsWith("/rest/sitemaps")) {
+            throw IllegalArgumentException("Expected a sitemap URL")
+        }
+        return Uri.Builder()
+            .scheme(NfcTag.SCHEME)
+            .authority("")
+            .appendEncodedPath(path.substring(15))
+            .build()
+    }
+
     companion object {
         internal fun build(
             id: String,

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -250,13 +250,21 @@ class WidgetListFragment :
         if (widget != null && context != null) {
             when (item.itemId) {
                 CONTEXT_MENU_ID_WRITE_SITEMAP_TAG -> {
-                    widget.linkedPage?.link?.let {
+                    widget.linkedPage?.createLink()?.let {
                         startActivity(WriteTagActivity.createSitemapNavigationIntent(context, it))
                     }
                     return true
                 }
                 CONTEXT_MENU_ID_OPEN_IN_MAPS -> {
                     widget.item?.state?.asLocation?.toMapsUrl()?.toUri().openInBrowser(context)
+                    return true
+                }
+                CONTEXT_MENU_ID_COPY_SITEMAP_LINK -> {
+                    Log.d(TAG, "Copy sitemap link for ${widget.linkedPage}")
+                    val link = widget.linkedPage?.createLink()?.toString() ?: return true
+                    val clipboardManager = context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+                    val clipData = ClipData.newPlainText(context.getString(R.string.app_name), link)
+                    clipboardManager.setPrimaryClip(clipData)
                     return true
                 }
             }
@@ -357,6 +365,9 @@ class WidgetListFragment :
 
         if (widget.linkedPage != null && nfcSupported) {
             menu.add(Menu.NONE, CONTEXT_MENU_ID_WRITE_SITEMAP_TAG, Menu.NONE, R.string.nfc_action_to_sitemap_page)
+        }
+        if (widget.linkedPage != null) {
+            menu.add(Menu.NONE, CONTEXT_MENU_ID_COPY_SITEMAP_LINK, Menu.NONE, R.string.copy_sitemap_link)
         }
 
         widget.item?.let {
@@ -648,6 +659,7 @@ class WidgetListFragment :
         private const val CONTEXT_MENU_ID_PIN_HOME_BLACK = 1005
         private const val CONTEXT_MENU_ID_OPEN_IN_MAPS = 1006
         private const val CONTEXT_MENU_ID_COPY_ITEM_NAME = 1007
+        private const val CONTEXT_MENU_ID_COPY_SITEMAP_LINK = 1008
         private const val CONTEXT_MENU_ID_WRITE_CUSTOM_TAG = 10000
         private const val CONTEXT_MENU_ID_WRITE_DEVICE_ID = 10001
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WriteTagActivity.kt
@@ -38,7 +38,6 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
 import androidx.annotation.DrawableRes
-import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
@@ -312,19 +311,9 @@ class WriteTagActivity : AbstractBaseActivity(), CoroutineScope {
             }
         }
 
-        fun createSitemapNavigationIntent(context: Context, sitemapUrl: String): Intent {
-            val sitemapUri = sitemapUrl.toUri()
-            val path = sitemapUri.path.orEmpty()
-            if (!path.startsWith("/rest/sitemaps")) {
-                throw IllegalArgumentException("Expected a sitemap URL")
-            }
-            val longUri = Uri.Builder()
-                .scheme(NfcTag.SCHEME)
-                .authority("")
-                .appendEncodedPath(path.substring(15))
-                .build()
+        fun createSitemapNavigationIntent(context: Context, sitemapLink: Uri): Intent {
             return Intent(context, WriteTagActivity::class.java)
-                .putExtra(EXTRA_LONG_URI, longUri)
+                .putExtra(EXTRA_LONG_URI, sitemapLink)
         }
     }
 

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -169,6 +169,7 @@
     <string name="show_and_copy_item_name">Show and copy Item name</string>
     <!-- An Item name has been copied to clipboard, e.g. Copied "GF_Lights" -->
     <string name="copied_item_name">Copied \"%s\"</string>
+    <string name="copy_sitemap_link">Copy link to this subpage</string>
 
     <!-- Error messages -->
     <string name="error_empty_sitemap_list">openHAB returned empty Sitemap list</string>


### PR DESCRIPTION
We already have links to Sitemap subpages (NFC tags), so re-use them for the device control.

Closes #3140