### PR TITLE
Shorten one widget related string

### DIFF
--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -585,7 +585,6 @@
     <string name="item_update_widget_text">%1$s: %2$s</string>
     <!-- Used in the widget preview -->
     <string name="item_update_widget_preview_text">Open garage</string>
-    <string name="widget_show_state">Append current state to name</string>
     <string name="widget_show_state_summary">The state is updated on the schedule that can be set in the settings under \"Send device information to server\"</string>
     <string name="widget_no_command">Don\'t send a command</string>
     <string name="error_getting_state">Error loading state</string>

--- a/mobile/src/main/res/xml/preferences_homescreen_widget.xml
+++ b/mobile/src/main/res/xml/preferences_homescreen_widget.xml
@@ -15,7 +15,8 @@
     <SwitchPreferenceCompat
         android:persistent="false"
         android:key="show_state"
-        android:title="@string/widget_show_state"
+        android:title="@string/create_home_screen_widget_no_command"
+        app:singleLineTitle="false"
         android:summary="@string/widget_show_state_summary"
         android:widgetLayout="@layout/preference_material_switch" />
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Re-use an existing string which is shorter and allow title to use multiple lines.

See screenshot in the forum for current behavior: https://community.openhab.org/t/android-widgets-are-not-showing-addon-values/152912