### PR TITLE
Avoid flicker when opening drawer

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -768,6 +768,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
                         }
                     } else {
                         chooseSitemap()
+                        updateSitemapDrawerEntries()
                     }
                     if (connection !is DemoConnection) {
                         prefs.edit {


### PR DESCRIPTION
Update Sitemaps in drawer when they are fetched. This avoids the flicker when the drawer is opened, because no update happens then (at least if there are no new Sitemaps on the server).