### PR TITLE
Increase notification API page size

### DIFF
--- a/mobile/src/foss/java/org/openhab/habdroid/core/CloudMessagingHelper.kt
+++ b/mobile/src/foss/java/org/openhab/habdroid/core/CloudMessagingHelper.kt
@@ -26,6 +26,7 @@ import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.core.connection.NotACloudServerException
 import org.openhab.habdroid.model.CloudMessage
 import org.openhab.habdroid.model.toCloudMessage
+import org.openhab.habdroid.ui.CloudNotificationListFragment
 import org.openhab.habdroid.ui.preference.PushNotificationStatus
 import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.PrefKeys
@@ -65,7 +66,7 @@ object CloudMessagingHelper {
     }
 
     private suspend fun loadNewMessages(context: Context, connection: Connection): List<CloudMessage>? {
-        val url = "api/v1/notifications?limit=20"
+        val url = "api/v1/notifications?limit=${CloudNotificationListFragment.PAGE_SIZE}"
         val messages = try {
             val response = connection.httpClient.get(url).asText().response
             Log.d(TAG, "Notifications request success")

--- a/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationListFragment.kt
@@ -210,9 +210,9 @@ class CloudNotificationListFragment : Fragment(), View.OnClickListener, SwipeRef
     }
 
     companion object {
-        private val TAG = CloudNotificationListFragment::class.java.simpleName
+        const val PAGE_SIZE = 50
 
-        private const val PAGE_SIZE = 20
+        private val TAG = CloudNotificationListFragment::class.java.simpleName
 
         fun newInstance(highlightedId: String?, primaryServer: Boolean): CloudNotificationListFragment {
             val f = CloudNotificationListFragment()


### PR DESCRIPTION
Now notifications can be hidden by other notifications which might require that fetching 20 notifications isn't enough to fill one page. Thus increase the page size to 50.

Also see #3837