### PR TITLE
Hide intro due to low contrast

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/MainActivity.kt
@@ -287,14 +287,14 @@ class MainActivity : AbstractBaseActivity() {
 
         processIntent(intent)
 
-        if (prefs.getBoolean(PrefKeys.FIRST_START, true) ||
+        /*if (prefs.getBoolean(PrefKeys.FIRST_START, true) ||
             prefs.getBoolean(PrefKeys.RECENTLY_RESTORED, false)
         ) {
             NotificationUpdateObserver.createNotificationChannels(this)
             Log.d(TAG, "Start intro")
             val intent = Intent(this, IntroActivity::class.java)
             startActivity(intent)
-        }
+        }*/
         UpdateBroadcastReceiver.updateComparableVersion(prefs.edit())
 
         val isSpeechRecognizerAvailable = SpeechRecognizer.isRecognitionAvailable(this)


### PR DESCRIPTION
The contrast between buttons and background is too low to be visible in some situations. Until fixed disable the intro for now.

https://community.openhab.org/t/unable-to-leave-welcome-screen/169896/10