### PR TITLE
Fix NPE in WorkManager

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -6,7 +6,7 @@ def isFoss = taskRequests.contains("Foss") || taskRequests.contains("foss")
 buildscript {
     ext.kotlin_coroutines_version = '1.8.1'
     ext.ok_http_version = '4.12.0'
-    ext.work_manager_version = '2.10.0'
+    ext.work_manager_version = '2.9.0'
     ext.about_libraries_version = '11.2.3'
     ext.powermock_version = '2.0.9'
     ext.espresso_version = '3.6.1'


### PR DESCRIPTION
Seems to be a bug in latest WorkManager version:

```
java.lang.NullPointerException: null cannot be cast to non-null type kotlin.String
    at androidx.work.Data$getStringArray$$inlined$getTypedArray$1.invoke(Data_.kt:65)
    at androidx.work.Data$getStringArray$$inlined$getTypedArray$1.invoke(Data_.kt:65)
    at androidx.work.Data.getStringArray(Data_.kt:185)
    at org.openhab.habdroid.background.ItemUpdateWorkerKt.getValueWithInfo(ItemUpdateWorker.kt:411)
    at org.openhab.habdroid.background.ItemUpdateWorker.doWork(ItemUpdateWorker.kt:76)
    at androidx.work.CoroutineWorker$startWork$1.invokeSuspend(CoroutineWorker.kt:67)
    at androidx.work.CoroutineWorker$startWork$1.invoke(Unknown Source:8)
    at androidx.work.CoroutineWorker$startWork$1.invoke(Unknown Source:4)
```