### PR TITLE
Improve SSE error handling

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/DayDream.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/DayDream.kt
@@ -77,11 +77,7 @@ class DayDream : DreamService(), CoroutineScope {
             getString(R.string.screensaver_error_loading_item, item)
         }
 
-        ItemClient.listenForItemChange(
-            this,
-            connection,
-            item
-        ) { _, payload ->
+        ItemClient.listenForItemChange(this, connection, item) { _, payload ->
             val state = payload.getString("value")
             Log.d(TAG, "Got state by event: $state")
             textView.text = state

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -1488,11 +1488,7 @@ class MainActivity : AbstractBaseActivity(), ConnectionFactory.UpdateListener {
     }
 
     private suspend fun listenUiCommandItem(item: String) {
-        ItemClient.listenForItemChange(
-            this,
-            connection ?: return,
-            item
-        ) { _, payload ->
+        ItemClient.listenForItemChange(this, connection ?: return, item) { _, payload ->
             val state = payload.getString("value")
             Log.d(TAG, "Got state by event: $state")
             handleUiCommand(state)


### PR DESCRIPTION
Avoid ANR by not trying to get events from a closed subscription. Instead wait 5 seconds and create a new channel then.