### PR TITLE
Refactor ConnectionFactory

### DIFF
--- a/mobile/src/full/java/org/openhab/habdroid/core/FcmRegistrationWorker.kt
+++ b/mobile/src/full/java/org/openhab/habdroid/core/FcmRegistrationWorker.kt
@@ -39,13 +39,14 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import org.openhab.habdroid.R
 import org.openhab.habdroid.core.connection.CloudConnection
-import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.PendingIntent_Immutable
 import org.openhab.habdroid.util.Util
+import org.openhab.habdroid.util.getConnectionFactory
 import org.openhab.habdroid.util.parcelable
 
 class FcmRegistrationWorker(private val context: Context, params: WorkerParameters) : CoroutineWorker(context, params) {
@@ -75,10 +76,7 @@ class FcmRegistrationWorker(private val context: Context, params: WorkerParamete
         val action = inputData.getString(KEY_ACTION)
         Log.d(TAG, "Run with action $action")
 
-        ConnectionFactory.waitForInitialization()
-
-        val connection = ConnectionFactory.primaryCloudConnection?.connection
-
+        val connection = context.getConnectionFactory().primaryFlow.first().cloud?.connection
         if (connection == null) {
             Log.d(TAG, "Got no connection")
             return retryOrFail()

--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHabApplication.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHabApplication.kt
@@ -37,6 +37,7 @@ import org.openhab.habdroid.BuildConfig
 import org.openhab.habdroid.R
 import org.openhab.habdroid.background.BackgroundTasksManager
 import org.openhab.habdroid.core.connection.ConnectionFactory
+import org.openhab.habdroid.core.connection.ConnectionManagerHelper
 import org.openhab.habdroid.util.CrashReportingHelper
 import org.openhab.habdroid.util.getDayNightMode
 import org.openhab.habdroid.util.getPrefs
@@ -59,6 +60,10 @@ class OpenHabApplication : MultiDexApplication() {
         } else {
             getSharedPreferences("secret_shared_prefs", MODE_PRIVATE)
         }
+    }
+
+    val connectionFactory: ConnectionFactory by lazy {
+        ConnectionFactory(this, getPrefs(), secretPrefs, ConnectionManagerHelper.create(this))
     }
 
     var systemDataSaverStatus: Int = ConnectivityManager.RESTRICT_BACKGROUND_STATUS_DISABLED
@@ -93,8 +98,8 @@ class OpenHabApplication : MultiDexApplication() {
 
         CrashReportingHelper.initialize(this)
         AppCompatDelegate.setDefaultNightMode(getPrefs().getDayNightMode(this))
-        ConnectionFactory.initialize(this)
         BackgroundTasksManager.initialize(this)
+        connectionFactory.start()
 
         dataSaverChangeListener.let { listener ->
             registerExportedReceiver(
@@ -165,7 +170,7 @@ class OpenHabApplication : MultiDexApplication() {
 
     override fun onTerminate() {
         super.onTerminate()
-        ConnectionFactory.shutdown()
+        connectionFactory.shutdown()
     }
 
     fun registerSystemDataSaverStateChangedListener(l: OnDataUsagePolicyChangedListener) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractBaseActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractBaseActivity.kt
@@ -57,6 +57,7 @@ import org.openhab.habdroid.ui.preference.PreferencesActivity
 import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.ScreenLockMode
 import org.openhab.habdroid.util.applyUserSelectedTheme
+import org.openhab.habdroid.util.getConnectionFactory
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getScreenLockMode
 import org.openhab.habdroid.util.hasPermissions
@@ -123,7 +124,14 @@ abstract class AbstractBaseActivity :
     @CallSuper
     override fun onStart() {
         super.onStart()
+        getConnectionFactory().trustManager.bindDisplayActivity(this)
         promptForDevicePasswordIfRequired()
+    }
+
+    @CallSuper
+    override fun onStop() {
+        super.onStop()
+        getConnectionFactory().trustManager.unbindDisplayActivity(this)
     }
 
     @CallSuper

--- a/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AbstractItemPickerActivity.kt
@@ -36,10 +36,10 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.openhab.habdroid.R
-import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.core.connection.DemoConnection
 import org.openhab.habdroid.databinding.ActivityItemPickerBinding
 import org.openhab.habdroid.databinding.BottomSheetItemPickerCommandBinding
@@ -49,6 +49,7 @@ import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.ItemClient
 import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.SuggestedCommandsFactory
+import org.openhab.habdroid.util.getConnectionFactory
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.parcelable
 import org.openhab.habdroid.util.parcelableArrayList
@@ -201,9 +202,7 @@ abstract class AbstractItemPickerActivity :
         itemPickerAdapter.clear()
 
         requestJob = launch {
-            ConnectionFactory.waitForInitialization()
-
-            val connection = ConnectionFactory.primaryUsableConnection?.connection
+            val connection = getConnectionFactory().primaryFlow.first().conn?.connection
             if (connection == null) {
                 updateViewVisibility(loading = false, loadError = true, showHint = false)
                 return@launch

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ChartImageActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ChartImageActivity.kt
@@ -21,13 +21,13 @@ import android.view.MenuItem
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import org.openhab.habdroid.R
 import org.openhab.habdroid.core.connection.Connection
-import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.databinding.ActivityChartimageBinding
 import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.model.Widget
 import org.openhab.habdroid.util.ScreenLockMode
 import org.openhab.habdroid.util.determineDataUsagePolicy
 import org.openhab.habdroid.util.getChartTheme
+import org.openhab.habdroid.util.getConnectionFactory
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.orDefaultIfEmpty
 import org.openhab.habdroid.util.parcelable
@@ -75,7 +75,7 @@ class ChartImageActivity :
     override fun onResume() {
         super.onResume()
 
-        connection = ConnectionFactory.activeUsableConnection?.connection
+        connection = getConnectionFactory().currentActive?.conn?.connection
         if (connection == null) {
             finish()
             return

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ChartWidgetActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ChartWidgetActivity.kt
@@ -72,7 +72,6 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import org.openhab.habdroid.R
 import org.openhab.habdroid.core.connection.Connection
-import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.databinding.ActivityChartBinding
 import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.model.ParsedState
@@ -82,6 +81,7 @@ import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.ItemClient
 import org.openhab.habdroid.util.appendQueryParameter
 import org.openhab.habdroid.util.determineDataUsagePolicy
+import org.openhab.habdroid.util.getConnectionFactory
 import org.openhab.habdroid.util.map
 import org.openhab.habdroid.util.orDefaultIfEmpty
 import org.openhab.habdroid.util.parcelable
@@ -191,7 +191,7 @@ class ChartWidgetActivity : AbstractBaseActivity() {
         super.onStart()
         val data = dataCacheFragment?.loadedData
         val loadExistingData = data?.let {
-            val dataUsagePolicy = determineDataUsagePolicy(ConnectionFactory.activeUsableConnection?.connection)
+            val dataUsagePolicy = determineDataUsagePolicy(getConnectionFactory().currentActive?.conn?.connection)
             val now = Instant.now().atZone(data.timestamp.zone)
             val dataIsOutdated = widget.refresh > 0 &&
                 Duration.between(data.timestamp, now).toMillis() > widget.refresh
@@ -209,7 +209,7 @@ class ChartWidgetActivity : AbstractBaseActivity() {
     }
 
     private fun onRefresh() = lifecycleScope.launch {
-        val connection = ConnectionFactory.activeUsableConnection?.connection
+        val connection = getConnectionFactory().currentActive?.conn?.connection
         val item = widget.item
         if (connection == null || item == null) {
             finish()

--- a/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationAdapter.kt
@@ -25,11 +25,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.databinding.NotificationlistItemBinding
 import org.openhab.habdroid.databinding.NotificationlistLoadingItemBinding
 import org.openhab.habdroid.model.CloudMessage
 import org.openhab.habdroid.util.determineDataUsagePolicy
+import org.openhab.habdroid.util.getConnectionFactory
 
 class CloudNotificationAdapter(context: Context, private val loadMoreListener: () -> Unit) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
@@ -126,7 +126,7 @@ class CloudNotificationAdapter(context: Context, private val loadMoreListener: (
                 isVisible = notification.message.isNotEmpty()
             }
 
-            val conn = ConnectionFactory.activeCloudConnection?.connection
+            val conn = itemView.context.getConnectionFactory().currentActive?.cloud?.connection
             if (conn == null) {
                 binding.notificationIcon.applyFallbackDrawable()
                 binding.notificationImage.isVisible = false

--- a/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/CloudNotificationListFragment.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.launch
 import org.json.JSONArray
 import org.json.JSONException
 import org.openhab.habdroid.R
-import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.databinding.FragmentNotificationlistBinding
 import org.openhab.habdroid.model.CloudMessage
 import org.openhab.habdroid.model.ServerConfiguration
@@ -36,6 +35,7 @@ import org.openhab.habdroid.model.toCloudMessage
 import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.getActiveServerId
 import org.openhab.habdroid.util.getConfiguredServerIds
+import org.openhab.habdroid.util.getConnectionFactory
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getPrimaryServerId
 import org.openhab.habdroid.util.getSecretPrefs
@@ -106,11 +106,12 @@ class CloudNotificationListFragment : Fragment() {
 
     private fun loadNotifications(clearExisting: Boolean) {
         val activity = activity as AbstractBaseActivity? ?: return
-        val conn = if (usePrimaryServer()) {
-            ConnectionFactory.primaryCloudConnection?.connection
+        val connInfo = if (usePrimaryServer()) {
+            activity.getConnectionFactory().currentPrimary
         } else {
-            ConnectionFactory.activeCloudConnection?.connection
+            activity.getConnectionFactory().currentActive
         }
+        val conn = connInfo?.conn?.connection
         if (conn == null) {
             updateViewVisibility(loading = false, loadError = true)
             return

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ColorItemActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ColorItemActivity.kt
@@ -16,10 +16,10 @@ package org.openhab.habdroid.ui
 import android.os.Bundle
 import android.view.MenuItem
 import org.openhab.habdroid.R
-import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.databinding.ActivityColorPickerBinding
 import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.util.ColorPickerHelper
+import org.openhab.habdroid.util.getConnectionFactory
 import org.openhab.habdroid.util.orDefaultIfEmpty
 import org.openhab.habdroid.util.parcelable
 
@@ -34,7 +34,7 @@ class ColorItemActivity : AbstractBaseActivity() {
         supportActionBar?.title = boundItem?.label.orDefaultIfEmpty(getString(R.string.widget_type_color))
 
         val pickerHelper = ColorPickerHelper(binding.picker, binding.brightnessSlider)
-        pickerHelper.attach(boundItem, this, ConnectionFactory.primaryUsableConnection?.connection)
+        pickerHelper.attach(boundItem, this, getConnectionFactory().currentPrimary?.conn?.connection)
     }
 
     override fun inflateBinding(): CommonBinding {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/DayDream.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/DayDream.kt
@@ -33,14 +33,15 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.openhab.habdroid.BuildConfig
 import org.openhab.habdroid.R
-import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.databinding.DaydreamBinding
 import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.ItemClient
 import org.openhab.habdroid.util.PrefKeys
+import org.openhab.habdroid.util.getConnectionFactory
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getStringOrNull
 
@@ -84,8 +85,7 @@ class DayDream :
     }
 
     private suspend fun listenForTextItem(item: String) {
-        ConnectionFactory.waitForInitialization()
-        val connection = ConnectionFactory.primaryUsableConnection?.connection ?: return
+        val connection = getConnectionFactory().primaryFlow.first().conn?.connection ?: return
 
         moveText()
         val initialText = try {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ImageWidgetActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ImageWidgetActivity.kt
@@ -29,13 +29,13 @@ import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import org.openhab.habdroid.R
 import org.openhab.habdroid.core.connection.Connection
-import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.databinding.ActivityImageBinding
 import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.IconBackground
 import org.openhab.habdroid.util.ImageConversionPolicy
 import org.openhab.habdroid.util.ScreenLockMode
 import org.openhab.habdroid.util.determineDataUsagePolicy
+import org.openhab.habdroid.util.getConnectionFactory
 import org.openhab.habdroid.util.getIconFallbackColor
 import org.openhab.habdroid.util.orDefaultIfEmpty
 
@@ -62,7 +62,7 @@ class ImageWidgetActivity : AbstractBaseActivity() {
     override fun onResume() {
         super.onResume()
 
-        connection = ConnectionFactory.activeUsableConnection?.connection
+        connection = getConnectionFactory().currentActive?.conn?.connection
         if (connection == null) {
             finish()
             return

--- a/mobile/src/main/java/org/openhab/habdroid/ui/ItemPickerAdapter.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/ItemPickerAdapter.kt
@@ -19,11 +19,11 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import java.util.Locale
-import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.databinding.ItempickerlistItemBinding
 import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.model.toOH2IconResource
 import org.openhab.habdroid.util.determineDataUsagePolicy
+import org.openhab.habdroid.util.getConnectionFactory
 
 class ItemPickerAdapter(context: Context, private val itemClickListener: ItemClickListener?) :
     RecyclerView.Adapter<ItemPickerAdapter.ItemViewHolder>(),
@@ -106,7 +106,7 @@ class ItemPickerAdapter(context: Context, private val itemClickListener: ItemCli
             binding.itemType.text = item.type.toString()
 
             val context = itemView.context
-            val connection = ConnectionFactory.primaryUsableConnection?.connection
+            val connection = context.getConnectionFactory().currentPrimary?.conn?.connection
             val icon = item.category.toOH2IconResource()
             if (icon != null && connection != null) {
                 binding.itemIcon.setImageUrl(

--- a/mobile/src/main/java/org/openhab/habdroid/ui/SelectionItemActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/SelectionItemActivity.kt
@@ -22,11 +22,11 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import org.openhab.habdroid.R
-import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.databinding.ActivitySelectionItemBinding
 import org.openhab.habdroid.databinding.SelectionItemBinding
 import org.openhab.habdroid.model.Item
 import org.openhab.habdroid.model.LabeledValue
+import org.openhab.habdroid.util.getConnectionFactory
 import org.openhab.habdroid.util.orDefaultIfEmpty
 import org.openhab.habdroid.util.parcelable
 
@@ -96,7 +96,8 @@ class SelectionAdapter(context: Context, val item: Item) : RecyclerView.Adapter<
                 isChecked = option.value == adapter?.itemState
                 text = option.label
                 setOnClickListener {
-                    val connection = ConnectionFactory.primaryUsableConnection?.connection ?: return@setOnClickListener
+                    val connection = context.getConnectionFactory().currentPrimary?.conn?.connection
+                        ?: return@setOnClickListener
                     adapter?.itemState = option.value
                     adapter?.notifyDataSetChanged()
                     connection.httpClient.sendItemCommand(item, option.value)

--- a/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/WidgetListFragment.kt
@@ -56,7 +56,6 @@ import kotlinx.coroutines.withContext
 import org.openhab.habdroid.R
 import org.openhab.habdroid.core.OpenHabApplication
 import org.openhab.habdroid.core.connection.Connection
-import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.databinding.FragmentWidgetlistBinding
 import org.openhab.habdroid.model.LinkedPage
 import org.openhab.habdroid.model.Widget
@@ -267,7 +266,7 @@ class WidgetListFragment :
     }
 
     private fun populateContextMenu(widget: Widget, menu: ContextMenu) {
-        val activity = (activity as AbstractBaseActivity?) ?: return
+        val activity = (activity as MainActivity?) ?: return
         val suggestedCommands = suggestedCommandsFactory.fill(widget)
         val nfcSupported = NfcAdapter.getDefaultAdapter(activity) != null || Util.isEmulator()
         val hasCommandOptions = suggestedCommands.entries.isNotEmpty() || suggestedCommands.shouldShowCustom
@@ -285,12 +284,11 @@ class WidgetListFragment :
                 Menu.NONE,
                 R.string.analyse
             ).setOnMenuItemClickListener {
-                val mainActivity = activity as MainActivity
-                val intent = mainActivity.getChartDetailsActivityIntent(
+                val intent = activity.getChartDetailsActivityIntent(
                     widget,
-                    mainActivity.serverProperties
+                    activity.serverProperties
                 )
-                mainActivity.startActivity(intent)
+                activity.startActivity(intent)
                 return@setOnMenuItemClickListener true
             }
 
@@ -585,9 +583,9 @@ class WidgetListFragment :
         }
     }
 
-    private fun createShortcut(activity: AbstractBaseActivity, linkedPage: LinkedPage, whiteBackground: Boolean) =
+    private fun createShortcut(activity: MainActivity, linkedPage: LinkedPage, whiteBackground: Boolean) =
         activity.launch {
-            val connection = ConnectionFactory.activeUsableConnection?.connection ?: return@launch
+            val connection = activity.connection ?: return@launch
 
             /**
              *  Icon size is defined in {@link AdaptiveIconDrawable}. Foreground size of

--- a/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/activity/ContentController.kt
@@ -43,7 +43,6 @@ import java.util.Stack
 import org.openhab.habdroid.R
 import org.openhab.habdroid.core.OpenHabApplication
 import org.openhab.habdroid.core.connection.Connection
-import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.databinding.FragmentStatusBinding
 import org.openhab.habdroid.model.LinkedPage
 import org.openhab.habdroid.model.Sitemap
@@ -58,6 +57,7 @@ import org.openhab.habdroid.ui.preference.PreferencesActivity
 import org.openhab.habdroid.util.CrashReportingHelper
 import org.openhab.habdroid.util.HttpClient
 import org.openhab.habdroid.util.PrefKeys
+import org.openhab.habdroid.util.getConnectionFactory
 import org.openhab.habdroid.util.getHumanReadableErrorMessage
 import org.openhab.habdroid.util.getPrefs
 import org.openhab.habdroid.util.getWifiManager
@@ -637,7 +637,7 @@ abstract class ContentController protected constructor(private val activity: Mai
 
     internal class NoNetworkFragment : StatusFragment() {
         override fun onClick(view: View) {
-            ConnectionFactory.restartNetworkCheck()
+            activity?.getConnectionFactory()?.restartNetworkCheck()
             activity?.recreate()
         }
 
@@ -720,7 +720,7 @@ abstract class ContentController protected constructor(private val activity: Mai
 
                     arguments?.getBoolean(KEY_WIFI_ENABLED) == true -> {
                         // If Wifi is enabled, primary button suggests retrying
-                        ConnectionFactory.restartNetworkCheck()
+                        activity?.getConnectionFactory()?.restartNetworkCheck()
                         activity?.recreate()
                     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/homescreenwidget/ItemUpdateWidget.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/homescreenwidget/ItemUpdateWidget.kt
@@ -36,11 +36,11 @@ import java.io.IOException
 import java.io.InputStream
 import kotlin.math.min
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import org.openhab.habdroid.R
 import org.openhab.habdroid.background.BackgroundTasksManager
-import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.model.IconFormat
 import org.openhab.habdroid.model.IconResource
 import org.openhab.habdroid.model.Item
@@ -55,6 +55,7 @@ import org.openhab.habdroid.util.ImageConversionPolicy
 import org.openhab.habdroid.util.ItemClient
 import org.openhab.habdroid.util.PendingIntent_Immutable
 import org.openhab.habdroid.util.dpToPixel
+import org.openhab.habdroid.util.getConnectionFactory
 import org.openhab.habdroid.util.getIconFallbackColor
 import org.openhab.habdroid.util.getStringOrEmpty
 import org.openhab.habdroid.util.getStringOrNull
@@ -169,9 +170,8 @@ open class ItemUpdateWidget : AppWidgetProvider() {
 
         GlobalScope.launch {
             val itemState = if (data.showState) {
-                ConnectionFactory.waitForInitialization()
                 try {
-                    ConnectionFactory.primaryUsableConnection?.connection?.let { connection ->
+                    context.getConnectionFactory().primaryFlow.first().conn?.connection?.let { connection ->
                         val item = ItemClient.loadItem(connection, data.item)
                         when {
                             item?.isOfTypeOrGroupType(Item.Type.Number) == true -> item.state?.asNumber?.toString()
@@ -269,8 +269,7 @@ open class ItemUpdateWidget : AppWidgetProvider() {
                     cachedIcon.use { setIcon(it, cachedIconType == IconFormat.Svg) }
                 } else {
                     Log.d(TAG, "Download icon")
-                    ConnectionFactory.waitForInitialization()
-                    val connection = ConnectionFactory.primaryUsableConnection?.connection
+                    val connection = context.getConnectionFactory().primaryFlow.first().conn?.connection
                     if (connection == null) {
                         Log.d(TAG, "Got no connection")
                         return

--- a/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ExtensionFuncs.kt
@@ -91,6 +91,7 @@ import org.json.JSONObject
 import org.openhab.habdroid.R
 import org.openhab.habdroid.core.OpenHabApplication
 import org.openhab.habdroid.core.connection.Connection
+import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.core.connection.DefaultConnection
 import org.openhab.habdroid.model.ServerConfiguration
 import org.openhab.habdroid.model.ServerPath
@@ -350,6 +351,8 @@ fun String.toJsonArrayOrNull() = try {
 fun Context.getPrefs(): SharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
 
 fun Context.getSecretPrefs(): SharedPreferences = (applicationContext as OpenHabApplication).secretPrefs
+
+fun Context.getConnectionFactory(): ConnectionFactory = (applicationContext as OpenHabApplication).connectionFactory
 
 /**
  * Shows an Toast and can be called from the background.


### PR DESCRIPTION
The previous design had 3 main disadvantages:
- State getters were racy, since connection and information flags could not be fetched atomically
- The callback based design doesn't play really nicely with coroutines
- ConflatedBroadcastChannel is deprecated

Replace the callback based listener logic as well as the 'wait for initialization' logic by Flows, and design the main flow so that it returns the needed data at once.