### PR TITLE
Refactor connection handling for API 31+

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -211,10 +211,10 @@ class ConnectionFactory internal constructor(
             activeConn = loadServerConnections(activeServer)
 
             val primaryServer = prefs.getPrimaryServerId()
-            if (primaryServer == activeServer) {
-                primaryConn = activeConn
+            primaryConn = if (primaryServer == activeServer) {
+                activeConn
             } else {
-                primaryConn = loadServerConnections(primaryServer)
+                loadServerConnections(primaryServer)
             }
 
             updateState(callListenersImmediately, null, null, null)

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -16,6 +16,7 @@
 package org.openhab.habdroid.core.connection
 
 import android.app.Activity
+import android.app.Application
 import android.content.Context
 import android.content.SharedPreferences
 import android.net.NetworkCapabilities
@@ -66,7 +67,7 @@ import org.openhab.habdroid.util.isDemoModeEnabled
  * (see the constants in [Connection]).
  */
 class ConnectionFactory internal constructor(
-    private val context: Context,
+    private val context: Application,
     private val prefs: SharedPreferences,
     private val secretPrefs: SharedPreferences,
     private val connectionHelper: ConnectionManagerHelper
@@ -560,17 +561,19 @@ class ConnectionFactory internal constructor(
         )
         private val CLIENT_CERT_UPDATE_TRIGGERING_PREFIXES = listOf(PrefKeys.SSL_CLIENT_CERT_PREFIX)
 
-        @VisibleForTesting lateinit var instance: ConnectionFactory
+        @VisibleForTesting
+        lateinit var instance: ConnectionFactory
 
-        fun initialize(ctx: Context) {
+        fun initialize(ctx: Application) {
             instance = ConnectionFactory(ctx, ctx.getPrefs(), ctx.getSecretPrefs(), ConnectionManagerHelper.create(ctx))
             instance.launch {
+                instance.connectionHelper.start()
                 instance.updateConnections()
             }
         }
 
         @VisibleForTesting
-        fun initialize(ctx: Context, prefs: SharedPreferences, connectionHelper: ConnectionManagerHelper) {
+        fun initialize(ctx: Application, prefs: SharedPreferences, connectionHelper: ConnectionManagerHelper) {
             instance = ConnectionFactory(ctx, prefs, prefs, connectionHelper)
         }
 

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -47,12 +47,10 @@ import okhttp3.OkHttpClient
 import okhttp3.internal.tls.OkHostnameVerifier
 import okhttp3.logging.HttpLoggingInterceptor
 import org.openhab.habdroid.core.CloudMessagingHelper
-import org.openhab.habdroid.core.OpenHabApplication
 import org.openhab.habdroid.model.ServerConfiguration
 import org.openhab.habdroid.util.CacheManager
 import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.getActiveServerId
-import org.openhab.habdroid.util.getCurrentWifiSsid
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getPrimaryServerId
 import org.openhab.habdroid.util.getSecretPrefs
@@ -422,27 +420,37 @@ class ConnectionFactory internal constructor(
         }
 
         var hasWrongWifi = false
+        val restrictedSsids = ServerConfiguration.load(prefs, secretPrefs, prefs.getActiveServerId())?.let { config ->
+            if (config.restrictToWifiSsids) config.wifiSsids else null
+        }
 
         if (local != null && local is DefaultConnection) {
             val localCandidates = available.filter { type ->
-                type is ConnectionManagerHelper.ConnectionType.Wifi ||
-                    type is ConnectionManagerHelper.ConnectionType.Bluetooth ||
-                    type is ConnectionManagerHelper.ConnectionType.Ethernet ||
-                    type is ConnectionManagerHelper.ConnectionType.Vpn
+                when (type) {
+                    is ConnectionManagerHelper.ConnectionType.Wifi -> {
+                        val ssid = type.fetchSsid(context)
+                        when {
+                            ssid.isNullOrEmpty() -> true // assume missing permissions
+                            restrictedSsids?.contains(ssid) == true -> {
+                                Log.d(TAG, "Skip Wi-Fi ${type.network} (server restricted to $restrictedSsids)")
+                                hasWrongWifi = true
+                                false
+                            }
+                            else -> true
+                        }
+                    }
+                    is ConnectionManagerHelper.ConnectionType.Bluetooth -> true
+                    is ConnectionManagerHelper.ConnectionType.Ethernet -> true
+                    is ConnectionManagerHelper.ConnectionType.Vpn -> true
+                    else -> false
+                }
             }
-            for (type in localCandidates) {
-                if (type is ConnectionManagerHelper.ConnectionType.Wifi && !serverMayUseWifi()) {
-                    Log.d(TAG, "Don't use current Wi-Fi because server is restricted to other Wi-Fis")
-                    hasWrongWifi = true
-                    continue
-                }
-
-                if (local.isReachableViaNetwork(type.network)) {
-                    Log.d(TAG, "Connecting to local URL via $type")
-                    local.network = type.network
-                    local.isMetered = !type.caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
-                    return local
-                }
+            val usableLocalNetwork = localCandidates.firstOrNull { local.isReachableViaNetwork(it.network) }
+            if (usableLocalNetwork != null) {
+                Log.d(TAG, "Connecting to local URL via $usableLocalNetwork")
+                local.network = usableLocalNetwork.network
+                local.isMetered = !usableLocalNetwork.caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+                return local
             }
         }
 
@@ -462,25 +470,6 @@ class ConnectionFactory internal constructor(
         }
 
         throw if (hasWrongWifi) WrongWifiException() else NoUrlInformationException(true)
-    }
-
-    private fun serverMayUseWifi(): Boolean {
-        val activeServerId = prefs.getActiveServerId()
-        val serverPrefs = ServerConfiguration.load(prefs, secretPrefs, activeServerId) ?: return true
-
-        if (!serverPrefs.restrictToWifiSsids) {
-            Log.d(TAG, "Server ${serverPrefs.name} isn't restricted to Wi-Fis")
-            return true
-        }
-
-        val currentSsid = context.getCurrentWifiSsid(OpenHabApplication.DATA_ACCESS_TAG_SELECT_SERVER_WIFI)
-
-        if (currentSsid.isNullOrEmpty()) {
-            Log.d(TAG, "Got SSID '$currentSsid'. Assume missing permissions.")
-            return false
-        }
-
-        return serverPrefs.wifiSsids?.contains(currentSsid) == true
     }
 
     private class ClientKeyManager(context: Context, private val alias: String?) : X509KeyManager {

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionManagerHelper.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionManagerHelper.kt
@@ -13,7 +13,6 @@
 
 package org.openhab.habdroid.core.connection
 
-import android.annotation.TargetApi
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -25,6 +24,8 @@ import android.net.NetworkCapabilities.NET_CAPABILITY_FOREGROUND
 import android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET
 import android.net.NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED
 import android.net.NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED
+import android.net.NetworkCapabilities.NET_CAPABILITY_NOT_VPN
+import android.net.NetworkCapabilities.NET_CAPABILITY_TRUSTED
 import android.net.NetworkCapabilities.NET_CAPABILITY_VALIDATED
 import android.net.NetworkCapabilities.TRANSPORT_BLUETOOTH
 import android.net.NetworkCapabilities.TRANSPORT_CELLULAR
@@ -32,12 +33,19 @@ import android.net.NetworkCapabilities.TRANSPORT_ETHERNET
 import android.net.NetworkCapabilities.TRANSPORT_VPN
 import android.net.NetworkCapabilities.TRANSPORT_WIFI
 import android.net.NetworkCapabilities.TRANSPORT_WIFI_AWARE
+import android.net.NetworkRequest
+import android.net.wifi.WifiInfo
 import android.os.Build
+import androidx.annotation.RequiresApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.openhab.habdroid.core.OpenHabApplication
+import org.openhab.habdroid.core.connection.ConnectionManagerHelper.ConnectionType
+import org.openhab.habdroid.util.extractWifiSsid
+import org.openhab.habdroid.util.getCurrentWifiSsid
 import org.openhab.habdroid.util.registerExportedReceiver
 
 typealias ConnectionChangedCallback = () -> Unit
@@ -46,6 +54,7 @@ interface ConnectionManagerHelper {
     val currentConnections: List<ConnectionType>
     var changeCallback: ConnectionChangedCallback?
 
+    fun start()
     fun shutdown()
 
     sealed class ConnectionType(val network: Network, val caps: NetworkCapabilities) {
@@ -59,7 +68,13 @@ interface ConnectionManagerHelper {
 
         class Vpn(network: Network, caps: NetworkCapabilities) : ConnectionType(network, caps)
 
-        class Wifi(network: Network, caps: NetworkCapabilities) : ConnectionType(network, caps)
+        class Wifi(network: Network, caps: NetworkCapabilities) : ConnectionType(network, caps) {
+            fun fetchSsid(context: Context) = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                (caps.transportInfo as? WifiInfo)?.ssid?.extractWifiSsid()
+            } else {
+                context.getCurrentWifiSsid(OpenHabApplication.DATA_ACCESS_TAG_SERVER_DISCOVERY)
+            }
+        }
 
         override fun toString() = "ConnectionType(type = ${javaClass.simpleName}, network=$network)"
     }
@@ -67,31 +82,37 @@ interface ConnectionManagerHelper {
     companion object {
         fun create(context: Context): ConnectionManagerHelper = when (Build.VERSION.SDK_INT) {
             in 21..25 -> HelperApi21(context)
-            else -> HelperApi26(context)
+            in 26..30 -> HelperApi26(context)
+            else -> HelperApi31(context)
         }
     }
 
     private class HelperApi21(context: Context) :
         ChangeCallbackHelperApi21(context),
         ConnectionManagerHelper {
-        private val typeHelper = NetworkTypeHelper(context)
+        private val typeHelper = NetworkTypeHelperApi21(context)
         override val currentConnections: List<ConnectionType> get() = typeHelper.currentConnections
     }
 
-    @TargetApi(26)
+    @RequiresApi(26)
     private class HelperApi26(context: Context) :
         ChangeCallbackHelperApi26(context),
         ConnectionManagerHelper {
-        private val typeHelper = NetworkTypeHelper(context)
+        private val typeHelper = NetworkTypeHelperApi21(context)
         override val currentConnections: List<ConnectionType> get() = typeHelper.currentConnections
     }
+
+    @RequiresApi(31)
+    private class HelperApi31(context: Context) :
+        NetworkTypeHelperApi31(context),
+        ConnectionManagerHelper
 
     private open class ChangeCallbackHelperApi21(context: Context) : BroadcastReceiver() {
         var changeCallback: ConnectionChangedCallback? = null
         private val context = context.applicationContext
-        private var ignoreNextBroadcast: Boolean
+        private var ignoreNextBroadcast = false
 
-        init {
+        fun start() {
             @Suppress("DEPRECATION")
             val filter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
             // Make sure to ignore the initial sticky broadcast, as we're only interested in changes
@@ -112,14 +133,14 @@ interface ConnectionManagerHelper {
         }
     }
 
-    @TargetApi(26)
+    @RequiresApi(26)
     private open class ChangeCallbackHelperApi26(context: Context) : ConnectivityManager.NetworkCallback() {
         var changeCallback: ConnectionChangedCallback? = null
         private val connectivityManager = context.getSystemService(ConnectivityManager::class.java)!!
         private val lastKnownCaps = HashMap<Network, NetworkCapabilities>()
         private var callbackJob: Job? = null
 
-        init {
+        fun start() {
             connectivityManager.registerDefaultNetworkCallback(this)
         }
 
@@ -165,32 +186,91 @@ interface ConnectionManagerHelper {
         }
     }
 
-    private class NetworkTypeHelper(context: Context) {
+    private class NetworkTypeHelperApi21(context: Context) {
         private val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         val currentConnections: List<ConnectionType> get() {
-            // TODO: Replace deprecated function
             @Suppress("DEPRECATION")
             return connectivityManager.allNetworks
                 .map { network -> network to connectivityManager.getNetworkCapabilities(network) }
                 .filter { (_, caps) -> caps?.isUsable() == true }
                 // nullable cast is safe, since null caps are filtered out above
-                .map { (network, caps) -> network to caps!! }
-                .map { (network, caps) ->
-                    when {
-                        caps.hasTransport(TRANSPORT_VPN) -> ConnectionType.Vpn(network, caps)
-                        caps.hasTransport(TRANSPORT_WIFI) ||
-                            caps.hasTransport(TRANSPORT_WIFI_AWARE) -> ConnectionType.Wifi(network, caps)
-                        caps.hasTransport(TRANSPORT_BLUETOOTH) -> ConnectionType.Bluetooth(network, caps)
-                        caps.hasTransport(TRANSPORT_ETHERNET) -> ConnectionType.Ethernet(network, caps)
-                        caps.hasTransport(TRANSPORT_CELLULAR) -> ConnectionType.Mobile(network, caps)
-                        else -> ConnectionType.Unknown(network, caps)
-                    }
+                .associate { (network, caps) -> network to caps!! }
+                .toMap()
+                .toConnectionTypeList()
+        }
+    }
+
+    @RequiresApi(31)
+    private open class NetworkTypeHelperApi31(context: Context) :
+        ConnectivityManager.NetworkCallback(FLAG_INCLUDE_LOCATION_INFO) {
+        var changeCallback: ConnectionChangedCallback? = null
+        private val networkCapsMap = mutableMapOf<Network, NetworkCapabilities>()
+        private val connectivityManager = context.getSystemService(ConnectivityManager::class.java)
+        val currentConnections: List<ConnectionType> get() = networkCapsMap.toConnectionTypeList()
+        private var callbackJob: Job? = null
+
+        fun start() {
+            val request = NetworkRequest.Builder()
+                // Capability set used here needs to stay in sync with isUsable() below
+                .addCapability(NET_CAPABILITY_INTERNET)
+                .addCapability(NET_CAPABILITY_NOT_RESTRICTED)
+                .addCapability(NET_CAPABILITY_FOREGROUND)
+                .addCapability(NET_CAPABILITY_NOT_SUSPENDED)
+                .removeCapability(NET_CAPABILITY_NOT_VPN)
+                .removeCapability(NET_CAPABILITY_TRUSTED)
+                .build()
+            connectivityManager.registerNetworkCallback(request, this)
+        }
+
+        fun shutdown() {
+            callbackJob?.cancel()
+            connectivityManager.unregisterNetworkCallback(this)
+        }
+
+        override fun onLost(network: Network) {
+            val caps = networkCapsMap.remove(network)
+            if (caps?.isUsable() == true) {
+                scheduleCallback()
+            }
+            super.onLost(network)
+        }
+
+        override fun onCapabilitiesChanged(network: Network, caps: NetworkCapabilities) {
+            if (caps.isUsable()) {
+                if (networkCapsMap.put(network, caps) == null) {
+                    scheduleCallback()
                 }
+            } else {
+                if (networkCapsMap.remove(network) != null) {
+                    scheduleCallback()
+                }
+            }
+        }
+
+        private fun scheduleCallback() {
+            callbackJob?.cancel()
+            callbackJob = GlobalScope.launch(Dispatchers.Main) {
+                delay(500)
+                changeCallback?.invoke()
+            }
         }
     }
 }
 
+fun Map<Network, NetworkCapabilities>.toConnectionTypeList() = map { (network, caps) ->
+    when {
+        caps.hasTransport(TRANSPORT_VPN) -> ConnectionType.Vpn(network, caps)
+        caps.hasTransport(TRANSPORT_WIFI) ||
+            caps.hasTransport(TRANSPORT_WIFI_AWARE) -> ConnectionType.Wifi(network, caps)
+        caps.hasTransport(TRANSPORT_BLUETOOTH) -> ConnectionType.Bluetooth(network, caps)
+        caps.hasTransport(TRANSPORT_ETHERNET) -> ConnectionType.Ethernet(network, caps)
+        caps.hasTransport(TRANSPORT_CELLULAR) -> ConnectionType.Mobile(network, caps)
+        else -> ConnectionType.Unknown(network, caps)
+    }
+}
+
 fun NetworkCapabilities.isUsable(): Boolean {
+    // Note: checks here need to stay in sync with NetworkTypeHelperApi31
     if (!hasCapability(NET_CAPABILITY_INTERNET) || !hasCapability(NET_CAPABILITY_NOT_RESTRICTED)) {
         return false
     }

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/DefaultConnection.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/DefaultConnection.kt
@@ -19,7 +19,9 @@ import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.net.SocketTimeoutException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import org.openhab.habdroid.model.ServerPath
@@ -42,7 +44,9 @@ open class DefaultConnection : AbstractConnection {
         Log.d(TAG, "Checking reachability of $baseUrl (via $network)")
         val url = baseUrl.toHttpUrl()
         val s = createConnectedSocket(InetSocketAddress(url.host, url.port), network)
-        s?.close()
+        withContext(Dispatchers.IO) {
+            s?.close()
+        }
         return s != null
     }
 
@@ -53,8 +57,10 @@ open class DefaultConnection : AbstractConnection {
         var retries = 0
         while (retries < 10) {
             try {
-                s.connect(socketAddress, 1000)
-                Log.d(TAG, "Socket connected (attempt  $retries)")
+                withContext(Dispatchers.IO) {
+                    s.connect(socketAddress, 1000)
+                }
+                Log.d(TAG, "Socket connected (attempt $retries)")
                 return s
             } catch (e: SocketTimeoutException) {
                 Log.d(TAG, "Socket timeout after $retries retries")

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -320,6 +320,10 @@ class MainActivity :
 
         updateDrawerServerEntries()
         onActiveConnectionChanged()
+        // Make sure the connection to be used is up-to-date. There can be scenarios where the current connection
+        // is e.g. a remote one just because the local server lookup timed out for whatever reason when we were last
+        // started, and the user might have done changes to fix those timeouts since that time.
+        ConnectionFactory.restartNetworkCheck()
 
         if (connection != null && serverProperties == null) {
             controller.clearServerCommunicationFailure()

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -559,12 +559,19 @@ fun Activity.applyUserSelectedTheme() {
     }
 }
 
+fun String.extractWifiSsid(): String? {
+    if (this == WifiManager.UNKNOWN_SSID) {
+        return null
+    }
+    return this.removeSurrounding("\"")
+}
+
 fun Context.getCurrentWifiSsid(attributionTag: String): String? {
     val wifiManager = getWifiManager(attributionTag)
     // TODO: Replace deprecated function
     @Suppress("DEPRECATION")
-    return wifiManager.connectionInfo.let { info ->
-        if (info.networkId == -1) null else info.ssid.removeSurrounding("\"")
+    return wifiManager.connectionInfo?.let { info ->
+        if (info.networkId == -1) null else info.ssid.extractWifiSsid()
     }
 }
 

--- a/mobile/src/test/java/org/openhab/habdroid/core/connection/ConnectionFactoryTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/core/connection/ConnectionFactoryTest.kt
@@ -14,7 +14,6 @@
 package org.openhab.habdroid.core.connection
 
 import android.app.Application
-import android.content.Context
 import android.content.SharedPreferences
 import android.net.Network
 import android.net.NetworkCapabilities
@@ -78,7 +77,7 @@ class ConnectionFactoryTest {
     @JvmField
     val retry = RetryRule()
 
-    private lateinit var mockContext: Context
+    private lateinit var mockContext: Application
     private lateinit var mockPrefs: SharedPreferences
     private lateinit var mockNetwork: Network
     private lateinit var mockNetworkCaps: NetworkCapabilities

--- a/mobile/src/test/java/org/openhab/habdroid/core/connection/ConnectionFactoryTest.kt
+++ b/mobile/src/test/java/org/openhab/habdroid/core/connection/ConnectionFactoryTest.kt
@@ -14,9 +14,11 @@
 package org.openhab.habdroid.core.connection
 
 import android.app.Application
+import android.content.Context
 import android.content.SharedPreferences
 import android.net.Network
 import android.net.NetworkCapabilities
+import android.net.wifi.WifiManager
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.doAnswer
@@ -77,6 +79,7 @@ class ConnectionFactoryTest {
     @JvmField
     val retry = RetryRule()
 
+    private lateinit var mockWifiManager: WifiManager
     private lateinit var mockContext: Application
     private lateinit var mockPrefs: SharedPreferences
     private lateinit var mockNetwork: Network
@@ -93,12 +96,19 @@ class ConnectionFactoryTest {
             on { getStringSet(eq(PrefKeys.SERVER_IDS), anyOrNull()) } doReturn setOf("1")
             on { getInt(eq(PrefKeys.ACTIVE_SERVER_ID), any()) } doReturn 1
         }
+
+        mockWifiManager = mock {
+        }
+        @Suppress("DEPRECATION")
+        whenever(mockWifiManager.connectionInfo) doReturn null
+
         mockContext = mock<Application> {
             on { cacheDir } doReturn cacheFolder
             on { getDir(any(), any()) } doAnswer { invocation ->
                 File(appDir, invocation.getArgument<Any>(0).toString())
             }
             on { getString(any()) } doReturn ""
+            on { getSystemService(Context.WIFI_SERVICE) } doReturn mockWifiManager
         }
         whenever(mockContext.applicationContext) doReturn mockContext
 
@@ -277,6 +287,7 @@ class ConnectionFactoryTest {
             changeCallback?.invoke()
         }
 
+        override fun start() {}
         override fun shutdown() {}
     }
 


### PR DESCRIPTION
Use non-deprecated functions, and restart connection check in `MainActivity.onStart()`.