### PR TITLE
Fix default value for chart scaling pref

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/util/PrefExtensions.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/PrefExtensions.kt
@@ -90,7 +90,7 @@ fun SharedPreferences.getNotificationTone(): Uri? {
 
 fun SharedPreferences.isScreenTimerDisabled(): Boolean = getBoolean(PrefKeys.SCREEN_TIMER_OFF, false)
 
-fun SharedPreferences.getChartScalingFactor(): Float = getFloat(PrefKeys.CHART_SCALING, 1.0F)
+fun SharedPreferences.getChartScalingFactor(): Float = getFloat(PrefKeys.CHART_SCALING, 1.5F)
 
 fun SharedPreferences.shouldRequestHighResChart(): Boolean = getBoolean(PrefKeys.CHART_HQ, true)
 


### PR DESCRIPTION
Code (1.0) and XML (1.5) disagreed about the default chart scale.

Fixes #3900