### PR TITLE
Don't truncate widget values

### DIFF
--- a/mobile/src/main/res/layout/widgetlist_iconvaluetext.xml
+++ b/mobile/src/main/res/layout/widgetlist_iconvaluetext.xml
@@ -35,7 +35,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textDirection="anyRtl"
-            android:maxLines="3"
             android:textAppearance="?attr/textAppearanceBodyMedium"
             tools:text="Widget value" />
 


### PR DESCRIPTION
The widget value is capped to 3 lines, which might not be enough space for some Text items with longer text, e.g. weather warnings (https://www.openhab.org/addons/bindings/dwdunwetter/). I don't see a reason why the value should be truncated.

This only applies to the default layout. For the compact layout, it's still limited to one line.