### PR TITLE
Fix Buttons not showing when the Buttongrid is inside a Frame

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/WidgetDataSource.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/WidgetDataSource.kt
@@ -41,8 +41,15 @@ class WidgetDataSource() {
             .filter { w -> w.parentId == null }
             .map { w -> w.id }
             .toSet()
-        return allWidgets
-            .filter { w -> w.parentId == null || w.parentId in firstLevelWidgetIds }
+        val secondLevelWidgetIds = allWidgets
+            .filter { w -> w.parentId in firstLevelWidgetIds }
+            .map { w -> w.id }
+            .toSet()
+        return allWidgets.filter { w ->
+            w.parentId == null ||
+                w.parentId in firstLevelWidgetIds ||
+                w.parentId in secondLevelWidgetIds && w.type == Widget.Type.Button
+        }
     }
 
     fun setSourceNode(rootNode: Node?) {


### PR DESCRIPTION
This supports having a buttongrid + buttons inside a frame, because the Buttons are sub-widgets which are normally excluded due to being the grand children of the first level.