### PR TITLE
WorkManager: cancel after reboot

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/BackgroundTasksManager.kt
@@ -132,6 +132,7 @@ class BackgroundTasksManager : BroadcastReceiver() {
             }
             Intent.ACTION_BOOT_COMPLETED -> {
                 Log.d(TAG, "Boot completed")
+                WorkManager.getInstance(context).cancelAllWorkByTag(WORKER_TAG_ITEM_UPLOADS)
                 KNOWN_KEYS.forEach { key -> scheduleWorker(context, key, true) }
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                     for (tileId in 1..AbstractTileService.TILE_COUNT) {


### PR DESCRIPTION
It doesn't seem correct to send Item updates that have been triggered before a reboot.
Other background tasks are enqueued again anyway, so this should only cancel widgets, NFC and Tasker.

Closes #3859