### PR TITLE
Fix FCM registration

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/CloudConnection.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/CloudConnection.kt
@@ -27,7 +27,8 @@ class CloudConnection internal constructor(
     val proxyUrl: HttpUrl
 ) : DefaultConnection(baseConnection, Connection.TYPE_CLOUD) {
 
-    override fun equals(other: Any?) = super.equals(other) && other is CloudConnection
+    override fun equals(other: Any?) =
+        super.equals(other) && other is CloudConnection && messagingSenderId == other.messagingSenderId
 }
 
 /**

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -345,8 +345,12 @@ class ConnectionFactory internal constructor(
         primaryCloud: CloudConnectionResult? = stateFlow.value.primaryCloud,
         activeCloud: CloudConnectionResult? = stateFlow.value.activeCloud
     ) {
+        val oldPrimaryCloud = stateFlow.value.primaryCloud?.connection
         val newState = StateHolder(isIntermediate, primary, active, primaryCloud, activeCloud)
         stateFlow.tryEmit(newState)
+        if (!isIntermediate && oldPrimaryCloud != primaryCloud?.connection) {
+            CloudMessagingHelper.onPrimaryConnectionUpdated(context, primaryCloud?.connection)
+        }
     }
 
     private fun triggerConnectionUpdateIfNeededAndPending(): Boolean {
@@ -428,7 +432,6 @@ class ConnectionFactory internal constructor(
                         primary?.remote?.toCloudConnection()
                     }
                     updateState(false, primaryCloud = CloudConnectionResult(result, null))
-                    CloudMessagingHelper.onPrimaryConnectionUpdated(context, result)
                 } catch (_: CancellationException) {
                     // ignored
                 } catch (e: Exception) {


### PR DESCRIPTION
The changes in #3998 changed the registration trigger from flow listener to direct callback, but only did so for the 'active server is not the same as primary server' path. Move the callback to a place that's executed for any primary cloud server update.

Fixes #4025
