### PR TITLE
Gradle: clean up dependency and plugin version management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,25 +37,10 @@ proguard/
 # Android Studio captures folder
 captures/
 
-# IntelliJ
+# IntelliJ / Android Studio
 *.iml
-.idea/tasks.xml
-.idea/gradle.xml
-.idea/assetWizardSettings.xml
-.idea/libraries
-.idea/misc.xml
-# Android Studio 3 in .gitignore file.
-.idea/caches
-.idea/modules.xml
-.idea/deploymentTargetDropDown.xml
-# Comment next line if keeping position of elements in Navigation Editor is relevant for you
-.idea/navEditor.xml
-.idea/workspace.xml
-.idea/deploymentTargetSelector.xml
-.idea/other.xml
-.idea/androidTestResultsUserPreferences.xml
-
-.kotlin
+.idea/
+.kotlin/
 
 # Keystore files
 *.jks

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,10 @@
 buildscript {
-    ext.kotlin_version = '2.0.21'
     repositories {
         mavenCentral()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.11.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath libs.android.gradle.plugin
+        classpath libs.kotlin.gradle.plugin
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,132 @@
+[versions]
+android-gradle-plugin = "8.11.2"
+kotlin-gradle-plugin = "2.0.21"
+google-services = "4.4.2"
+firebase-crashlytics-gradle = "3.0.3"
+unmock-plugin = "0.8.0"
+about-libraries-plugin = "11.2.3"
+missing-metadata-guava = "31.1.1"
+
+kotlin-coroutines = "1.8.1"
+kotlin-stdlib = "2.0.21"
+desugar-jdk-libs = "2.1.5"
+
+core-ktx = "1.15.0"
+activity-ktx = "1.9.3"
+fragment-ktx = "1.8.6"
+appcompat = "1.7.0"
+legacy-support-v4 = "1.0.0"
+recyclerview = "1.3.2"
+constraintlayout = "2.2.1"
+preference-ktx = "1.2.1"
+biometric = "1.1.0"
+multidex = "2.0.1"
+work-manager = "2.10.0"
+security-crypto = "1.0.0"
+
+material = "1.12.0"
+media3 = "1.5.1"
+photoview = "2.3.0"
+appintro = "6.3.1"
+skeletonlayout = "5.0.0"
+androidsvg = "1.4"
+colorpicker = "0.1.1"
+
+okhttp = "4.12.0"
+jmdns = "3.6.1"
+
+play-services-maps = "19.0.0"
+osmdroid-android = "6.1.20"
+
+material-about-library = "3.1.2"
+about-libraries = "11.2.3"
+
+firebase-bom = "33.7.0"
+acra = "5.12.0"
+
+mockito-core = "5.11.0"
+mockito-kotlin = "2.2.0"
+powermock = "2.0.9"
+junit = "4.13.2"
+json = "20240303"
+espresso = "3.6.1"
+junit-ktx = "1.2.1"
+
+androidchart = "3.1.0.26"
+
+
+[libraries]
+android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "android-gradle-plugin" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-gradle-plugin" }
+
+google-services-plugin = { module = "com.google.gms:google-services", version.ref = "google-services" }
+firebase-crashlytics-gradle-plugin = { module = "com.google.firebase:firebase-crashlytics-gradle", version.ref = "firebase-crashlytics-gradle" }
+unmock-plugin = { module = "com.github.bjoernq:unmockplugin", version.ref = "unmock-plugin" }
+aboutlibraries-plugin = { module = "com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin", version.ref = "about-libraries-plugin" }
+missing-metadata-guava-plugin = { module = "de.jjohannes.gradle:missing-metadata-guava", version.ref = "missing-metadata-guava" }
+
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
+kotlinx-coroutines-jdk9 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk9", version.ref = "kotlin-coroutines" }
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlin-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
+kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin-stdlib" }
+
+core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
+activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activity-ktx" }
+fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment-ktx" }
+appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
+legacy-support-v4 = { module = "androidx.legacy:legacy-support-v4", version.ref = "legacy-support-v4" }
+recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "recyclerview" }
+constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
+preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "preference-ktx" }
+biometric = { module = "androidx.biometric:biometric", version.ref = "biometric" }
+multidex = { module = "androidx.multidex:multidex", version.ref = "multidex" }
+work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work-manager" }
+work-gcm = { module = "androidx.work:work-gcm", version.ref = "work-manager" }
+security-crypto = { module = "androidx.security:security-crypto", version.ref = "security-crypto" }
+
+material = { module = "com.google.android.material:material", version.ref = "material" }
+media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
+media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3" }
+media3-exoplayer-hls = { module = "androidx.media3:media3-exoplayer-hls", version.ref = "media3" }
+photoview = { module = "com.github.chrisbanes:PhotoView", version.ref = "photoview" }
+appintro = { module = "com.github.AppIntro:AppIntro", version.ref = "appintro" }
+skeletonlayout = { module = "com.faltenreich:skeletonlayout", version.ref = "skeletonlayout" }
+androidsvg = { module = "com.caverock:androidsvg-aar", version.ref = "androidsvg" }
+colorpicker = { module = "com.github.chimbori:colorpicker", version.ref = "colorpicker" }
+
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
+okhttp-sse = { module = "com.squareup.okhttp3:okhttp-sse", version.ref = "okhttp" }
+mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
+jmdns = { module = "org.jmdns:jmdns", version.ref = "jmdns" }
+
+play-services-maps = { module = "com.google.android.gms:play-services-maps", version.ref = "play-services-maps" }
+osmdroid-android = { module = "org.osmdroid:osmdroid-android", version.ref = "osmdroid-android" }
+
+material-about-library = { module = "com.github.daniel-stoneuk:material-about-library", version.ref = "material-about-library" }
+aboutlibraries-core = { module = "com.mikepenz:aboutlibraries-core", version.ref = "about-libraries" }
+aboutlibraries = { module = "com.mikepenz:aboutlibraries", version.ref = "about-libraries" }
+
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
+firebase-messaging-ktx = { module = "com.google.firebase:firebase-messaging-ktx" }
+firebase-crashlytics-ktx = { module = "com.google.firebase:firebase-crashlytics-ktx" }
+
+acra-mail = { module = "ch.acra:acra-mail", version.ref = "acra" }
+acra-notification = { module = "ch.acra:acra-notification", version.ref = "acra" }
+
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito-core" }
+mockito-kotlin = { module = "com.nhaarman.mockitokotlin2:mockito-kotlin", version.ref = "mockito-kotlin" }
+junit = { module = "junit:junit", version.ref = "junit" }
+json = { module = "org.json:json", version.ref = "json" }
+powermock-core = { module = "org.powermock:powermock-core", version.ref = "powermock" }
+powermock-api-mockito2 = { module = "org.powermock:powermock-api-mockito2", version.ref = "powermock" }
+powermock-module-junit4 = { module = "org.powermock:powermock-module-junit4", version.ref = "powermock" }
+espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
+espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "espresso" }
+espresso-contrib = { module = "androidx.test.espresso:espresso-contrib", version.ref = "espresso" }
+junit-ktx = { module = "androidx.test.ext:junit", version.ref = "junit-ktx" }
+
+desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar-jdk-libs" }
+
+androidchart = { module = "com.github.AppDevNext:AndroidChart", version.ref = "androidchart" }

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -4,38 +4,28 @@ def taskRequests = getGradle().getStartParameter().getTaskRequests().toString()
 def isFoss = taskRequests.contains("Foss") || taskRequests.contains("foss")
 
 buildscript {
-    ext.kotlin_coroutines_version = '1.8.1'
-    ext.ok_http_version = '4.12.0'
-    ext.work_manager_version = '2.10.0'
-    ext.about_libraries_version = '11.2.3'
-    ext.powermock_version = '2.0.9'
-    ext.espresso_version = '3.6.1'
-    ext.media3_version = '1.5.1'
-    ext.acra_version = '5.12.0'
-
     repositories {
         mavenCentral()
         google()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
+        maven { url "https://plugins.gradle.org/m2/" }
     }
 
     dependencies {
-        classpath "com.google.gms:google-services:4.4.2"
-        classpath "com.google.firebase:firebase-crashlytics-gradle:3.0.3"
-        classpath 'com.github.bjoernq:unmockplugin:0.8.0'
-        classpath "com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:$about_libraries_version"
-        classpath "de.jjohannes.gradle:missing-metadata-guava:31.1.1"
+        classpath libs.google.services.plugin
+        classpath libs.firebase.crashlytics.gradle.plugin
+        classpath libs.unmock.plugin
+        classpath libs.aboutlibraries.plugin
+        classpath libs.missing.metadata.guava.plugin
     }
 }
 
 apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
 apply plugin: "kotlin-parcelize"
-apply plugin: 'de.mobilej.unmock'
+apply plugin: "de.mobilej.unmock"
 apply plugin: "com.mikepenz.aboutlibraries.plugin"
 apply plugin: "de.jjohannes.missing-metadata-guava"
+
 if (!isFoss) {
     apply plugin: "com.google.gms.google-services"
     apply plugin: "com.google.firebase.crashlytics"
@@ -43,7 +33,7 @@ if (!isFoss) {
 
 android {
     useLibrary "org.apache.http.legacy"
-    namespace 'org.openhab.habdroid'
+    namespace "org.openhab.habdroid"
 
     defaultConfig {
         applicationId "org.openhab.habdroid"
@@ -56,6 +46,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "long", "TIMESTAMP", System.getenv("SOURCE_DATE_EPOCH") != null ? System.getenv("SOURCE_DATE_EPOCH").toLong() + "L" : System.currentTimeMillis() + "L"
     }
+
     buildTypes {
         release {
             minifyEnabled true
@@ -74,18 +65,15 @@ android {
             dimension "license"
             manifestPlaceholders = [maps_api_key: project.findProperty("mapsApiKey") ?: ""]
         }
-        foss {
-            dimension "license"
-        }
+        foss { dimension "license" }
 
-        stable {
-            dimension "release"
-        }
+        stable { dimension "release" }
         beta {
             dimension "release"
             applicationIdSuffix ".beta"
         }
     }
+
     testOptions {
         unitTests {
             returnDefaultValues = true
@@ -98,11 +86,13 @@ android {
             }
         }
     }
+
     compileOptions {
         coreLibraryDesugaringEnabled true
         targetCompatibility 1.8
         sourceCompatibility 1.8
     }
+
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
         freeCompilerArgs += [
@@ -111,23 +101,23 @@ android {
         ]
         allWarningsAsErrors = true
     }
+
     lint {
         abortOnError false
-        lintConfig file('lint.xml')
+        lintConfig file("lint.xml")
     }
-    androidResources {
-        generateLocaleConfig true
-    }
+
+    androidResources { generateLocaleConfig true }
+
     buildFeatures {
         buildConfig true
         viewBinding true
     }
-
 }
 
 aboutLibraries {
     duplicationMode = DuplicateMode.MERGE
-    excludeFields = ['generated']
+    excludeFields = ["generated"]
 }
 
 unMock {
@@ -137,85 +127,87 @@ unMock {
 }
 
 repositories {
-    maven {
-        url "https://maven.fabric.io/public"
-    }
+    maven { url "https://maven.fabric.io/public" }
     mavenCentral()
-    maven {
-        url "https://jitpack.io"
-    }
+    maven { url "https://jitpack.io" }
     google()
 }
 
 dependencies {
-    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutines_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-jdk9:$kotlin_coroutines_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
-    implementation "androidx.core:core-ktx:1.15.0"
-    implementation "androidx.activity:activity-ktx:1.9.3"
-    implementation "androidx.fragment:fragment-ktx:1.8.6"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "androidx.appcompat:appcompat:1.7.0"
-    implementation "androidx.legacy:legacy-support-v4:1.0.0"
-    implementation "androidx.recyclerview:recyclerview:1.3.2"
-    implementation "androidx.constraintlayout:constraintlayout:2.2.1"
-    implementation "androidx.preference:preference-ktx:1.2.1"
-    implementation "androidx.biometric:biometric:1.1.0"
-    implementation "com.google.android.material:material:1.12.0"
-    implementation "androidx.multidex:multidex:2.0.1"
-    implementation "androidx.work:work-runtime-ktx:$work_manager_version"
-    fullImplementation "androidx.work:work-gcm:$work_manager_version"
-    implementation "androidx.security:security-crypto:1.0.0"
-    implementation "androidx.media3:media3-exoplayer:$media3_version"
-    implementation "androidx.media3:media3-ui:$media3_version"
-    implementation "androidx.media3:media3-exoplayer-hls:$media3_version"
-    implementation "org.jmdns:jmdns:3.6.1"
-    implementation "com.squareup.okhttp3:okhttp:$ok_http_version"
-    implementation "com.squareup.okhttp3:logging-interceptor:$ok_http_version"
-    implementation "com.squareup.okhttp3:okhttp-sse:$ok_http_version"
-    implementation "com.github.chimbori:colorpicker:0.1.1"
-    implementation "com.caverock:androidsvg-aar:1.4"
-    implementation "com.github.AppIntro:AppIntro:6.3.1"
-    implementation "com.github.chrisbanes:PhotoView:2.3.0"
-    implementation "com.faltenreich:skeletonlayout:5.0.0"
-    // MapView support
-    fullImplementation "com.google.android.gms:play-services-maps:19.0.0"
-    fossImplementation "org.osmdroid:osmdroid-android:6.1.20"
-    // About screen
-    implementation "com.github.daniel-stoneuk:material-about-library:3.1.2"
-    // Used libraries
-    implementation "com.mikepenz:aboutlibraries-core:$about_libraries_version"
-    implementation "com.mikepenz:aboutlibraries:$about_libraries_version"
+    coreLibraryDesugaring libs.desugar.jdk.libs
 
-    implementation "com.github.AppDevNext:AndroidChart:3.1.0.26"
+    implementation libs.kotlinx.coroutines.core
+    implementation libs.kotlinx.coroutines.jdk9
+    implementation libs.kotlinx.coroutines.android
 
-    // Firebase
-    implementation platform("com.google.firebase:firebase-bom:33.7.0")
-    fullImplementation "com.google.firebase:firebase-messaging-ktx"
-    fullImplementation "com.google.firebase:firebase-crashlytics-ktx"
+    implementation libs.core.ktx
+    implementation libs.activity.ktx
+    implementation libs.fragment.ktx
+    implementation libs.kotlin.stdlib.jdk8
 
-    // Firebase replacements
-    fossImplementation "ch.acra:acra-mail:$acra_version"
-    fossImplementation "ch.acra:acra-notification:$acra_version"
+    implementation libs.appcompat
+    implementation libs.legacy.support.v4
+    implementation libs.recyclerview
+    implementation libs.constraintlayout
+    implementation libs.preference.ktx
+    implementation libs.biometric
+    implementation libs.material
+    implementation libs.multidex
 
-    testImplementation "org.mockito:mockito-core:5.11.0"
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
-    testImplementation "junit:junit:4.13.2"
-    testImplementation "org.json:json:20240303"
-    testImplementation "com.squareup.okhttp3:mockwebserver:$ok_http_version"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutines_version"
-    // PowerMock
-    testImplementation "org.powermock:powermock-core:$powermock_version"
-    testImplementation "org.powermock:powermock-api-mockito2:$powermock_version"
-    testImplementation "org.powermock:powermock-module-junit4:$powermock_version"
-    // Espresso UI tests
-    androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_version", {
+    implementation libs.work.runtime.ktx
+    fullImplementation libs.work.gcm
+
+    implementation libs.security.crypto
+
+    implementation libs.media3.exoplayer
+    implementation libs.media3.ui
+    implementation libs.media3.exoplayer.hls
+
+    implementation libs.jmdns
+
+    implementation libs.okhttp
+    implementation libs.logging.interceptor
+    implementation libs.okhttp.sse
+
+    implementation libs.colorpicker
+    implementation libs.androidsvg
+    implementation libs.appintro
+    implementation libs.photoview
+    implementation libs.skeletonlayout
+
+    fullImplementation libs.play.services.maps
+    fossImplementation libs.osmdroid.android
+
+    implementation libs.material.about.library
+    implementation libs.aboutlibraries.core
+    implementation libs.aboutlibraries
+
+    implementation libs.androidchart
+
+    implementation platform(libs.firebase.bom)
+    fullImplementation libs.firebase.messaging.ktx
+    fullImplementation libs.firebase.crashlytics.ktx
+
+    fossImplementation libs.acra.mail
+    fossImplementation libs.acra.notification
+
+    testImplementation libs.mockito.core
+    testImplementation libs.mockito.kotlin
+    testImplementation libs.junit
+    testImplementation libs.json
+    testImplementation libs.mockwebserver
+    testImplementation libs.kotlinx.coroutines.test
+
+    testImplementation libs.powermock.core
+    testImplementation libs.powermock.api.mockito2
+    testImplementation libs.powermock.module.junit4
+
+    androidTestImplementation(libs.espresso.core) {
         exclude group: "com.android.support", module: "support-annotations"
     }
-    androidTestImplementation "androidx.test.espresso:espresso-intents:$espresso_version"
-    androidTestImplementation "androidx.test.espresso:espresso-contrib:$espresso_version", {
+    androidTestImplementation libs.espresso.intents
+    androidTestImplementation(libs.espresso.contrib) {
         exclude group: "com.android.support", module: "support-annotations"
     }
-    androidTestImplementation "androidx.test.ext:junit:1.2.1"
+    androidTestImplementation libs.junit.ktx
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
+rootProject.name = "openhab-android"
 include ':mobile'


### PR DESCRIPTION
### Summary

This PR cleans up and simplifies the Gradle configuration by centralizing dependency and plugin versions using a Gradle Version Catalog. The goal is to make the build files easier to read and maintain without changing any behavior.

### What changed

I consolidated dependency and plugin versions that were previously spread across multiple Gradle files into a single libs.versions.toml file. This reduces duplication and makes it clearer where versions are defined. I also did some light formatting and organization of the Gradle files to improve readability.

### What did not change

There are no dependency upgrades or downgrades in this PR. All versions remain exactly the same as before. There are no functional or runtime changes, and there is no impact to the full or foss build variants.

### Motivation

While getting familiar with the project and the build setup, I found the Gradle configuration a bit difficult to follow as a new contributor. This change is meant to make the project more approachable and easier to maintain going forward.

### Testing

The project syncs successfully in Android Studio. I ran clean and assemble builds locally and verified that both full and foss variants still resolve and build as expected.

### Notes

This is my first contribution to the project. Feedback is very welcome and I am happy to adjust anything to better match the project’s conventions.