### PR TITLE
Add interactive chart activity

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -186,6 +186,8 @@ dependencies {
     implementation "com.mikepenz:aboutlibraries-core:$about_libraries_version"
     implementation "com.mikepenz:aboutlibraries:$about_libraries_version"
 
+    implementation "com.github.AppDevNext:AndroidChart:3.1.0.26"
+
     // Firebase
     implementation platform("com.google.firebase:firebase-bom:33.7.0")
     fullImplementation "com.google.firebase:firebase-messaging-ktx"

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -105,6 +105,10 @@
             android:label="@string/log"
             android:exported="false" />
         <activity
+            android:name=".ui.ChartImageActivity"
+            android:label="@string/chart_activity_title"
+            android:exported="false" />
+        <activity
             android:name=".ui.ChartWidgetActivity"
             android:label="@string/chart_activity_title"
             android:exported="false" />

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ChartImageActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ChartImageActivity.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.openhab.habdroid.ui
+
+import android.content.res.Configuration
+import android.os.Bundle
+import android.util.Log
+import android.view.Menu
+import android.view.MenuItem
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import org.openhab.habdroid.R
+import org.openhab.habdroid.core.connection.Connection
+import org.openhab.habdroid.core.connection.ConnectionFactory
+import org.openhab.habdroid.model.Item
+import org.openhab.habdroid.model.Widget
+import org.openhab.habdroid.ui.widget.WidgetImageView
+import org.openhab.habdroid.util.ScreenLockMode
+import org.openhab.habdroid.util.determineDataUsagePolicy
+import org.openhab.habdroid.util.getChartTheme
+import org.openhab.habdroid.util.getPrefs
+import org.openhab.habdroid.util.orDefaultIfEmpty
+import org.openhab.habdroid.util.parcelable
+
+class ChartImageActivity :
+    AbstractBaseActivity(),
+    SwipeRefreshLayout.OnRefreshListener {
+    private lateinit var swipeLayout: SwipeRefreshLayout
+    private lateinit var chart: WidgetImageView
+    private lateinit var period: String
+    private lateinit var widget: Widget
+    private lateinit var chartTheme: CharSequence
+    private var connection: Connection? = null
+
+    private var serverFlags: Int = 0
+    private var density: Int = 0
+    private var showLegend: Boolean = true
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(R.layout.activity_chartimage)
+
+        widget = intent.parcelable(EXTRA_WIDGET)!!
+        period = widget.period
+        // If Widget#legend is null, show legend only for groups
+        showLegend = widget.legend ?: (widget.item?.type == Item.Type.Group)
+
+        serverFlags = intent.getIntExtra(EXTRA_SERVER_FLAGS, 0)
+
+        supportActionBar?.title = widget.label.orDefaultIfEmpty(getString(R.string.chart_activity_title))
+
+        chart = findViewById(R.id.chart)
+        swipeLayout = findViewById(R.id.activity_content)
+        swipeLayout.setOnRefreshListener(this)
+        swipeLayout.applyColors()
+
+        density = resources.configuration.densityDpi
+
+        updateChartTheme()
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        connection = ConnectionFactory.activeUsableConnection?.connection
+        if (connection == null) {
+            finish()
+            return
+        }
+
+        loadChartImage(false)
+        if (determineDataUsagePolicy(connection).canDoRefreshes) {
+            chart.startRefreshingIfNeeded()
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        chart.cancelRefresh()
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        Log.d(TAG, "onCreateOptionsMenu()")
+        menuInflater.inflate(R.menu.chart_menu, menu)
+        updateHasLegendButtonState(menu.findItem(R.id.show_legend))
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        Log.d(TAG, "onOptionsItemSelected()")
+        return when {
+            item.itemId == R.id.refresh -> {
+                onRefresh()
+                true
+            }
+            item.itemId == R.id.show_legend -> {
+                showLegend = !showLegend
+                updateHasLegendButtonState(item)
+                true
+            }
+            item.itemId == android.R.id.home -> {
+                finish()
+                super.onOptionsItemSelected(item)
+            }
+            // The dropdown menu is opened
+            item.itemId == R.id.period -> true
+            periodForMenuItem(item.itemId) != null -> {
+                period = periodForMenuItem(item.itemId)!!
+                onRefresh()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun periodForMenuItem(itemId: Int) = when (itemId) {
+        R.id.period_h -> "h"
+        R.id.period_4h -> "4h"
+        R.id.period_8h -> "8h"
+        R.id.period_12h -> "12h"
+        R.id.period_d -> "D"
+        R.id.period_2d -> "2D"
+        R.id.period_3d -> "3D"
+        R.id.period_w -> "W"
+        R.id.period_2w -> "2W"
+        R.id.period_m -> "M"
+        R.id.period_2m -> "2M"
+        R.id.period_4m -> "4M"
+        R.id.period_y -> "Y"
+        else -> null
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putBoolean(SHOW_LEGEND, showLegend)
+        outState.putString(PERIOD, period)
+        super.onSaveInstanceState(outState)
+    }
+
+    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
+        showLegend = savedInstanceState.getBoolean(SHOW_LEGEND)
+        period = savedInstanceState.getString(PERIOD)!!
+        super.onRestoreInstanceState(savedInstanceState)
+    }
+
+    override fun onRefresh() {
+        loadChartImage(true)
+        swipeLayout.isRefreshing = false
+    }
+
+    private fun loadChartImage(force: Boolean) {
+        val conn = connection ?: return finish()
+        val chartUrl = widget.toChartUrl(
+            getPrefs(),
+            chart.width,
+            chart.height,
+            chartTheme,
+            density,
+            period,
+            showLegend
+        ) ?: return
+
+        Log.d(TAG, "Load chart with url $chartUrl")
+        chart.setImageUrl(conn, chartUrl, refreshDelayInMs = widget.refresh, forceLoad = force)
+    }
+
+    private fun updateHasLegendButtonState(item: MenuItem) {
+        if (showLegend) {
+            item.setIcon(R.drawable.ic_error_white_24dp)
+            item.setTitle(R.string.chart_activity_hide_legend)
+        } else {
+            item.setIcon(R.drawable.ic_error_outline_white_24dp)
+            item.setTitle(R.string.chart_activity_show_legend)
+        }
+        onRefresh()
+    }
+
+    override fun doesLockModeRequirePrompt(mode: ScreenLockMode): Boolean = mode == ScreenLockMode.Enabled
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        updateChartTheme()
+        onRefresh()
+    }
+
+    private fun updateChartTheme() {
+        chartTheme = getChartTheme(serverFlags)
+    }
+
+    companion object {
+        private val TAG = ChartImageActivity::class.java.simpleName
+
+        private const val SHOW_LEGEND = "show_legend"
+        private const val PERIOD = "period"
+        const val EXTRA_WIDGET = "widget"
+        const val EXTRA_SERVER_FLAGS = "server_flags"
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ChartWidgetActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ChartWidgetActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2024 Contributors to the openHAB project
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -13,87 +13,129 @@
 
 package org.openhab.habdroid.ui
 
-import android.content.res.Configuration
+import android.content.Intent
+import android.content.res.ColorStateList
+import android.net.Uri
 import android.os.Bundle
+import android.os.Parcelable
+import android.text.format.DateFormat
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import android.view.View
+import android.widget.Button
+import android.widget.TextView
+import androidx.core.graphics.ColorUtils
+import androidx.core.view.isVisible
+import androidx.lifecycle.lifecycleScope
+import com.github.mikephil.charting.charts.LineChart
+import com.github.mikephil.charting.components.AxisBase
+import com.github.mikephil.charting.components.Legend
+import com.github.mikephil.charting.components.MarkerView
+import com.github.mikephil.charting.components.XAxis
+import com.github.mikephil.charting.data.Entry
+import com.github.mikephil.charting.data.LineData
+import com.github.mikephil.charting.data.LineDataSet
+import com.github.mikephil.charting.formatter.IAxisValueFormatter
+import com.github.mikephil.charting.formatter.IValueFormatter
+import com.github.mikephil.charting.highlight.Highlight
+import com.github.mikephil.charting.utils.ViewPortHandler
+import com.google.android.material.shape.MaterialShapeDrawable
+import com.google.android.material.shape.RelativeCornerSize
+import com.google.android.material.shape.ShapeAppearanceModel
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.Period
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.time.format.FormatStyle
+import java.time.temporal.ChronoUnit
+import java.time.temporal.TemporalAmount
+import java.util.Locale
+import kotlin.collections.map
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.parcelize.Parcelize
+import org.json.JSONObject
 import org.openhab.habdroid.R
 import org.openhab.habdroid.core.connection.Connection
 import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.model.Item
+import org.openhab.habdroid.model.ParsedState
 import org.openhab.habdroid.model.Widget
-import org.openhab.habdroid.ui.widget.WidgetImageView
-import org.openhab.habdroid.util.ScreenLockMode
-import org.openhab.habdroid.util.determineDataUsagePolicy
-import org.openhab.habdroid.util.getChartTheme
-import org.openhab.habdroid.util.getPrefs
-import org.openhab.habdroid.util.orDefaultIfEmpty
+import org.openhab.habdroid.model.withValue
+import org.openhab.habdroid.util.HttpClient
+import org.openhab.habdroid.util.ItemClient
+import org.openhab.habdroid.util.map
 import org.openhab.habdroid.util.parcelable
+import org.openhab.habdroid.util.resolveThemedColor
+import org.openhab.habdroid.util.resolveThemedColorArray
+import org.openhab.habdroid.util.serializable
 
-class ChartWidgetActivity :
-    AbstractBaseActivity(),
-    SwipeRefreshLayout.OnRefreshListener {
-    private lateinit var swipeLayout: SwipeRefreshLayout
-    private lateinit var chart: WidgetImageView
-    private lateinit var period: String
+class ChartWidgetActivity : AbstractBaseActivity() {
+    private lateinit var period: TemporalAmount
     private lateinit var widget: Widget
-    private lateinit var chartTheme: CharSequence
-    private var connection: Connection? = null
-
+    private lateinit var chart: LineChart
+    private lateinit var progressContainer: View
+    private lateinit var progressText: TextView
+    private lateinit var errorContainer: View
+    private lateinit var errorText: TextView
+    private lateinit var retryButton: Button
+    private lateinit var seriesColors: Array<Int>
     private var serverFlags: Int = 0
-    private var density: Int = 0
-    private var showLegend: Boolean = true
+    private var loadedChartData: ChartData? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_chart)
 
-        widget = intent.parcelable(EXTRA_WIDGET)!!
-        period = widget.period
-        // If Widget#legend is null, show legend only for groups
-        showLegend = widget.legend ?: (widget.item?.type == Item.Type.Group)
-
-        serverFlags = intent.getIntExtra(EXTRA_SERVER_FLAGS, 0)
-
-        supportActionBar?.title = widget.label.orDefaultIfEmpty(getString(R.string.chart_activity_title))
-
-        chart = findViewById(R.id.chart)
-        swipeLayout = findViewById(R.id.activity_content)
-        swipeLayout.setOnRefreshListener(this)
-        swipeLayout.applyColors()
-
-        density = resources.configuration.densityDpi
-
-        updateChartTheme()
-    }
-
-    override fun onResume() {
-        super.onResume()
-
-        connection = ConnectionFactory.activeUsableConnection?.connection
-        if (connection == null) {
+        val widget = intent.parcelable<Widget>(EXTRA_WIDGET)
+        if (widget == null) {
             finish()
             return
+        } else {
+            this.widget = widget
+            parsePeriod(widget.period)?.let { period = it }
+        }
+        serverFlags = intent.getIntExtra(EXTRA_SERVER_FLAGS, 0)
+
+        if (savedInstanceState != null) {
+            savedInstanceState.serializable<Period>(PERIOD)?.let { period = it }
+            savedInstanceState.serializable<Duration>(PERIOD)?.let { period = it }
+            loadedChartData = savedInstanceState.parcelable(DATA)
         }
 
-        loadChartImage(false)
-        if (determineDataUsagePolicy(connection).canDoRefreshes) {
-            chart.startRefreshingIfNeeded()
+        seriesColors = resolveThemedColorArray(R.attr.chartSeriesColors)
+        progressContainer = findViewById(R.id.progress_container)
+        progressText = findViewById(R.id.progress_text)
+        errorContainer = findViewById(R.id.error_container)
+        errorText = findViewById(R.id.error_message)
+        retryButton = findViewById(R.id.retry_button)
+        chart = findViewById<LineChart>(R.id.chart).also {
+            configureChart(it)
         }
-    }
-
-    override fun onPause() {
-        super.onPause()
-        chart.cancelRefresh()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         Log.d(TAG, "onCreateOptionsMenu()")
-        menuInflater.inflate(R.menu.chart_menu, menu)
-        updateHasLegendButtonState(menu.findItem(R.id.show_legend))
+        loadedChartData?.let { data ->
+            menuInflater.inflate(R.menu.chart_menu, menu)
+            menu.removeItem(R.id.show_legend)
+
+            // Make sure we don't fetch overly large data sets by removing periods that would yield too many items
+            val dataPeriodHours = Duration.between(data.startTime, data.timestamp).toHours()
+            val pointsPerHour = data.data.size * data.data[0].dataPoints.size / dataPeriodHours
+            val now = LocalDateTime.now()
+            DURATION_MENU_MAPPING.forEach { itemId, period ->
+                val periodInHours = Duration.between(now.minus(period), now).toHours()
+                menu.findItem(itemId).isVisible = pointsPerHour * periodInHours < DATA_POINT_LIMIT
+            }
+        }
         return true
     }
 
@@ -104,19 +146,16 @@ class ChartWidgetActivity :
                 onRefresh()
                 true
             }
-            item.itemId == R.id.show_legend -> {
-                showLegend = !showLegend
-                updateHasLegendButtonState(item)
-                true
-            }
             item.itemId == android.R.id.home -> {
                 finish()
                 super.onOptionsItemSelected(item)
             }
             // The dropdown menu is opened
-            item.itemId == R.id.period -> true
-            periodForMenuItem(item.itemId) != null -> {
-                period = periodForMenuItem(item.itemId)!!
+            item.itemId == R.id.period -> {
+                true
+            }
+            DURATION_MENU_MAPPING.containsKey(item.itemId) -> {
+                period = DURATION_MENU_MAPPING[item.itemId]!!
                 onRefresh()
                 true
             }
@@ -124,84 +163,351 @@ class ChartWidgetActivity :
         }
     }
 
-    private fun periodForMenuItem(itemId: Int) = when (itemId) {
-        R.id.period_h -> "h"
-        R.id.period_4h -> "4h"
-        R.id.period_8h -> "8h"
-        R.id.period_12h -> "12h"
-        R.id.period_d -> "D"
-        R.id.period_2d -> "2D"
-        R.id.period_3d -> "3D"
-        R.id.period_w -> "W"
-        R.id.period_2w -> "2W"
-        R.id.period_m -> "M"
-        R.id.period_2m -> "2M"
-        R.id.period_4m -> "4M"
-        R.id.period_y -> "Y"
-        else -> null
-    }
-
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putBoolean(SHOW_LEGEND, showLegend)
-        outState.putString(PERIOD, period)
+        when (val p = period) {
+            is Period -> outState.putSerializable(PERIOD, p)
+            is Duration -> outState.putSerializable(PERIOD, p)
+        }
+        outState.putParcelable(DATA, loadedChartData)
         super.onSaveInstanceState(outState)
     }
 
-    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
-        showLegend = savedInstanceState.getBoolean(SHOW_LEGEND)
-        period = savedInstanceState.getString(PERIOD)!!
-        super.onRestoreInstanceState(savedInstanceState)
-    }
-
-    override fun onRefresh() {
-        loadChartImage(true)
-        swipeLayout.isRefreshing = false
-    }
-
-    private fun loadChartImage(force: Boolean) {
-        val conn = connection ?: return finish()
-        val chartUrl = widget.toChartUrl(
-            getPrefs(),
-            chart.width,
-            chart.height,
-            chartTheme,
-            density,
-            period,
-            showLegend
-        ) ?: return
-
-        Log.d(TAG, "Load chart with url $chartUrl")
-        chart.setImageUrl(conn, chartUrl, refreshDelayInMs = widget.refresh, forceLoad = force)
-    }
-
-    private fun updateHasLegendButtonState(item: MenuItem) {
-        if (showLegend) {
-            item.setIcon(R.drawable.ic_error_white_24dp)
-            item.setTitle(R.string.chart_activity_hide_legend)
+    override fun onStart() {
+        super.onStart()
+        val data = loadedChartData
+        val dataIsOutdated = data != null &&
+            widget.refresh > 0 &&
+            Duration.between(data.timestamp, Instant.now()).toMillis() > widget.refresh
+        if (data == null || dataIsOutdated) {
+            onRefresh()
         } else {
-            item.setIcon(R.drawable.ic_error_outline_white_24dp)
-            item.setTitle(R.string.chart_activity_show_legend)
+            configureChartForData(data)
+            showChart()
         }
+    }
+
+    private fun onRefresh() = lifecycleScope.launch {
+        val connection = ConnectionFactory.activeUsableConnection?.connection
+        val item = widget.item
+        if (connection == null || item == null) {
+            finish()
+            return@launch
+        }
+
+        loadedChartData = null
+        invalidateOptionsMenu()
+        showLoadingIndicator()
+
+        val data = try {
+            loadData(connection, item, period, widget.service) { itemName ->
+                progressText.text = getString(R.string.chart_activity_loading_progress_item, itemName)
+            }
+        } catch (e: HttpClient.HttpException) {
+            Log.w(TAG, "Could not load chart data", e)
+            if (e.statusCode == 401 || e.statusCode == 403) {
+                showError(
+                    getString(R.string.chart_error_authentication),
+                    getString(R.string.chart_error_retry_button_chart_image)
+                ) {
+                    goToChartImageActivity()
+                }
+            } else {
+                showError(
+                    getString(R.string.chart_error_generic, e.statusCode),
+                    getString(R.string.chart_error_retry_button_retry)
+                ) {
+                    retryLoad()
+                }
+            }
+            return@launch
+        }
+
+        configureChartForData(data)
+        loadedChartData = data
+        invalidateOptionsMenu()
+        showChart()
+    }
+
+    private fun showLoadingIndicator() {
+        chart.isVisible = false
+        progressContainer.isVisible = true
+        errorContainer.isVisible = false
+        progressText.text = ""
+    }
+
+    private fun showChart() {
+        progressContainer.isVisible = false
+        errorContainer.isVisible = false
+        chart.isVisible = true
+    }
+
+    private fun showError(message: CharSequence, retryButtonText: CharSequence, retryAction: () -> Unit) {
+        chart.isVisible = false
+        progressContainer.isVisible = false
+        errorContainer.isVisible = true
+        errorText.text = message
+        retryButton.text = retryButtonText
+        retryButton.setOnClickListener { retryAction() }
+    }
+
+    private fun goToChartImageActivity() {
+        val intent = Intent(this, ChartImageActivity::class.java)
+            .putExtra(ChartImageActivity.EXTRA_WIDGET, widget)
+            .putExtra(ChartImageActivity.EXTRA_SERVER_FLAGS, serverFlags)
+        finish()
+        startActivity(intent)
+    }
+
+    private fun retryLoad() {
         onRefresh()
     }
 
-    override fun doesLockModeRequirePrompt(mode: ScreenLockMode): Boolean = mode == ScreenLockMode.Enabled
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        updateChartTheme()
-        onRefresh()
+    @Throws(HttpClient.HttpException::class)
+    private suspend fun loadData(
+        connection: Connection,
+        item: Item,
+        period: TemporalAmount,
+        serviceId: String?,
+        progressCb: (itemName: String) -> Unit
+    ): ChartData {
+        val itemsForChart = if (item.type == Item.Type.Group) {
+            // sitemap response doesn't include member list, so re-fetch item to get members
+            ItemClient.loadItem(connection, item.name)?.members ?: listOf(item)
+        } else {
+            listOf(item)
+        }
+        val timestamp = ZonedDateTime.now()
+        val startTime = timestamp.minus(period)
+        val allSeries = itemsForChart.map { item ->
+            progressCb(item.label ?: item.name)
+            loadSeriesForItem(connection, item, startTime, serviceId)
+        }
+        return ChartData(allSeries, timestamp, startTime)
     }
 
-    private fun updateChartTheme() {
-        chartTheme = getChartTheme(serverFlags)
+    private fun configureChart(chart: LineChart) = with(chart) {
+        val foregroundColor = resolveThemedColor(R.attr.colorOnSurface)
+        val padding = 4F // dp
+
+        setTouchEnabled(true)
+        setDragDecelerationFrictionCoef(0.9f)
+        setDragEnabled(true)
+        isScaleXEnabled = true
+        isScaleYEnabled = false
+
+        setDrawBorders(true)
+        setDrawGridBackground(false)
+        setBorderColor(foregroundColor)
+
+        marker = ValueMarkerView(chart, seriesColors)
+        isHighlightPerTapEnabled = true
+        isHighlightPerDragEnabled = true
+
+        minOffset = padding
+        extraBottomOffset = padding
+
+        with(legend) {
+            textColor = foregroundColor
+            form = Legend.LegendForm.CIRCLE
+            yOffset = padding
+            isWordWrapEnabled = true
+        }
+        with(description) {
+            isEnabled = false
+        }
+
+        val locale = Locale.getDefault()
+        val formatHoursAndMinutes = DateTimeFormatter.ofPattern(DateFormat.getBestDateTimePattern(locale, "JJmm"))
+        val formatHoursAndMinutesWithSeconds =
+            DateTimeFormatter.ofPattern(DateFormat.getBestDateTimePattern(locale, "JJmmss"))
+        val formatDateAndTime = DateTimeFormatter.ofPattern(DateFormat.getBestDateTimePattern(locale, "d JJmm"))
+        val formatDate = DateTimeFormatter.ofPattern(DateFormat.getBestDateTimePattern(locale, "dM"))
+
+        with(xAxis) {
+            textColor = foregroundColor
+            valueFormatter = object : IAxisValueFormatter {
+                override fun getFormattedValue(value: Float, axis: AxisBase?) = loadedChartData?.let { data ->
+                    val axisRangeSeconds = axis?.mEntries?.let {
+                        val deltaSeconds = (it[it.size - 1] - it[0]) / 1000
+                        deltaSeconds.toInt()
+                    } ?: -1
+                    val format = when (axisRangeSeconds) {
+                        in 0..120 -> formatHoursAndMinutesWithSeconds
+                        in 24 * 3600..5 * 24 * 3600 -> formatDateAndTime
+                        in 5 * 24 * 3600..Int.MAX_VALUE -> formatDate
+                        else -> formatHoursAndMinutes
+                    }
+                    data.startTime.plus(value.toLong(), ChronoUnit.MILLIS)
+                        .let { format.format(it) }
+                }
+            }
+            position = XAxis.XAxisPosition.BOTTOM
+        }
+
+        with(axisLeft) {
+            textColor = foregroundColor
+        }
+        with(axisRight) {
+            isEnabled = false
+        }
+    }
+
+    private fun configureChartForData(data: ChartData) {
+        val dataSets = data.data.mapIndexed { index, series ->
+            val values = series.dataPoints.map {
+                val dpTimestamp = ZonedDateTime.ofInstant(it.timestamp, data.startTime.zone)
+                Entry(Duration.between(data.startTime, dpTimestamp).toMillis().toFloat(), it.value.toFloat(), it)
+            }
+            LineDataSet(values, series.data.name).apply {
+                setDrawCircles(false)
+                setColor(seriesColors[index])
+                setDrawCircleHole(false)
+                setDrawValues(false)
+                lineWidth = 1F
+                mode = LineDataSet.Mode.STEPPED
+                valueFormatter = object : IValueFormatter {
+                    override fun getFormattedValue(
+                        value: Float,
+                        entry: Entry?,
+                        dataSetIndex: Int,
+                        viewPortHandler: ViewPortHandler?
+                    ) = series.data.state.withValue(value).toString()
+                }
+            }
+        }
+        chart.axisLeft.valueFormatter = object : IAxisValueFormatter {
+            override fun getFormattedValue(value: Float, axis: AxisBase?) =
+                data.data[0].data.state.withValue(value).toString()
+        }
+        chart.legend.isEnabled = data.data.size > 1
+        chart.data = LineData(dataSets)
+        chart.fitScreen()
+    }
+
+    @Throws(HttpClient.HttpException::class)
+    private suspend fun loadSeriesForItem(
+        connection: Connection,
+        item: Item,
+        startTime: ZonedDateTime,
+        serviceId: String?
+    ): Series {
+        val uriBuilder = Uri.Builder()
+            .path("rest/persistence/items/${item.name}")
+            .appendQueryParameter("starttime", startTime.toString())
+        if (!serviceId.isNullOrEmpty()) {
+            uriBuilder.appendQueryParameter("serviceId", serviceId)
+        }
+
+        return connection.httpClient
+            .get(uriBuilder.build().toString())
+            .asText()
+            .let { resp ->
+                withContext(Dispatchers.IO) {
+                    val json = JSONObject(resp.response)
+                    val seriesData = SeriesData(item.label ?: item.name, item.state?.asNumber, startTime.zone)
+                    val dataPoints = json.getJSONArray("data").map { dpjson ->
+                        val timestamp = Instant.ofEpochMilli(dpjson.getLong("time"))
+                        val state = dpjson.getString("state").toDouble()
+                        DataPoint(timestamp, state, seriesData)
+                    }
+                    Series(seriesData, dataPoints)
+                }
+            }
+    }
+
+    private fun parsePeriod(period: String): TemporalAmount? {
+        if (period.isEmpty() || period.last() !in listOf('h', 'H', 'D', 'W', 'M', 'Y')) {
+            return null
+        }
+        val periodAsIso8601 = when {
+            period.startsWith('P') -> period
+            period == "h" || period == "H" -> "PT1H"
+            period.length == 1 -> "P1$period"
+            period.endsWith("H", ignoreCase = true) -> "PT${period.substring(0, period.length)}H"
+            else -> "P$period"
+        }
+        return try {
+            Period.parse(periodAsIso8601)
+        } catch (_: DateTimeParseException) {
+            try {
+                Duration.parse(periodAsIso8601)
+            } catch (_: DateTimeParseException) {
+                null
+            }
+        }
+    }
+
+    @Parcelize
+    data class SeriesData(val name: String, val state: ParsedState.NumberState?, val zoneId: ZoneId) : Parcelable
+
+    @Parcelize
+    data class DataPoint(val timestamp: Instant, val value: Double, val seriesData: SeriesData) : Parcelable
+
+    @Parcelize
+    data class Series(val data: SeriesData, val dataPoints: List<DataPoint>) : Parcelable
+
+    @Parcelize
+    data class ChartData(val data: List<Series>, val timestamp: ZonedDateTime, val startTime: ZonedDateTime) :
+        Parcelable
+
+    private class ValueMarkerView(chartView: LineChart, seriesColors: Array<Int>) :
+        MarkerView(chartView.context, R.layout.chart_marker) {
+        private val text = getChildAt(0) as TextView
+        private val dataSetColors: List<ColorStateList>
+        private val background = MaterialShapeDrawable(
+            ShapeAppearanceModel.Builder()
+                .setAllCornerSizes(RelativeCornerSize(0.15F))
+                .build()
+        )
+        private val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)
+
+        init {
+            setChartView(chartView)
+            val backgroundColor = chartView.context.resolveThemedColor(R.attr.colorSurface)
+            dataSetColors = seriesColors.map { color ->
+                val fg = ColorUtils.setAlphaComponent(color, 96)
+                ColorStateList.valueOf(ColorUtils.compositeColors(fg, backgroundColor))
+            }
+            text.background = background
+            text.setTextColor(chartView.context.resolveThemedColor(R.attr.colorOnSurface))
+        }
+
+        override fun refreshContent(e: Entry?, highlight: Highlight?) {
+            val dp = e?.data as? DataPoint
+            text.isVisible = dp != null
+            if (dp != null) {
+                val value = dp.seriesData.state?.withValue(dp.value.toFloat())?.toString() ?: e.y.toString()
+                val formattedTimestamp = formatter.format(LocalDateTime.ofInstant(dp.timestamp, dp.seriesData.zoneId))
+                text.text = "${formattedTimestamp}\n${dp.seriesData.name}: $value"
+                highlight?.let { background.setFillColor(dataSetColors[it.dataSetIndex]) }
+            }
+            super.refreshContent(e, highlight)
+        }
     }
 
     companion object {
         private val TAG = ChartWidgetActivity::class.java.simpleName
 
-        private const val SHOW_LEGEND = "show_legend"
+        private val DURATION_MENU_MAPPING: Map<Int, TemporalAmount> = mapOf(
+            R.id.period_h to Duration.ofHours(1),
+            R.id.period_4h to Duration.ofHours(4),
+            R.id.period_8h to Duration.ofHours(8),
+            R.id.period_12h to Duration.ofHours(12),
+            R.id.period_d to Duration.ofDays(1),
+            R.id.period_2d to Duration.ofDays(2),
+            R.id.period_3d to Duration.ofDays(3),
+            R.id.period_w to Period.ofWeeks(1),
+            R.id.period_2w to Period.ofWeeks(2),
+            R.id.period_m to Period.ofMonths(1),
+            R.id.period_2m to Period.ofMonths(2),
+            R.id.period_4m to Period.ofMonths(4),
+            R.id.period_y to Period.ofYears(1)
+        )
+
+        private const val DATA_POINT_LIMIT = 500000
+
         private const val PERIOD = "period"
+        private const val DATA = "data"
         const val EXTRA_WIDGET = "widget"
         const val EXTRA_SERVER_FLAGS = "server_flags"
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ChartWidgetActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ChartWidgetActivity.kt
@@ -369,7 +369,7 @@ class ChartWidgetActivity : AbstractBaseActivity() {
             }
             LineDataSet(values, series.data.name).apply {
                 setDrawCircles(false)
-                setColor(seriesColors[index])
+                setColor(seriesColors[index % seriesColors.size])
                 setDrawCircleHole(false)
                 setDrawValues(false)
                 lineWidth = 1F
@@ -492,7 +492,7 @@ class ChartWidgetActivity : AbstractBaseActivity() {
                 val value = dp.seriesData.state?.withValue(dp.value.toFloat())?.toString() ?: e.y.toString()
                 val formattedTimestamp = formatter.format(LocalDateTime.ofInstant(dp.timestamp, dp.seriesData.zoneId))
                 text.text = "${formattedTimestamp}\n${dp.seriesData.name}: $value"
-                highlight?.let { background.setFillColor(dataSetColors[it.dataSetIndex]) }
+                highlight?.let { background.setFillColor(dataSetColors[it.dataSetIndex % dataSetColors.size]) }
             }
             super.refreshContent(e, highlight)
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -286,9 +286,8 @@ class WidgetListFragment :
                 R.string.analyse
             ).setOnMenuItemClickListener {
                 val mainActivity = activity as MainActivity
-                val intent = Intent(mainActivity, ChartWidgetActivity::class.java)
-                intent.putExtra(ChartWidgetActivity.EXTRA_WIDGET, widget)
-                intent.putExtra(ChartWidgetActivity.EXTRA_SERVER_FLAGS, mainActivity.serverProperties?.flags)
+                val serverFlags = mainActivity.serverProperties?.flags ?: 0
+                val intent = mainActivity.getChartDetailsActivityIntent(widget, serverFlags)
                 mainActivity.startActivity(intent)
                 return@setOnMenuItemClickListener true
             }

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -61,6 +61,7 @@ import com.google.android.material.shape.ShapeAppearanceModel
 import java.io.EOFException
 import java.io.IOException
 import java.io.InputStream
+import java.io.Serializable
 import java.net.ConnectException
 import java.net.Socket
 import java.net.SocketTimeoutException
@@ -486,6 +487,17 @@ fun Context.resolveThemedColorToResource(@AttrRes colorAttr: Int, @ColorRes fall
     return ta.getResourceId(0, fallbackColorRes).also { ta.recycle() }
 }
 
+fun Context.resolveThemedColorArray(@AttrRes arrayAttr: Int): Array<Int> {
+    val tv = TypedValue()
+    theme.resolveAttribute(arrayAttr, tv, false)
+    val ta = resources.obtainTypedArray(tv.data)
+    val result = (0 until ta.length())
+        .map { index -> ta.getColor(index, 0) }
+        .toTypedArray()
+    ta.recycle()
+    return result
+}
+
 fun Context.getChartTheme(serverFlags: Int): CharSequence {
     val tv = TypedValue()
     if (serverFlags and ServerProperties.SERVER_FLAG_TRANSPARENT_CHARTS == 0) {
@@ -691,4 +703,11 @@ inline fun <reified T> Bundle.parcelableArrayList(key: String): List<T>? = when 
     else ->
         @Suppress("DEPRECATION")
         getParcelableArrayList(key)
+}
+
+inline fun <reified T : Serializable> Bundle.serializable(key: String): T? = when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getSerializable(key, T::class.java)
+    else ->
+        @Suppress("DEPRECATION")
+        getSerializable(key) as? T
 }

--- a/mobile/src/main/res/layout/activity_chart.xml
+++ b/mobile/src/main/res/layout/activity_chart.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/coordinator"
@@ -9,20 +8,78 @@
 
     <include layout="@layout/app_bar" />
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+    <FrameLayout
         android:id="@+id/activity_content"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <org.openhab.habdroid.ui.widget.WidgetImageView
+        <com.github.mikephil.charting.charts.LineChart
             android:id="@+id/chart"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:imageScalingType="scaleToFitWithViewAdjustment"
-            app:addRandomnessToUrl="true"
-            tools:src="@drawable/day_dream_preview" />
+            android:visibility="gone" />
 
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+        <LinearLayout
+            android:id="@+id/progress_container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:gravity="center">
 
+            <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/progress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="16dp"
+                android:indeterminate="true" />
+
+            <TextView
+                android:id="@+id/progress_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                tools:text="Loading data for some item" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/error_container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:gravity="center_vertical"
+            android:visibility="gone">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:padding="16dp"
+                app:srcCompat="@drawable/ic_connection_error"
+                app:tint="?colorOnSurfaceVariant"
+                app:tintMode="src_in" />
+
+            <TextView
+                android:id="@+id/error_message"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:padding="16dp"
+                android:textAlignment="center"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textColor="?colorOnSurfaceVariant"
+                android:gravity="center"
+                tools:text="Some error occurred" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/retry_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                tools:text="@string/try_again_button" />
+
+        </LinearLayout>
+
+    </FrameLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/mobile/src/main/res/layout/activity_chartimage.xml
+++ b/mobile/src/main/res/layout/activity_chartimage.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/coordinator"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/app_bar" />
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/activity_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <org.openhab.habdroid.ui.widget.WidgetImageView
+            android:id="@+id/chart"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:imageScalingType="scaleToFitWithViewAdjustment"
+            app:addRandomnessToUrl="true"
+            tools:src="@drawable/day_dream_preview" />
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/mobile/src/main/res/layout/chart_marker.xml
+++ b/mobile/src/main/res/layout/chart_marker.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:textAppearance="?textAppearanceLabelSmall"
+    android:padding="8dp" />

--- a/mobile/src/main/res/values-night/themes.xml
+++ b/mobile/src/main/res/values-night/themes.xml
@@ -4,6 +4,7 @@
         <item name="chartTheme">dark</item>
         <item name="transparentChartTheme">dark_transparent</item>
         <item name="valueColors">@array/valueColorsDarkBackground</item>
+        <item name="chartSeriesColors">@array/chartSeriesColorsDarkBackground</item>
         <item name="android:statusBarColor">?android:colorBackground</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
         <item name="skeletonBackground">#1E1E1E</item>

--- a/mobile/src/main/res/values-v23/themes.xml
+++ b/mobile/src/main/res/values-v23/themes.xml
@@ -6,6 +6,7 @@
         <item name="chartTheme">white</item>
         <item name="transparentChartTheme">white_transparent</item>
         <item name="valueColors">@array/valueColorsBrightBackground</item>
+        <item name="chartSeriesColors">@array/chartSeriesColorsBrightBackground</item>
         <item name="skeletonBackground">#F2F2F2</item>
         <item name="skeletonShimmer">#E0E0E0</item>
     </style>

--- a/mobile/src/main/res/values/arrays.xml
+++ b/mobile/src/main/res/values/arrays.xml
@@ -91,23 +91,27 @@
     </array>
 
     <array name="chartSeriesColorsBrightBackground">
-        <item>#1976D2</item> <!-- blue 700 -->
-        <item>#D32F2F</item> <!-- red 700 -->
+        <item>#E64A19</item> <!-- deep orange 700 -->
         <item>#388E3C</item> <!-- green 700 -->
-        <item>#0097A7</item> <!-- cyan 700 -->
+        <item>#1976D2</item> <!-- blue 700 -->
+        <item>#512DA8</item> <!-- deep purple 700 -->
         <item>#FFA000</item> <!-- amber 700 -->
-        <item>#7B1FA2</item> <!-- purple 700 -->
+        <item>#0097A7</item> <!-- cyan 700 -->
+        <item>#C2185B</item> <!-- pink 700 -->
         <item>#616161</item> <!-- grey 700 -->
+        <item>#AFB42B</item> <!-- lime 700 -->
     </array>
 
     <array name="chartSeriesColorsDarkBackground">
-        <item>#03A9F4</item> <!-- blue 500 -->
-        <item>#F44336</item> <!-- red 500 -->
+        <item>#FF5722</item> <!-- deep orange 500 -->
         <item>#4CAF50</item> <!-- green 500 -->
-        <item>#00BCD4</item> <!-- cyan 500 -->
+        <item>#03A9F4</item> <!-- blue 500 -->
+        <item>#673AB7</item> <!-- deep purple 500 -->
         <item>#FFC107</item> <!-- amber 500 -->
-        <item>#9C27B0</item> <!-- purple 500 -->
+        <item>#00BCD4</item> <!-- cyan 500 -->
+        <item>#E91E63</item> <!-- pink 500 -->
         <item>#9E9E9E</item> <!-- grey 500 -->
+        <item>#CDDC39</item> <!-- lime 500 -->
     </array>
 
     <string-array name="valueColorNames" translatable="false">

--- a/mobile/src/main/res/values/arrays.xml
+++ b/mobile/src/main/res/values/arrays.xml
@@ -90,6 +90,26 @@
         <item>#daa520</item> <!-- gold -->
     </array>
 
+    <array name="chartSeriesColorsBrightBackground">
+        <item>#1976D2</item> <!-- blue 700 -->
+        <item>#D32F2F</item> <!-- red 700 -->
+        <item>#388E3C</item> <!-- green 700 -->
+        <item>#0097A7</item> <!-- cyan 700 -->
+        <item>#FFA000</item> <!-- amber 700 -->
+        <item>#7B1FA2</item> <!-- purple 700 -->
+        <item>#616161</item> <!-- grey 700 -->
+    </array>
+
+    <array name="chartSeriesColorsDarkBackground">
+        <item>#03A9F4</item> <!-- blue 500 -->
+        <item>#F44336</item> <!-- red 500 -->
+        <item>#4CAF50</item> <!-- green 500 -->
+        <item>#00BCD4</item> <!-- cyan 500 -->
+        <item>#FFC107</item> <!-- amber 500 -->
+        <item>#9C27B0</item> <!-- purple 500 -->
+        <item>#9E9E9E</item> <!-- grey 500 -->
+    </array>
+
     <string-array name="valueColorNames" translatable="false">
         <item>maroon</item>
         <item>red</item>

--- a/mobile/src/main/res/values/attrs.xml
+++ b/mobile/src/main/res/values/attrs.xml
@@ -29,6 +29,7 @@
         <attr name="chartTheme" format="string" />
         <attr name="transparentChartTheme" format="string" />
         <attr name="valueColors" format="reference" />
+        <attr name="chartSeriesColors" format="reference" />
         <attr name="skeletonBackground" format="color" />
         <attr name="skeletonShimmer" format="color" />
     </declare-styleable>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -450,6 +450,11 @@
     <string name="chart_activity_period_2_month">2 months</string>
     <string name="chart_activity_period_4_month">4 months</string>
     <string name="chart_activity_period_1_year">1 year</string>
+    <string name="chart_activity_loading_progress_item">Loading data for %1$s</string>
+    <string name="chart_error_authentication">The server requires authentication for loading chart data.\nYou can either enter correct authentication credentials in the server configuration in the app, or load the chart as image.</string>
+    <string name="chart_error_generic">Loading the chart data failed (HTTP status code %1$d).</string>
+    <string name="chart_error_retry_button_chart_image">Load chart as image</string>
+    <string name="chart_error_retry_button_retry">Retry</string>
 
     <!-- NFC -->
     <string name="nfc_action_on">On</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -452,6 +452,7 @@
     <string name="chart_activity_period_1_year">1 year</string>
     <string name="chart_activity_loading_progress_item">Loading data for %1$s</string>
     <string name="chart_error_authentication">The server requires authentication for loading chart data.\nYou can either enter correct authentication credentials in the server configuration in the app, or load the chart as image.</string>
+    <string name="chart_error_state_format">Data for Item %1$s could not be loaded. Most likely the type of the Item is not compatible with being shown in a chart.</string>
     <string name="chart_error_generic">Loading the chart data failed (HTTP status code %1$d).</string>
     <string name="chart_error_retry_button_chart_image">Load chart as image</string>
     <string name="chart_error_retry_button_retry">Retry</string>

--- a/mobile/src/main/res/values/themes.xml
+++ b/mobile/src/main/res/values/themes.xml
@@ -13,6 +13,7 @@
         <item name="chartTheme">white</item>
         <item name="transparentChartTheme">white_transparent</item>
         <item name="valueColors">@array/valueColorsBrightBackground</item>
+        <item name="chartSeriesColors">@array/chartSeriesColorsBrightBackground</item>
         <item name="skeletonBackground">#F2F2F2</item>
         <item name="skeletonShimmer">#E0E0E0</item>
     </style>


### PR DESCRIPTION
This one uses the persistence REST API and replaces the one showing a larger server-side generated chart image if supported (that is, for OH >= 2). It uses client-side chart rendering, the advantage of which is the possibility of zooming into the chart data and getting tooltips for values.