### PR TITLE
Disable read-only widgets for now

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/model/Widget.kt
@@ -100,7 +100,7 @@ data class Widget(
         return InputTypeHint.Text
     }
 
-    val readOnly get() = item?.readOnly == true
+    val readOnly get() = false // TODO: Re-enable once implemented in Basic UI
 
     private val configuredMinValue get() = when {
         rawMinValue != null -> rawMinValue


### PR DESCRIPTION
For a consistent user experience wait until this feature has been implemented in Basic UI.