### PR TITLE
Restart SSE connection in listenForItemChange() when not alive

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/background/ItemsControlsProviderService.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/background/ItemsControlsProviderService.kt
@@ -37,6 +37,7 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.jdk9.flowPublish
 import kotlinx.coroutines.launch
@@ -79,15 +80,13 @@ class ItemsControlsProviderService : ControlsProviderService() {
             .mapNotNull { factory.maybeCreateControl(it.value) }
             .forEach { control -> send(control) }
 
-        ItemClient.listenForItemChange(this, connection, "*") { topicPath, payload ->
-            val item = allItems[topicPath[2]]
-            if (item != null) {
-                val newItem = item.copy(state = payload.getString("value").toParsedState())
-                launch {
-                    factory.maybeCreateControl(newItem)?.let { control -> send(control) }
-                }
+        ItemClient.listenForItemChange(this, connection, null)
+            .consumeEach { (itemName, state) ->
+                allItems[itemName]
+                    ?.copy(state = state.toParsedState())
+                    ?.let { factory.maybeCreateControl(it) }
+                    ?.let { control -> send(control) }
             }
-        }
     }
 
     override fun performControlAction(controlId: String, action: ControlAction, consumer: Consumer<Int>) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/DayDream.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/DayDream.kt
@@ -32,6 +32,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -95,11 +96,11 @@ class DayDream :
         }
         setText(initialText)
 
-        ItemClient.listenForItemChange(this, connection, item) { _, payload ->
-            val state = payload.getString("value")
-            Log.d(TAG, "Got state by event: $state")
-            setText(state)
-        }
+        ItemClient.listenForItemChange(this, connection, item)
+            .consumeEach { (_, state) ->
+                Log.d(TAG, "Got state by event: $state")
+                setText(state)
+            }
     }
 
     private fun setText(text: String) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -78,6 +78,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -1606,11 +1607,11 @@ class MainActivity : AbstractBaseActivity() {
     }
 
     private suspend fun listenUiCommandItem(item: String) {
-        ItemClient.listenForItemChange(this, connection ?: return, item) { _, payload ->
-            val state = payload.getString("value")
-            Log.d(TAG, "Got state by event: $state")
-            handleUiCommand(state, prefs.getActiveServerId())
-        }
+        ItemClient.listenForItemChange(this, connection ?: return, item)
+            .consumeEach { (_, state) ->
+                Log.d(TAG, "Got state by event: $state")
+                handleUiCommand(state, prefs.getActiveServerId())
+            }
     }
 
     private fun handleUiCommand(command: String, serverId: Int) {

--- a/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/HttpClient.kt
@@ -308,7 +308,7 @@ class HttpClient(client: OkHttpClient, baseUrl: String?, username: String?, pass
         suspend fun getNextEvent(): String = listener.channel.receive()
 
         fun cancel() {
-            listener.channel.close()
+            listener.channel.cancel()
             source.cancel()
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/util/ItemClient.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ItemClient.kt
@@ -20,10 +20,12 @@ import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.parsers.ParserConfigurationException
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -109,47 +111,23 @@ object ItemClient {
         }
     }
 
-    suspend fun listenForItemChange(
-        scope: CoroutineScope,
-        connection: Connection,
-        item: String,
-        callback: (topicPath: List<String>, payload: JSONObject) -> Unit
-    ) {
-        fun createSubscription() = connection.httpClient.makeSse(
-            // Support for both the "openhab" and the older "smarthome" root topic by using a wildcard
-            connection.httpClient.buildUrl("rest/events?topics=*/items/$item/command")
-        )
-        var eventSubscription = createSubscription()
+    // Emits pairs of 'item name' - 'item state'
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun listenForItemChange(scope: CoroutineScope, connection: Connection, itemName: String?) = scope.produce {
+        while (scope.isActive) {
+            val subscription = connection.httpClient.makeSse(
+                // Support for both the "openhab" and the older "smarthome" root topic by using a wildcard
+                connection.httpClient.buildUrl("rest/events?topics=*/items/${itemName ?: "*"}/command")
+            )
 
-        suspend fun restartSubscription() {
-            try {
-                eventSubscription.cancel()
-            } catch (e: Exception) {
-                Log.e(TAG, "Error cancelling SSE subscription for item $item", e)
-            }
-            delay(5.seconds)
-            eventSubscription = createSubscription()
-        }
-
-        var watchdogJob: Job? = null
-
-        fun resetAliveWatchdog() {
-            watchdogJob?.cancel()
-            watchdogJob = scope.launch {
-                delay(30.seconds) // ALIVE event is sent every 10 seconds
-                Log.d(TAG, "No events received for item $item, restarting subscription")
-                restartSubscription()
-            }
-        }
-        resetAliveWatchdog()
-
-        try {
             while (scope.isActive) {
                 try {
-                    val event = JSONObject(eventSubscription.getNextEvent())
-                    resetAliveWatchdog()
+                    // ALIVE event is sent every 10 seconds, so use a timeout somewhat larger than that
+                    val event = withTimeout(30.seconds) {
+                        JSONObject(subscription.getNextEvent())
+                    }
                     if (event.optString("type") == "ALIVE") {
-                        Log.d(TAG, "Got ALIVE event for item $item")
+                        Log.d(TAG, "Got ALIVE event for item $itemName")
                         continue
                     }
                     val topic = event.getString("topic")
@@ -160,20 +138,24 @@ object ItemClient {
                     // When an update for a group is sent, there's also one for the individual item.
                     // Therefore always take the element on index two.
                     if (topicPath.size !in 4..5) {
-                        throw JSONException("Unexpected topic path $topic for item $item")
+                        throw JSONException("Unexpected topic path $topic")
                     }
                     val payload = JSONObject(event.getString("payload"))
                     Log.d(TAG, "Got payload: $payload")
-                    callback(topicPath, payload)
+                    send(topicPath[2] to payload.getString("value"))
                 } catch (e: JSONException) {
-                    Log.e(TAG, "Failed parsing JSON of state change event for item $item", e)
+                    Log.e(TAG, "Failed parsing JSON of state change event for item $itemName", e)
                 } catch (e: HttpClient.SseFailureException) {
-                    Log.e(TAG, "SSE failure for item $item", e)
-                    restartSubscription()
+                    Log.e(TAG, "SSE failure for item $itemName", e)
+                    break // restart subscription
+                } catch (e: TimeoutCancellationException) {
+                    Log.d(TAG, "No events received for item $itemName, restarting subscription $scope")
+                    break // restart subscription
                 }
             }
-        } finally {
-            eventSubscription.cancel()
+
+            subscription.cancel()
+            delay(5.seconds)
         }
     }
 }


### PR DESCRIPTION
When restarting openHAB existing SSE connections may look like they are still intact to the client, but no further events are received. Thus restart a connection when no ALIVE events are received anymore.