### PR TITLE
Translate f7 underscores into iconify style dashes

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/IconResource.kt
@@ -28,6 +28,7 @@ import org.openhab.habdroid.util.appendQueryParameter
 import org.openhab.habdroid.util.getIconFormat
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getStringOrNull
+import kotlin.text.replace
 
 @Parcelize
 data class IconResource internal constructor(
@@ -76,6 +77,7 @@ data class IconResource internal constructor(
             "f7" -> {
                 iconSource = "iconify"
                 iconSet = "f7"
+                iconName = iconName.replace("_", "-")
             }
         }
 


### PR DESCRIPTION
f7 icons use underscores. When they're imported into iconify, the underscores became dashes.

When user actually specified `f7:icon_name` it should work without them having to know that we implemented it with iconify.

Alternatively users can use `iconify:f7:icon-name` with dashes.

If they had specified `f7:icon-name` that would still to work too.
