### PR TITLE
Fix notifications without message

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/CloudNotification.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/CloudNotification.kt
@@ -133,7 +133,7 @@ fun JSONObject.toCloudMessage(): CloudMessage? {
             CloudMessage.CloudNotification(
                 id = id,
                 title = payload?.optString("title").orEmpty(),
-                message = payload?.getString("message") ?: getString("message"),
+                message = payload?.optString("message", "") ?: getString("message"),
                 createdTimestamp = created,
                 icon = (payload?.optStringOrNull("icon") ?: optStringOrNull("icon")).toIconResource(),
                 tag = tag,


### PR DESCRIPTION
I personally use only the title for most notifications, so I discovered a crash when using the following code to create a notification:

```js
actions.notificationBuilder()
.withTitle("foo")
.send();
```

There's no message passed to `notificationBuilder()`. In this case, handle it like an empty string as message.