### PR TITLE
Get sender of alarm

### DIFF
--- a/mobile/src/foss/AndroidManifest.xml
+++ b/mobile/src/foss/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Not allowed on Play Store -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 
     <application>
         <service


### PR DESCRIPTION
https://community.openhab.org/t/phantom-alarmclock-times-sent-by-null/167186

A user reports that an unknown app ("which was sent by null") sets invalid alarm times. To see the app causing this issue, permissions the query all installed apps is required.
As this isn't allowed on Play Store, only add it to the F-Droid version.