### PR TITLE
Support f7, material, and iconify icons

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
@@ -70,8 +70,8 @@ data class IconResource internal constructor(
         when (iconSource) {
             "material" -> {
                 iconSource = "iconify"
-                iconSet = "ic"
                 iconName = "$iconSet-$iconName"
+                iconSet = "ic"
             }
             "f7" -> {
                 iconSource = "iconify"

--- a/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
@@ -23,6 +23,7 @@ import java.util.Locale
 import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
+import org.openhab.habdroid.R
 import org.openhab.habdroid.util.appendQueryParameter
 import org.openhab.habdroid.util.getIconFormat
 import org.openhab.habdroid.util.getPrefs
@@ -35,11 +36,12 @@ data class IconResource internal constructor(
     internal val customState: String
 ) : Parcelable {
     fun toUrl(context: Context, includeState: Boolean): String {
-        return toUrl(includeState, context.getPrefs().getIconFormat())
+        val iconSize = context.resources.getDimensionPixelSize(R.dimen.widgetlist_icon_size)
+        return toUrl(includeState, context.getPrefs().getIconFormat(), iconSize)
     }
 
     @VisibleForTesting
-    fun toUrl(includeState: Boolean, iconFormat: IconFormat): String {
+    fun toUrl(includeState: Boolean, iconFormat: IconFormat, desiredSizePixels: Int): String {
         if (!isOh2) {
             return "images/$icon.png"
         }
@@ -88,8 +90,8 @@ data class IconResource internal constructor(
                 builder.scheme("https")
                        .authority("api.iconify.design")
                        .path(iconSet)
-                       .appendPath(iconName + ".svg")
-                       .appendQueryParameter("height", "64")
+                       .appendPath("$iconName.svg")
+                       .appendQueryParameter("height", desiredSizePixels.toString())
             }
             else -> builder.path("icon/")
         }

--- a/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
@@ -56,11 +56,26 @@ data class IconResource internal constructor(
             2 -> {
                 iconSource = segments[0]
                 iconName = segments[1]
+                if (iconSource == "material") {
+                    iconSet = "baseline"
+                }
             }
             3 -> {
                 iconSource = segments[0]
                 iconSet = segments[1]
                 iconName = segments[2]
+            }
+        }
+
+        when (iconSource) {
+            "material" -> {
+                iconSource = "iconify"
+                iconName = "$iconSet-$iconName"
+                iconSet = "ic"
+            }
+            "f7" -> {
+                iconSource = "iconify"
+                iconSet = "f7"
             }
         }
 
@@ -83,10 +98,7 @@ data class IconResource internal constructor(
                     builder.appendQueryParameter("state", customState)
                 }
             }
-            "if", "iconify", "material" -> {
-                if (iconSource == "material") {
-                    iconSet = "mdi"
-                }
+            "if", "iconify" -> {
                 builder.scheme("https")
                        .authority("api.iconify.design")
                        .path(iconSet)

--- a/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
@@ -44,41 +44,54 @@ data class IconResource internal constructor(
             return "images/$icon.png"
         }
 
-        var iconName = "none"
+        var iconSource = "oh"
         var iconSet = "classic"
+        var iconName = "none"
 
         val segments = icon.split(":", limit = 3)
         when (segments.size) {
             1 -> iconName = segments[0]
             2 -> {
-                // Keep iconName=none for unsupported icon sources
-                if (segments[0] == "oh") {
-                    iconName = segments[1]
-                }
+                iconSource = segments[0]
+                iconName = segments[1]
             }
             3 -> {
-                // Keep iconName=none for unsupported icon sources
-                if (segments[0] == "oh") {
-                    iconSet = segments[1]
-                    iconName = segments[2]
-                }
+                iconSource = segments[0]
+                iconSet = segments[1]
+                iconName = segments[2]
             }
-        }
-
-        val suffix = when (iconFormat) {
-            IconFormat.Png -> "PNG"
-            IconFormat.Svg -> "SVG"
         }
 
         val builder = Uri.Builder()
-            .path("icon/")
-            .appendPath(iconName)
-            .appendQueryParameter("format", suffix)
-            .appendQueryParameter("anyFormat", true)
-            .appendQueryParameter("iconset", iconSet)
 
-        if (customState.isNotEmpty() && includeState) {
-            builder.appendQueryParameter("state", customState)
+        when (iconSource) {
+            "oh" -> {
+                val suffix = when (iconFormat) {
+                    IconFormat.Png -> "PNG"
+                    IconFormat.Svg -> "SVG"
+                }
+
+                builder.path("icon")
+                       .appendPath(iconName)
+                       .appendQueryParameter("format", suffix)
+                       .appendQueryParameter("anyFormat", true)
+                       .appendQueryParameter("iconset", iconSet)
+
+                if (customState.isNotEmpty() && includeState) {
+                    builder.appendQueryParameter("state", customState)
+                }
+            }
+            "if", "iconify", "material" -> {
+                if (iconSource == "material") {
+                    iconSet = "mdi"
+                }
+                builder.scheme("https")
+                       .authority("api.iconify.design")
+                       .path(iconSet)
+                       .appendPath(iconName + ".svg")
+                       .appendQueryParameter("height", "64")
+            }
+            else -> builder.path("icon/")
         }
 
         return builder.build().toString()

--- a/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
@@ -70,8 +70,8 @@ data class IconResource internal constructor(
         when (iconSource) {
             "material" -> {
                 iconSource = "iconify"
-                iconName = "$iconSet-$iconName"
                 iconSet = "ic"
+                iconName = "$iconSet-$iconName"
             }
             "f7" -> {
                 iconSource = "iconify"
@@ -97,8 +97,8 @@ data class IconResource internal constructor(
 
                 // set unknown iconSource to oh:classic:none icon
                 if (iconSource != "oh") {
-                    iconName = "none"
                     iconSet = "classic"
+                    iconName = "none"
                 }
 
                 builder.path("icon")

--- a/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
@@ -82,10 +82,23 @@ data class IconResource internal constructor(
         val builder = Uri.Builder()
 
         when (iconSource) {
-            "oh" -> {
+            "if", "iconify" -> {
+                builder.scheme("https")
+                    .authority("api.iconify.design")
+                    .path(iconSet)
+                    .appendPath("$iconName.svg")
+                    .appendQueryParameter("height", desiredSizePixels.toString())
+            }
+            else -> {
                 val suffix = when (iconFormat) {
                     IconFormat.Png -> "PNG"
                     IconFormat.Svg -> "SVG"
+                }
+
+                // set unknown iconSource to oh:classic:none icon
+                if (iconSource != "oh") {
+                    iconName = "none"
+                    iconSet = "classic"
                 }
 
                 builder.path("icon")
@@ -98,14 +111,6 @@ data class IconResource internal constructor(
                     builder.appendQueryParameter("state", customState)
                 }
             }
-            "if", "iconify" -> {
-                builder.scheme("https")
-                       .authority("api.iconify.design")
-                       .path(iconSet)
-                       .appendPath("$iconName.svg")
-                       .appendQueryParameter("height", desiredSizePixels.toString())
-            }
-            else -> builder.path("icon/")
         }
 
         return builder.build().toString()

--- a/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.kt
@@ -54,12 +54,13 @@ class HttpClient constructor(client: OkHttpClient, baseUrl: String?, username: S
         if (authHeader != null) {
             // Forcibly put authorization info into request, as redirect/retry interceptor might have removed it
             clientBuilder.addNetworkInterceptor { chain ->
-                var request = chain.request()
-                // Don't add auth header to requests to external icons
-                if (baseUrl != null && request.url.toString().startsWith(baseUrl)) {
-                    request = request.newBuilder().addHeader("Authorization", authHeader).build()
-                }
-                chain.proceed(request)
+                val request = chain.request()
+                // Make sure not to send authentication credentials to external servers
+                chain.proceed(if (this.baseUrl?.host == request.url.host) {
+                    request.newBuilder().addHeader("Authorization", authHeader).build()
+                } else {
+                    request
+                })
             }
         }
         this.client = clientBuilder.build()

--- a/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.kt
@@ -54,10 +54,11 @@ class HttpClient constructor(client: OkHttpClient, baseUrl: String?, username: S
         if (authHeader != null) {
             // Forcibly put authorization info into request, as redirect/retry interceptor might have removed it
             clientBuilder.addNetworkInterceptor { chain ->
-                val request = chain.request()
-                    .newBuilder()
-                    .addHeader("Authorization", authHeader)
-                    .build()
+                var request = chain.request()
+                // Don't add auth header to requests to external icons
+                if (baseUrl != null && request.url.toString().startsWith(baseUrl)) {
+                    request = request.newBuilder().addHeader("Authorization", authHeader).build()
+                }
                 chain.proceed(request)
             }
         }

--- a/mobile/src/test/java/org/openhab/habdroid/model/IconResourceTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/model/IconResourceTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.habdroid.model
+
+import org.json.JSONException
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IconResourceTest {
+    @Test
+    fun testOhIcons() {
+        mapOf(
+            "light" to "icon/light?format=PNG&anyFormat=true&iconset=classic",
+            "oh:light" to "icon/light?format=PNG&anyFormat=true&iconset=classic",
+            "oh:classic:light" to "icon/light?format=PNG&anyFormat=true&iconset=classic",
+            "oh:custom:light" to "icon/light?format=PNG&anyFormat=true&iconset=custom"
+        ).forEach {
+            testIconToUrl(it.key, it.value)
+        }
+    }
+    
+    @Test
+    fun testMaterialIcons() {
+        mapOf(
+            "material:light" to "https://api.iconify.design/ic/baseline-light.svg?height=64",
+            "material:outline:light" to "https://api.iconify.design/ic/outline-light.svg?height=64"
+        ).forEach {
+            testIconToUrl(it.key, it.value)
+        }
+    }
+
+    @Test
+    fun testF7Icons() {
+        mapOf(
+            "f7:airplane" to "https://api.iconify.design/f7/airplane.svg?height=64",
+            "f7:IGNORED:airplane" to "https://api.iconify.design/f7/airplane.svg?height=64"
+        ).forEach {
+            testIconToUrl(it.key, it.value)
+        }
+    }
+
+    @Test
+    fun testIconifyIcons() {
+        mapOf(
+            "if:codicon:lightbulb" to "https://api.iconify.design/codicon/lightbulb.svg?height=64",
+            "iconify:codicon:lightbulb" to "https://api.iconify.design/codicon/lightbulb.svg?height=64",
+        ).forEach {
+            testIconToUrl(it.key, it.value)
+        }
+    }
+
+    private fun testIconToUrl(icon: String, url: String) {
+        assertEquals(
+            "$icon icon failed!",
+            url,
+            IconResource(icon, true, "").toUrl(false, IconFormat.Png, 64)
+        )
+    }
+}

--- a/mobile/src/test/java/org/openhab/habdroid/model/IconResourceTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/model/IconResourceTest.kt
@@ -60,9 +60,20 @@ class IconResourceTest {
     fun testIconifyIcons() {
         mapOf(
             "if:codicon:lightbulb" to "https://api.iconify.design/codicon/lightbulb.svg?height=64",
-            "iconify:codicon:lightbulb" to "https://api.iconify.design/codicon/lightbulb.svg?height=64",
+            "iconify:codicon:lightbulb" to "https://api.iconify.design/codicon/lightbulb.svg?height=64"
         ).forEach {
             testIconToUrl(it.key, it.value)
+        }
+    }
+
+    @Test
+    fun testUnknownIconSources() {
+        listOf(
+            "unknown:ignored",
+            "unknown:ignored:ignored"
+        ).forEach {
+            val urlForUnknownIcons = "icon/none?format=PNG&anyFormat=true&iconset=classic"
+            testIconToUrl(it, urlForUnknownIcons)
         }
     }
 

--- a/mobile/src/test/java/org/openhab/habdroid/model/SitemapTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/model/SitemapTest.kt
@@ -60,11 +60,11 @@ class SitemapTest {
         assertNull(demoSitemapWithLabel.icon)
         assertEquals(
             "icon/home?format=SVG&anyFormat=true&iconset=classic",
-            homeSitemapWithoutLabel.icon?.toUrl(false, IconFormat.Svg)
+            homeSitemapWithoutLabel.icon?.toUrl(false, IconFormat.Svg, 64)
         )
         assertEquals(
             "icon/home?format=SVG&anyFormat=true&iconset=classic",
-            homeSitemapWithoutLabel.icon?.toUrl(true, IconFormat.Svg)
+            homeSitemapWithoutLabel.icon?.toUrl(true, IconFormat.Svg, 64)
         )
     }
 

--- a/mobile/src/test/java/org/openhab/habdroid/model/WidgetTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/model/WidgetTest.kt
@@ -51,43 +51,43 @@ class WidgetTest {
 
     @Test
     fun getIconPath_iconExists_returnIconUrlFromImages() {
-        assertEquals("images/groupicon.png", sutXml[0].icon?.toUrl(false, IconFormat.Png))
-        assertEquals("images/groupicon.png", sutXml[0].icon?.toUrl(true, IconFormat.Png))
+        assertEquals("images/groupicon.png", sutXml[0].icon?.toUrl(false, IconFormat.Png, 64))
+        assertEquals("images/groupicon.png", sutXml[0].icon?.toUrl(true, IconFormat.Png, 64))
     }
 
     @Test
     fun testGetIconPath() {
         assertEquals(
             "icon/groupicon?format=PNG&anyFormat=true&iconset=classic&state=OFF",
-            sut1[0].icon?.toUrl(true, IconFormat.Png)
+            sut1[0].icon?.toUrl(true, IconFormat.Png, 64)
         )
         assertEquals(
             "icon/groupicon?format=SVG&anyFormat=true&iconset=classic&state=ON",
-            sut2[0].icon?.toUrl(true, IconFormat.Svg)
+            sut2[0].icon?.toUrl(true, IconFormat.Svg, 64)
         )
         assertEquals(
             "icon/slider?format=SVG&anyFormat=true&iconset=classic&state=81",
-            sut3[1].icon?.toUrl(true, IconFormat.Svg)
+            sut3[1].icon?.toUrl(true, IconFormat.Svg, 64)
         )
         assertEquals(
             "Rollersutter icon must always be 0 to 100, not ON/OFF",
             "icon/rollershutter?format=SVG&anyFormat=true&iconset=classic&state=0",
-            sut3[2].icon?.toUrl(true, IconFormat.Svg)
+            sut3[2].icon?.toUrl(true, IconFormat.Svg, 64)
         )
         assertEquals(
             "Iconset must be extracted from icon name",
             "icon/rollershutter?format=SVG&anyFormat=true&iconset=mdi&state=42",
-            sut3[3].icon?.toUrl(true, IconFormat.Svg)
+            sut3[3].icon?.toUrl(true, IconFormat.Svg, 64)
         )
         assertEquals(
             "Iconset must be extracted from icon name",
             "icon/frame?format=SVG&anyFormat=true&iconset=classic",
-            sut3[0].icon?.toUrl(false, IconFormat.Svg)
+            sut3[0].icon?.toUrl(false, IconFormat.Svg, 64)
         )
         assertEquals(
             "If data saver is active, icon paths must not contain a state",
             "icon/rollershutter?format=SVG&anyFormat=true&iconset=mdi",
-            sut3[3].icon?.toUrl(false, IconFormat.Svg)
+            sut3[3].icon?.toUrl(false, IconFormat.Svg, 64 )
         )
     }
 


### PR DESCRIPTION
Resolves #3339  

Perform translations to request material and f7 icons from iconify:

material:iconname -> iconify:ic:baseline-iconname
material:set:iconname -> iconify:ic:set-iconname
f7:iconname -> iconify:f7:iconname
