### PR TITLE
Catch more HttpException

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/ImageWidgetActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ImageWidgetActivity.kt
@@ -130,12 +130,17 @@ class ImageWidgetActivity : AbstractBaseActivity() {
             }
         } else {
             val link = intent.getStringExtra(WIDGET_LINK)!!
-            val widgetState = JSONObject(
-                conn.httpClient
-                    .get(link)
-                    .asText()
-                    .response
-            ).getString("state") ?: return finish()
+            val widgetState = try {
+                JSONObject(
+                    conn.httpClient
+                        .get(link)
+                        .asText()
+                        .response
+                ).getString("state") ?: return finish()
+            } catch (e: HttpClient.HttpException) {
+                Log.d(TAG, "Failed to load image", e)
+                return finish()
+            }
 
             if (widgetState.matches("data:image/.*;base64,.*".toRegex())) {
                 Log.d(TAG, "Load image from value")

--- a/mobile/src/main/java/org/openhab/habdroid/util/ItemClient.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ItemClient.kt
@@ -34,6 +34,7 @@ import org.xml.sax.SAXException
 object ItemClient {
     private val TAG = ItemClient::class.java.simpleName
 
+    @Throws(HttpClient.HttpException::class)
     suspend fun loadItems(connection: Connection): List<Item>? {
         val response = connection.httpClient.get("rest/items")
         val contentType = response.response.contentType()
@@ -72,6 +73,7 @@ object ItemClient {
         }
     }
 
+    @Throws(HttpClient.HttpException::class)
     suspend fun loadItem(connection: Connection, itemName: String): Item? {
         val response = connection.httpClient.get("rest/items/$itemName")
         val contentType = response.response.contentType()


### PR DESCRIPTION
I see some crashes due to HttpException in Firebase, but there's no origin visible. This PR adds a few more try/catch blocks around network calls. Let's see if that fixes all crashes.