### PR TITLE
Don't cache responses with 0 content length

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.kt
@@ -206,7 +206,7 @@ class HttpClient(client: OkHttpClient, baseUrl: String?, username: String?, pass
                                 HttpException(call.request(), url, response.message, response.code)
                             )
                         }
-                        body == null -> {
+                        body == null || body.contentLength() == 0L -> {
                             cont.resumeWithException(HttpException(call.request(), url, "Empty body", 500))
                         }
                         else -> {


### PR DESCRIPTION
I noticed that myopenhab.org sometimes returns http code 200 for an icon and a valid svg content type, but the content length is 0. In that case, change to http code to 500 to avoid caching.

Fixes #3733