### PR TITLE
Clear existing OSM markers before binding

### DIFF
--- a/mobile/src/foss/java/org/openhab/habdroid/ui/MapViewHelper.kt
+++ b/mobile/src/foss/java/org/openhab/habdroid/ui/MapViewHelper.kt
@@ -83,6 +83,9 @@ object MapViewHelper {
         override fun bindAfterDataSaverCheck(widget: Widget) {
             super.bindAfterDataSaverCheck(widget)
             handler.post {
+                binding.mapview.overlays
+                    .filter { o -> o is Marker }
+                    .let { binding.mapview.overlays.removeAll(it) }
                 binding.mapview.applyPositionAndLabel(
                     boundWidget?.item,
                     binding.icontext.label.text,


### PR DESCRIPTION
Makes sure markers of previous binding do not accumulate.

Fixes #3978