### PR TITLE
Allow one level of nested frames in sitemaps

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/WidgetDataSource.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/WidgetDataSource.kt
@@ -41,13 +41,11 @@ class WidgetDataSource {
             .map { w -> w.id }
             .toSet()
         val secondLevelWidgetIds = allWidgets
-            .filter { w -> w.parentId in firstLevelWidgetIds }
+            .filter { w -> w.parentId in firstLevelWidgetIds && w.type in ALLOWED_SECOND_LEVEL_PARENTS }
             .map { w -> w.id }
             .toSet()
         return allWidgets.filter { w ->
-            w.parentId == null ||
-                w.parentId in firstLevelWidgetIds ||
-                w.parentId in secondLevelWidgetIds && w.type == Widget.Type.Button
+            w.parentId == null || w.parentId in (firstLevelWidgetIds + secondLevelWidgetIds)
         }
     }
 
@@ -70,5 +68,6 @@ class WidgetDataSource {
 
     companion object {
         private val TAG = WidgetDataSource::class.java.simpleName
+        private val ALLOWED_SECOND_LEVEL_PARENTS = setOf(Widget.Type.Buttongrid, Widget.Type.Frame)
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/model/WidgetDataSource.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/WidgetDataSource.kt
@@ -45,7 +45,7 @@ class WidgetDataSource {
             .map { w -> w.id }
             .toSet()
         return allWidgets.filter { w ->
-            w.parentId == null || w.parentId in (firstLevelWidgetIds + secondLevelWidgetIds)
+            w.parentId == null || w.parentId in firstLevelWidgetIds || w.parentId in secondLevelWidgetIds
         }
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -52,6 +52,7 @@ import androidx.core.view.get
 import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
+import androidx.core.view.marginStart
 import androidx.core.widget.ContentLoadingProgressBar
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.DialogFragment
@@ -261,7 +262,8 @@ class WidgetAdapter(
             colorMapper,
             serverFlags,
             chartTheme,
-            { widgetsByParentId[widget.id] }
+            { widgetsByParentId[widget.id] },
+            widgetsById[widget.parentId]
         )
         holder.bind(widget)
         if (holder is FrameViewHolder) {
@@ -406,7 +408,8 @@ class WidgetAdapter(
         val colorMapper: ColorMapper,
         val serverFlags: Int,
         val chartTheme: CharSequence?,
-        val childWidgetGetter: () -> List<Widget>?
+        val childWidgetGetter: () -> List<Widget>?,
+        val parentWidget: Widget?
     )
 
     abstract class ViewHolder internal constructor(
@@ -423,6 +426,7 @@ class WidgetAdapter(
         protected val colorMapper get() = requireHolderContext().colorMapper
         protected val fragmentPresenter get() = requireHolderContext().fragmentPresenter
         protected val childWidgets get() = requireHolderContext().childWidgetGetter()
+        protected val parentWidget get() = requireHolderContext().parentWidget
 
         abstract fun bind(widget: Widget)
 
@@ -610,6 +614,9 @@ class WidgetAdapter(
             labelView.text = widget.label + label
             labelView.applyWidgetColor(widget.valueColor, colorMapper)
             labelView.isGone = widget.label.isEmpty()
+            containerView.layoutParams = (containerView.layoutParams as ViewGroup.MarginLayoutParams).apply {
+                marginStart = if (parentWidget?.type == Widget.Type.Frame) marginEnd else 0
+            }
         }
 
         fun setShownAsFirst(shownAsFirst: Boolean) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -606,7 +606,7 @@ class WidgetAdapter(
         private val spacer: View = itemView.findViewById(R.id.first_view_spacer)
         private val originalPaddingTop = containerView.paddingTop
         private val backgroundColorMap =
-            mapOf(false to R.attr.colorPrimaryContainer, true to R.attr.colorSecondaryContainer)
+            mapOf(false to R.attr.colorPrimaryContainer, true to R.attr.colorTertiaryContainer)
                 .mapValues { itemView.context.resolveThemedColor(it.value) }
 
         init {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -53,6 +53,7 @@ import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.core.view.marginStart
+import androidx.core.view.updatePadding
 import androidx.core.widget.ContentLoadingProgressBar
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.DialogFragment
@@ -115,6 +116,7 @@ import org.openhab.habdroid.util.MjpegStreamer
 import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.beautify
 import org.openhab.habdroid.util.determineDataUsagePolicy
+import org.openhab.habdroid.util.dpToPixel
 import org.openhab.habdroid.util.getChartTheme
 import org.openhab.habdroid.util.getIconFallbackColor
 import org.openhab.habdroid.util.getImageWidgetScalingType
@@ -601,6 +603,7 @@ class WidgetAdapter(
         private val labelView: TextView = itemView.findViewById(R.id.widgetlabel)
         private val containerView: View = itemView.findViewById(R.id.container)
         private val spacer: View = itemView.findViewById(R.id.first_view_spacer)
+        private val originalPaddingTop = containerView.paddingTop
 
         init {
             itemView.isClickable = false
@@ -614,8 +617,13 @@ class WidgetAdapter(
             labelView.text = widget.label + label
             labelView.applyWidgetColor(widget.valueColor, colorMapper)
             labelView.isGone = widget.label.isEmpty()
-            containerView.layoutParams = (containerView.layoutParams as ViewGroup.MarginLayoutParams).apply {
-                marginStart = if (parentWidget?.type == Widget.Type.Frame) marginEnd else 0
+            val isNested = parentWidget?.type == Widget.Type.Frame
+
+            val paddingTop = if (isNested) 0 else originalPaddingTop
+            containerView.updatePadding(top = paddingTop, bottom = paddingTop)
+
+            labelView.layoutParams = (labelView.layoutParams as ViewGroup.MarginLayoutParams).apply {
+                marginStart = if (isNested) labelView.resources.dpToPixel(8f).toInt() else 0
             }
         }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetAdapter.kt
@@ -19,6 +19,7 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.res.ColorStateList
 import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
 import android.text.InputType.TYPE_CLASS_NUMBER
 import android.text.InputType.TYPE_CLASS_TEXT
 import android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL
@@ -604,6 +605,9 @@ class WidgetAdapter(
         private val containerView: View = itemView.findViewById(R.id.container)
         private val spacer: View = itemView.findViewById(R.id.first_view_spacer)
         private val originalPaddingTop = containerView.paddingTop
+        private val backgroundColorMap =
+            mapOf(false to R.attr.colorPrimaryContainer, true to R.attr.colorSecondaryContainer)
+                .mapValues { itemView.context.resolveThemedColor(it.value) }
 
         init {
             itemView.isClickable = false
@@ -621,6 +625,8 @@ class WidgetAdapter(
 
             val paddingTop = if (isNested) 0 else originalPaddingTop
             containerView.updatePadding(top = paddingTop, bottom = paddingTop)
+
+            backgroundColorMap[isNested]?.let { (containerView.background as GradientDrawable).setColor(it) }
 
             labelView.layoutParams = (labelView.layoutParams as ViewGroup.MarginLayoutParams).apply {
                 marginStart = if (isNested) labelView.resources.dpToPixel(8f).toInt() else 0

--- a/mobile/src/main/res/drawable/frame_nested_chip_background.xml
+++ b/mobile/src/main/res/drawable/frame_nested_chip_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:topRightRadius="16dp" android:bottomRightRadius="16dp" />
+    <solid android:color="?attr/colorTertiaryContainer" />
+</shape>

--- a/mobile/src/main/res/layout/widgetlist_frameitem_nested.xml
+++ b/mobile/src/main/res/layout/widgetlist_frameitem_nested.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.legacy.widget.Space
+        android:id="@+id/first_view_spacer"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:visibility="gone" />
+
+    <FrameLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="4dp"
+        android:layout_marginEnd="16dp"
+        android:paddingHorizontal="16dp"
+        android:background="@drawable/frame_nested_chip_background">
+
+        <TextView
+            android:id="@+id/widgetlabel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:paddingVertical="8dp"
+            android:maxLines="2"
+            android:ellipsize="end"
+            android:textAppearance="?attr/textAppearanceTitleSmall"
+            android:textColor="?attr/colorOnTertiaryContainer"
+            tools:text="Frame title" />
+
+    </FrameLayout>
+
+</FrameLayout>

--- a/mobile/src/main/res/layout/widgetlist_frameitem_nested_compact.xml
+++ b/mobile/src/main/res/layout/widgetlist_frameitem_nested_compact.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.legacy.widget.Space
+        android:id="@+id/first_view_spacer"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:visibility="gone" />
+
+    <FrameLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="4dp"
+        android:layout_marginEnd="16dp"
+        android:paddingVertical="4dp"
+        android:paddingHorizontal="16dp"
+        android:background="@drawable/frame_nested_chip_background">
+
+        <TextView
+            android:id="@+id/widgetlabel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:maxLines="2"
+            android:ellipsize="end"
+            android:textAppearance="?attr/textAppearanceTitleSmall"
+            android:textColor="?attr/colorOnTertiaryContainer"
+            tools:text="Frame title" />
+
+    </FrameLayout>
+
+</FrameLayout>


### PR DESCRIPTION
<img width="319" alt="image" src="https://github.com/user-attachments/assets/81af47fd-4d38-4ac0-a985-91260b2a20d2">

```
sitemap nestedframe {
  Frame label="outer" {
    Frame label="inner1" {
      Text label="Text inside inner1"
    }
    Frame label="inner2" {
      Text label="Text inside inner2"
    }
  }
  Frame label="outer too" {
    Text label="Inside outer too"
  }
}
```

I learned that nested frames aren't "supposed" to be supported, but BasicUI and iOS renders them, whilst Android doesn't.

Here, I propose to render nested frames, and also provide a visual clue for the nesting structure by using `colorTertiaryContainer`, indenting the header text and reduce the header bg's height/padding, as suggested by @maniac103 

Resolve #324, #1639, #2804
Also [#420 ](https://github.com/openhab/openhab-webui/issues/420)


