### PR TITLE
WebViewUI: Open drawer instead of going back to Sitemaps

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -1368,7 +1368,11 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
     }
 
     fun setDrawerLocked(locked: Boolean) {
-        drawerLayout.isSwipeDisabled = locked
+        drawerLayout.swipeToOpenDisabled = locked
+    }
+
+    fun openDrawer() {
+        drawerLayout.open()
     }
 
     private fun handlePropertyFetchFailure(result: ServerProperties.Companion.PropsFailure) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/AbstractWebViewFragment.kt
@@ -396,8 +396,8 @@ abstract class AbstractWebViewFragment : Fragment(), ConnectionFactory.UpdateLis
         callback?.updateActionBarState()
     }
 
-    private fun closeFragment() {
-        callback?.closeFragment()
+    private fun openDrawer() {
+        callback?.openDrawer()
     }
 
     open class OHAppInterface(private val context: Context, private val fragment: AbstractWebViewFragment) {
@@ -417,7 +417,7 @@ abstract class AbstractWebViewFragment : Fragment(), ConnectionFactory.UpdateLis
         fun exitToApp() {
             Log.d(TAG, "exitToApp()")
             fragment.launch {
-                fragment.closeFragment()
+                fragment.openDrawer()
             }
         }
 
@@ -474,7 +474,7 @@ abstract class AbstractWebViewFragment : Fragment(), ConnectionFactory.UpdateLis
     }
 
     interface ParentCallback {
-        fun closeFragment()
+        fun openDrawer()
 
         fun updateActionBarState()
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
@@ -467,14 +467,8 @@ abstract class ContentController protected constructor(private val activity: Mai
         return false
     }
 
-    override fun closeFragment() {
-        if (temporaryPage != null) {
-            temporaryPage = null
-            activity.updateTitle()
-            updateActionBarState()
-            updateFragmentState(FragmentUpdateReason.PAGE_UPDATE)
-            updateConnectionState()
-        }
+    override fun openDrawer() {
+        activity.openDrawer()
     }
 
     override fun onPageUpdated(pageUrl: String, pageTitle: String?, widgets: List<Widget>) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/LockableDrawerLayout.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/LockableDrawerLayout.kt
@@ -20,10 +20,12 @@ import android.view.MotionEvent
 import androidx.drawerlayout.widget.DrawerLayout
 
 class LockableDrawerLayout(context: Context, attrs: AttributeSet?) : DrawerLayout(context, attrs) {
-    var isSwipeDisabled = false
+    var swipeToOpenDisabled = false
+    private val shouldIgnoreTouch
+        get() = swipeToOpenDisabled && !isOpen
 
     override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
-        if (isSwipeDisabled) {
+        if (shouldIgnoreTouch) {
             return false
         }
         return super.onInterceptTouchEvent(ev)
@@ -31,7 +33,7 @@ class LockableDrawerLayout(context: Context, attrs: AttributeSet?) : DrawerLayou
 
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(ev: MotionEvent): Boolean {
-        if (isSwipeDisabled) {
+        if (shouldIgnoreTouch) {
             return false
         }
         return super.onTouchEvent(ev)


### PR DESCRIPTION
When pressing the 'back to app' button the drawer is opened instead of closing the UI. This way users can switch faster between e.g. MainUI and notifications.