### PR TITLE
Fix updateHttpClientForClientCert

### DIFF
--- a/mobile/src/androidTest/java/org/openhab/habdroid/ui/IntroTest.kt
+++ b/mobile/src/androidTest/java/org/openhab/habdroid/ui/IntroTest.kt
@@ -19,6 +19,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.openhab.habdroid.R
+import org.openhab.habdroid.core.connection.ConnectionFactory
 import org.openhab.habdroid.util.PrefKeys
 import org.openhab.habdroid.util.getPrefs
 
@@ -125,5 +126,39 @@ class IntroTest {
             )
         )
         materialButton.perform(click())
+    }
+
+    @Test
+    fun filtersLegacyTlsProtocolsWhileRetainingSupportedAndFutureProtocols() {
+        val filteredProtocols = ConnectionFactory.filterLegacyTlsProtocols(
+            arrayOf(
+                "SSL",
+                "SSLv2",
+                "SSLv3",
+                "TLSv1",
+                "TLSv1.0",
+                "TLSv1.1",
+                "TLSv1.2",
+                "TLSv1.3",
+                "TLSv9.9"
+            )
+        )
+
+        org.junit.Assert.assertArrayEquals(
+            arrayOf("TLSv1.2", "TLSv1.3", "TLSv9.9"),
+            filteredProtocols
+        )
+    }
+
+    @Test
+    fun rejectsTlsConfigurationWhenOnlyLegacyProtocolsAreEnabled() {
+        try {
+            ConnectionFactory.filterLegacyTlsProtocols(
+                arrayOf("SSL", "SSLv3", "TLSv1", "TLSv1.0", "TLSv1.1")
+            )
+            org.junit.Assert.fail("Expected legacy-only TLS configuration to be rejected")
+        } catch (_: IllegalStateException) {
+            // The transport must fail closed rather than create a socket with no acceptable protocol.
+        }
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
+++ b/mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt
@@ -329,8 +329,47 @@ class ConnectionFactory internal constructor(
         try {
             val sslContext = SSLContext.getInstance("TLS")
             sslContext.init(keyManagers, arrayOf<TrustManager>(trustManager), null)
+            val socketFactory = object : javax.net.ssl.SSLSocketFactory() {
+                private val delegate = sslContext.socketFactory
+
+                private fun filterLegacyProtocols(socket: Socket): Socket {
+                    val sslSocket = socket as? javax.net.ssl.SSLSocket
+                        ?: throw IllegalStateException("TLS socket factory returned a non-SSL socket")
+                    sslSocket.enabledProtocols = filterLegacyTlsProtocols(sslSocket.enabledProtocols)
+                    return sslSocket
+                }
+
+                override fun getDefaultCipherSuites(): Array<String> = delegate.defaultCipherSuites
+
+                override fun getSupportedCipherSuites(): Array<String> = delegate.supportedCipherSuites
+
+                override fun createSocket(): Socket = filterLegacyProtocols(delegate.createSocket())
+
+                override fun createSocket(host: String, port: Int): Socket =
+                    filterLegacyProtocols(delegate.createSocket(host, port))
+
+                override fun createSocket(
+                    host: String,
+                    port: Int,
+                    localHost: java.net.InetAddress,
+                    localPort: Int
+                ): Socket = filterLegacyProtocols(delegate.createSocket(host, port, localHost, localPort))
+
+                override fun createSocket(host: java.net.InetAddress, port: Int): Socket =
+                    filterLegacyProtocols(delegate.createSocket(host, port))
+
+                override fun createSocket(
+                    address: java.net.InetAddress,
+                    port: Int,
+                    localAddress: java.net.InetAddress,
+                    localPort: Int
+                ): Socket = filterLegacyProtocols(delegate.createSocket(address, port, localAddress, localPort))
+
+                override fun createSocket(socket: Socket, host: String, port: Int, autoClose: Boolean): Socket =
+                    filterLegacyProtocols(delegate.createSocket(socket, host, port, autoClose))
+            }
             httpClient = httpClient.newBuilder()
-                .sslSocketFactory(sslContext.socketFactory, trustManager)
+                .sslSocketFactory(socketFactory, trustManager)
                 .build()
             lastClientCertAlias = clientCertAlias
         } catch (e: Exception) {
@@ -585,6 +624,18 @@ class ConnectionFactory internal constructor(
 
     companion object {
         private val TAG = ConnectionFactory::class.java.simpleName
+        private val LEGACY_TLS_PROTOCOLS = setOf("TLSv1", "TLSv1.0", "TLSv1.1")
+
+        @VisibleForTesting
+        internal fun filterLegacyTlsProtocols(protocols: Array<String>): Array<String> {
+            val filteredProtocols = protocols.filterNot { protocol ->
+                protocol.startsWith("SSL") || protocol in LEGACY_TLS_PROTOCOLS
+            }.toTypedArray()
+            check(filteredProtocols.isNotEmpty()) {
+                "TLS provider has no enabled protocols after legacy protocol filtering"
+            }
+            return filteredProtocols
+        }
         private val UPDATE_TRIGGERING_KEYS = listOf(
             PrefKeys.DEMO_MODE,
             PrefKeys.ACTIVE_SERVER_ID,


### PR DESCRIPTION
## What does this implement/fix?

| Property | Value |
|---|---|
| Method | `updateHttpClientForClientCert` |
| Class | `org.openhab.habdroid.core.connection.ConnectionFactory` |
| File | `mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt` |
| Specification | `SSLContextSpec` |
| Analysis tool | `ape` |

## Summary

### Observed dynamic-analysis failure

The dynamic-analysis run by `ape` reported (`SSLContextSpec`) while exercising `org.openhab.habdroid.core.connection.ConnectionFactory.updateHttpClientForClientCert`:

> expecting one of {TLSv1.2, TLSv1.3} but found TLS.

### Root cause

The application passes the generic literal "TLS" to SSLContext.getInstance, while the reported SSLContextSpec predicate accepts only TLSv1.2 or TLSv1.3. The literal mismatch is confirmed; the effective negotiated protocol remains unproven.

### Correction strategy

Preserve the provider-selected generic TLS context so later protocol versions remain negotiable. Enforce the security property at the connection/socket layer by removing only explicit legacy protocol names (SSL variants, TLSv1, and TLSv1.0/TLSv1.1) from the provider-enabled protocols. Start from the provider's enabled protocols rather than constructing a closed TLSv1.2/TLSv1.3 allowlist, retain unknown future TLS versions, and fail closed if filtering leaves no protocol.

### Coordinated changes

- `mobile/src/main/java/org/openhab/habdroid/core/connection/ConnectionFactory.kt`: Keep SSLContext("TLS") provider-selected while applying protocol filtering to every socket created by the OkHttp TLS factory. The wrapper preserves the existing trust manager, hostname verification, client-certificate behavior, and provider-disabled protocols; a socket with no permitted protocol fails before a TLS connection can be established.; Provide an internal Kotlin test seam for the exact runtime filtering policy, allowing coordinated Android tests to verify legacy removal, retention of current and future TLS names, and the fail-closed empty result without reflection.
- `mobile/src/androidTest/java/org/openhab/habdroid/ui/IntroTest.kt`: Imports the coordinated package-visible Android-test seam directly, avoiding reflection.; Retains the existing introduction flow test and adds direct tests for the coordinated filterLegacyTlsProtocols seam. The first test proves all requested legacy names are removed while TLSv1.2, TLSv1.3, and an unknown future protocol remain in provider order. The second test requires the specified IllegalStateException when filtering leaves no acceptable protocol.

### Verification included

- Legacy SSL, TLSv1, TLSv1.0, and TLSv1.1 names are removed.
- TLSv1.2 and TLSv1.3 remain when originally enabled.
- An unknown future TLS protocol name remains enabled.
- Filtering fails closed when no acceptable protocol remains.
- Filtering fails closed with IllegalStateException when every input protocol is legacy.

### Residual review requirements

The patch remains review-only until these assumptions are confirmed:

- Android's SSLContext socket factory satisfies the SSLSocketFactory contract and returns an SSLSocket from each createSocket overload used by OkHttp.
- Provider protocol names use the conventional SSL-prefixed and TLSv1/TLSv1.0/TLSv1.1 legacy identifiers; unknown non-SSL TLS protocol names must remain enabled.
- Runtime endpoint coverage and static-analyzer acceptance remain to be verified; the generic SSLContext("TLS") literal is intentionally retained to avoid pinning future TLS support.
- The coordinated production edit exposes ConnectionFactory.filterLegacyTlsProtocols as an internal Android-test seam accepting and returning Array<String>, as specified by the previous-file contract.
- The Android test compilation configuration grants this established androidTest source set access to Kotlin internal declarations in the application module.
- The existing IntroTest dependencies, including MainActivity and AppIntro resources, are pre-existing test infrastructure not supplied with this target; this edit does not alter them.
- Runtime endpoint validation and analyzer acceptance remain review-time concerns because this test covers only the deterministic protocol filtering seam.

## How was this tested?

- [x] Automated test coverage added in 1 test file(s)
- [x] Project compiles successfully (`:mobile:assembleFossBetaDebugAndroidTest`)
- [ ] Confirmed by a project maintainer

## Reviewer notes

Do not merge until these assumptions and blockers are resolved:

- Android's SSLContext socket factory satisfies the SSLSocketFactory contract and returns an SSLSocket from each createSocket overload used by OkHttp.
- Provider protocol names use the conventional SSL-prefixed and TLSv1/TLSv1.0/TLSv1.1 legacy identifiers; unknown non-SSL TLS protocol names must remain enabled.
- Runtime endpoint coverage and static-analyzer acceptance remain to be verified; the generic SSLContext("TLS") literal is intentionally retained to avoid pinning future TLS support.
- The coordinated production edit exposes ConnectionFactory.filterLegacyTlsProtocols as an internal Android-test seam accepting and returning Array<String>, as specified by the previous-file contract.
- The Android test compilation configuration grants this established androidTest source set access to Kotlin internal declarations in the application module.
- The existing IntroTest dependencies, including MainActivity and AppIntro resources, are pre-existing test infrastructure not supplied with this target; this edit does not alter them.
- Runtime endpoint validation and analyzer acceptance remain review-time concerns because this test covers only the deterministic protocol filtering seam.

## Additional context

I’m an undergraduate Computer Engineering student at the University of Brasília (UnB), and this contribution is part of a research project involving software security analysis.

I’m happy to adjust the implementation to better match the project’s architecture, coding conventions, or maintainers’ recommendations.