### PR TITLE
Show charts for all Sitemap widgets

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -277,8 +277,24 @@ class WidgetListFragment :
 
         // Offer widget for all Items. For read-only Items the "Show state" widget is useful.
         if (widget.item != null) {
+            menu.add(
+                Menu.NONE,
+                CONTEXT_MENU_ID_SHOW_CHART,
+                Menu.NONE,
+                R.string.analyse
+            ).setOnMenuItemClickListener {
+                val mainActivity = activity as MainActivity
+                val intent = Intent(mainActivity, ChartWidgetActivity::class.java)
+                intent.putExtra(ChartWidgetActivity.EXTRA_WIDGET, widget)
+                intent.putExtra(ChartWidgetActivity.EXTRA_SERVER_FLAGS, mainActivity.serverProperties?.flags)
+                mainActivity.startActivity(intent)
+                return@setOnMenuItemClickListener true
+            }
+
+
             val widgetMenu = menu.addSubMenu(
-                Menu.NONE, CONTEXT_MENU_ID_CREATE_HOME_SCREEN_WIDGET,
+                Menu.NONE,
+                CONTEXT_MENU_ID_CREATE_HOME_SCREEN_WIDGET,
                 Menu.NONE,
                 R.string.create_home_screen_widget_title
             )
@@ -648,6 +664,7 @@ class WidgetListFragment :
         private const val CONTEXT_MENU_ID_PIN_HOME_BLACK = 1005
         private const val CONTEXT_MENU_ID_OPEN_IN_MAPS = 1006
         private const val CONTEXT_MENU_ID_COPY_ITEM_NAME = 1007
+        private const val CONTEXT_MENU_ID_SHOW_CHART = 1008
         private const val CONTEXT_MENU_ID_WRITE_CUSTOM_TAG = 10000
         private const val CONTEXT_MENU_ID_WRITE_DEVICE_ID = 10001
 

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -633,6 +633,7 @@
     <string name="create_home_screen_widget_title">Create widget</string>
     <string name="create_home_screen_widget_no_command">Show current state</string>
     <string name="create_home_screen_widget_not_supported">Please go to the widget menu on your home screen and create a widget from there</string>
+    <string name="analyse">Analyze</string>
 
     <!-- Data saver -->
     <string name="data_saver_title">Data saver</string>


### PR DESCRIPTION
Add an entry to the context menu that allows showing a chart on a new screen. It's possible to display charts for all Items in Main UI settings and this is quite useful. The word 'Analyze' is also taken from Main UI.

(Screenshot from German device)
![grafik](https://github.com/openhab/openhab-android/assets/22525368/bfb13c68-85ff-4871-8ab6-6624fafe99a8)