### PR TITLE
Clear default button icon tint

### DIFF
--- a/mobile/src/main/res/layout/widgetlist_sectionswitchitem_button.xml
+++ b/mobile/src/main/res/layout/widgetlist_sectionswitchitem_button.xml
@@ -16,4 +16,6 @@
     tools:layout_width="wrap_content"
     app:iconGravity="textStart"
     app:iconPadding="0dp"
+    app:iconTint="@android:color/white"
+    app:iconTintMode="multiply"
     tools:text="Action 1" />

--- a/mobile/src/main/res/layout/widgetlist_sectionswitchitem_button_compact.xml
+++ b/mobile/src/main/res/layout/widgetlist_sectionswitchitem_button_compact.xml
@@ -14,4 +14,6 @@
     app:toggleCheckedStateOnClick="false"
     app:iconGravity="textStart"
     app:iconPadding="0dp"
+    app:iconTint="@android:color/white"
+    app:iconTintMode="multiply"
     tools:text="Action 1" />


### PR DESCRIPTION
That tint overwrote both the icon coloring and the iconcolor attribute.

Fixes #3815