### PR TITLE
Make sure to format number values correctly for unit 'one'

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/ParsedState.kt
@@ -176,7 +176,11 @@ data class ParsedState internal constructor(
          */
         fun toString(locale: Locale): String {
             if (!format.isNullOrEmpty()) {
-                val actualFormat = format.replace("%unit%", unit.orEmpty())
+                val actualFormat = format
+                    .replace("%unit%", unit.orEmpty())
+                    // In case of 'one' unit, the unit is part of the format pattern, but not part of the value
+                    // sent by the server. Avoid ending the value with a space in that case.
+                    .trim()
                 try {
                     return String.format(locale, actualFormat, getActualValue())
                 } catch (e: IllegalFormatException) {


### PR DESCRIPTION
In that case the 'state' part of the item response has no unit (e.g. '12'), but the format pattern still contains the unit (e.g. '%.0f %unit%'), in which case we sent commands like '15 ' to the server, which it rejected. Make sure to omit the space in that case.

Fixes #3882