### PR TITLE
Replace Enum.values() by Enum.entries

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/preference/widgets/CustomInputTypePreference.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/preference/widgets/CustomInputTypePreference.kt
@@ -43,8 +43,8 @@ open class CustomInputTypePreference(context: Context, attrs: AttributeSet) :
             inputType = getInt(0, 0)
             autofillHints = getString(1)?.split(',')?.toTypedArray()
             val whitespaceBehaviorId = getInt(2, 0)
-            whitespaceBehavior = if (whitespaceBehaviorId < WhitespaceBehavior.values().size) {
-                WhitespaceBehavior.values()[whitespaceBehaviorId]
+            whitespaceBehavior = if (whitespaceBehaviorId < WhitespaceBehavior.entries.size) {
+                WhitespaceBehavior.entries[whitespaceBehaviorId]
             } else {
                 WhitespaceBehavior.IGNORE
             }
@@ -114,8 +114,8 @@ open class CustomInputTypePreference(context: Context, attrs: AttributeSet) :
                 }
             }
             val whitespaceBehaviorId = arguments?.getInt(KEY_WHITESPACE_BEHAVIOR, 0) ?: 0
-            whitespaceBehavior = if (whitespaceBehaviorId < WhitespaceBehavior.values().size) {
-                WhitespaceBehavior.values()[whitespaceBehaviorId]
+            whitespaceBehavior = if (whitespaceBehaviorId < WhitespaceBehavior.entries.size) {
+                WhitespaceBehavior.entries[whitespaceBehaviorId]
             } else {
                 WhitespaceBehavior.IGNORE
             }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/WidgetImageView.kt
@@ -68,8 +68,8 @@ class WidgetImageView(context: Context, attrs: AttributeSet?) : AppCompatImageVi
             emptyHeightToWidthRatio = getFraction(R.styleable.WidgetImageView_emptyHeightToWidthRatio, 1, 1, 0f)
             addRandomnessToUrl = getBoolean(R.styleable.WidgetImageView_addRandomnessToUrl, false)
             val imageScalingType = getInt(R.styleable.WidgetImageView_imageScalingType, 0)
-            if (imageScalingType < ImageScalingType.values().size) {
-                setImageScalingType(ImageScalingType.values()[imageScalingType])
+            if (imageScalingType < ImageScalingType.entries.size) {
+                setImageScalingType(ImageScalingType.entries[imageScalingType])
             }
             recycle()
         }

--- a/mobile/src/main/java/org/openhab/habdroid/util/CacheManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/CacheManager.kt
@@ -71,11 +71,11 @@ class CacheManager private constructor(appContext: Context) {
     }
 
     fun removeWidgetIcon(widgetId: Int) {
-        IconFormat.values().forEach { format -> getWidgetIconFile(widgetId, format).delete() }
+        IconFormat.entries.forEach { format -> getWidgetIconFile(widgetId, format).delete() }
     }
 
     fun getWidgetIconFormat(widgetId: Int): IconFormat? {
-        return IconFormat.values()
+        return IconFormat.entries
             .firstOrNull { format -> getWidgetIconFile(widgetId, format).exists() }
     }
 

--- a/mobile/src/test/java/org/openhab/habdroid/model/ItemTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/model/ItemTest.kt
@@ -163,7 +163,7 @@ class ItemTest {
     @Test
     fun tagsHaveLabel() {
         val mustHaveLabel = listOf(Item.Tag.Location, Item.Tag.Equipment)
-        Item.Tag.values()
+        Item.Tag.entries
             .filter { tag -> tag.parent in mustHaveLabel }
             .forEach { tag ->
                 assertNotNull(tag.labelResId)


### PR DESCRIPTION
> Prior to the introduction of entries in Kotlin 1.9.0, the values() function was used to retrieve an array of enum constants.

from https://kotlinlang.org/docs/enum-classes.html#working-with-enum-constants