### PR TITLE
Use slim version of super-linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: super-linter/super-linter@v6.4.1
+        uses: super-linter/super-linter/slim@v6.4.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_KOTLIN: true


### PR DESCRIPTION
All required linters are part of the slim variant: https://github.com/super-linter/super-linter?tab=readme-ov-file#super-linter-variants