### PR TITLE
Fix chart being partially obscured in landscape orientation

### DIFF
--- a/mobile/src/main/res/layout/activity_chart.xml
+++ b/mobile/src/main/res/layout/activity_chart.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <include
         android:id="@+id/app_bar"


### PR DESCRIPTION
Make sure it's not obscured by the navigation bar by making CoordinatorLayout dispatch window insets to its children.

Fixes #3955