### PR TITLE
Fix flickering snackbar

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractBaseActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractBaseActivity.kt
@@ -69,6 +69,7 @@ abstract class AbstractBaseActivity : AppCompatActivity(), CoroutineScope {
     protected open val forceNonFullscreen = false
     private var authPrompt: AuthPrompt? = null
     private lateinit var coordinator: CoordinatorLayout
+    protected lateinit var layoutForSnackbar: View
     private lateinit var toolbar: MaterialToolbar
     private lateinit var content: View
     lateinit var appBarLayout: AppBarLayout
@@ -107,6 +108,7 @@ abstract class AbstractBaseActivity : AppCompatActivity(), CoroutineScope {
         enableDrawingBehindStatusBar()
 
         coordinator = findViewById(R.id.coordinator)
+        layoutForSnackbar = coordinator
         content = findViewById(R.id.activity_content)
         insetsController = WindowInsetsControllerCompat(window, coordinator)
 
@@ -235,7 +237,7 @@ abstract class AbstractBaseActivity : AppCompatActivity(), CoroutineScope {
             throw IllegalArgumentException("Tag is empty")
         }
 
-        val snackbar = Snackbar.make(coordinator, message, duration)
+        val snackbar = Snackbar.make(layoutForSnackbar, message, duration)
         if (actionResId != 0 && onClickListener != null) {
             snackbar.setAction(actionResId) { onClickListener() }
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -871,6 +871,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
 
     private fun setupDrawer() {
         drawerLayout = findViewById(R.id.drawer_container)
+        layoutForSnackbar = drawerLayout
         drawerToggle = ActionBarDrawerToggle(this, drawerLayout,
             R.string.drawer_open, R.string.drawer_close)
         drawerLayout.addDrawerListener(drawerToggle)


### PR DESCRIPTION
The root view must not set `android:animateLayoutChanges="true"`.

https://github.com/material-components/material-components-android/issues/648

Closes #3393