### PR TITLE
Consider mappings or options for displayed state

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -65,7 +65,11 @@ data class Widget(
     val rawInputHint: InputTypeHint?
 ) : Parcelable {
     val label get() = rawLabel.split("[", "]")[0].trim()
-    val stateFromLabel: String? get() = rawLabel.split("[", "]").getOrNull(1)?.trim()
+    val stateFromLabel: String? get() {
+        val value = rawLabel.split("[", "]").getOrNull(1)?.trim()
+        val optionLabel = mappingsOrItemOptions.find { it.value == value }?.label
+        return optionLabel ?: value
+    }
 
     val mappingsOrItemOptions get() = if (mappings.isEmpty() && item?.options != null) item.options else mappings
 


### PR DESCRIPTION
One use case for this are items bound to channels of type system.signal-strength. Those are number items with a default pattern of %0.f and options mapping the valid values 0..4 to descriptive strings. Show those descriptive strings (e.g. 'Excellent') if available instead of the plain number value ('4').