### PR TITLE
Fix stateFromLabel when label contains square brackets in pattern

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -73,7 +73,7 @@ data class Widget(
 ) : Parcelable {
     val label get() = rawLabel.split("[", "]")[0].trim()
     val stateFromLabel: String? get() {
-        val value = rawLabel.split("[", "]").getOrNull(1)?.trim()
+        val value = Widget.stateLabelRegex.find(rawLabel)?.groupValues?.getOrNull(1)?.trim()
         val optionLabel = mappingsOrItemOptions.find { it.value == value }?.label
         return optionLabel ?: value
     }
@@ -243,6 +243,8 @@ data class Widget(
                 state.toParsedState(item.state?.asNumber?.format)
             else -> state.toParsedState()
         }
+
+        internal val stateLabelRegex = Regex("\\[(.*)\\]$")
     }
 }
 

--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -73,7 +73,7 @@ data class Widget(
 ) : Parcelable {
     val label get() = rawLabel.split("[", "]")[0].trim()
     val stateFromLabel: String? get() {
-        val value = Widget.stateLabelRegex.find(rawLabel)?.groupValues?.getOrNull(1)?.trim()
+        val value = Widget.stateLabelRegex.find(rawLabel)?.groupValues?.getOrNull(1)
         val optionLabel = mappingsOrItemOptions.find { it.value == value }?.label
         return optionLabel ?: value
     }

--- a/mobile/src/test/java/org/openhab/habdroid/model/WidgetTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/model/WidgetTest.kt
@@ -46,7 +46,7 @@ class WidgetTest {
         assertEquals(sutXml.size, 2)
         assertEquals(sut1.size, 2)
         assertEquals(sut2.size, 1)
-        assertEquals(sut3.size, 4)
+        assertEquals(sut3.size, 5)
     }
 
     @Test
@@ -170,6 +170,7 @@ class WidgetTest {
         assertNull(sut1[0].stateFromLabel)
         assertNull(sut2[0].stateFromLabel)
         assertEquals("81 %", sut3[1].stateFromLabel)
+        assertEquals("Value [42]", sut3[4].stateFromLabel)
     }
 
     @Test
@@ -443,6 +444,26 @@ class WidgetTest {
                       'link': 'http://openhab.local:8080/rest/sitemaps/demo/02020002',
                       'leaf': true,
                       'timeout': false
+                    },
+                    'widgets': []
+                  }, {
+                    'widgetId': '0202_0_0_1',
+                    'type': 'Switch',
+                    'label': 'Test [Value [42]]',
+                    'icon': 'input',
+                    'mappings': [],
+                    'item': {
+                      'link': 'http://openhab.local:8080/rest/items/DemoString',
+                      'state': 'Value [42]',
+                      'stateDescription': {
+                          'pattern': '%s',
+                          'readOnly': false,
+                          'options': []
+                      },
+                    'type': 'String',
+                      'name': 'DemoString',
+                      'tags': [],
+                      'groupNames': []
                     },
                     'widgets': []
                   } ]


### PR DESCRIPTION
Fix #3756

The problem was:
- StringItem's state contains `[]`
- Sitemap puts the item's (display) state into the label as `Label [formattedstate]`
- So now we have nested `[]` causing parsing errors when trying to extract the formattedstate from `[mytext with [] in it]`.